### PR TITLE
fix: declare webhook dependency in manifest and demote URL logging to DEBUG

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,19 @@
 # History
 
+## 2026-04-09 — v1.1.0 quick wins: manifest webhook dependency + demote URL logging
+
+Two small v1.1.0 items from the roadmap addressed together:
+
+### `manifest.json` — declare `"webhook"` dependency
+The integration relies on `homeassistant.components.webhook` being loaded, but `manifest.json` had an empty `"dependencies": []`. Added `"webhook"` so hassfest and HA's component loader see the explicit dependency. No behaviour change at runtime (HA loads webhook early anyway), but makes the dependency discoverable.
+
+### `__init__.py` — demote webhook URL logging from INFO to DEBUG
+Full webhook URLs (including the `?token=` bearer secret) were written to HA logs at INFO level on every startup. Log files are routinely shared in bug reports, which would expose the URL even though webhooks are local-only. Changed to: log only the count of registered webhooks at INFO, and emit the full URLs at DEBUG for developers who need them.
+
+No test changes needed — 234 tests all pass. Lint clean.
+
+---
+
 ## 2026-04-09 — Test coverage expansion: 5 new test files, 103 new tests (233 total)
 
 Addressed all major coverage gaps identified in a structured analysis of the codebase. Previous suite: 130 tests. New suite: 233 tests (+103). All passing, lint clean.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,7 @@ Issues that are non-blocking for a first release but important for production qu
 ### Security
 
 - [ ] Unvalidated controller URL allows SSRF — validate scheme and optionally reject loopback/link-local (`config_flow.py:53`)
-- [ ] Webhook URLs logged at INFO level on every startup — demote to DEBUG (`__init__.py:71`)
+- [x] Webhook URLs logged at INFO level on every startup — demote to DEBUG (`__init__.py:71`)
 - [ ] Unbounded webhook body stored in memory — apply `max_bytes` cap on `request.json()` (`webhook_handler.py:86`)
 - [ ] Credentials leak risk via exception messages in logs — log class name only, not `str(err)` (`unifi_client.py:105,181`)
 - [x] Overly broad UniFi OS detection — remove `or resp.status == 200` fallback (`unifi_client.py:142`)
@@ -68,7 +68,7 @@ Issues that are non-blocking for a first release but important for production qu
 ### Tech debt
 
 - [ ] Pin CI action versions to commit SHAs instead of `@master` / `@main` (`ci.yml`)
-- [ ] Add `"dependencies": ["webhook"]` to `manifest.json`
+- [x] Add `"dependencies": ["webhook"]` to `manifest.json`
 - [ ] Add CI diff check between `strings.json` and `translations/en.json` to prevent drift
 - [ ] Tighten `JSONDecodeError` catch in webhook handler instead of bare `except Exception`
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,11 +11,6 @@ Prioritised backlog. Items are grouped by type. Work top-to-bottom within each g
 **Problem:** The controller URL field accepts any string and passes it directly to the HTTP client. A malicious or misconfigured user could supply an internal address (e.g. `http://localhost:8123/`) to probe internal services.
 **Fix:** Validate that the URL scheme is `http` or `https`, and optionally reject loopback and link-local addresses using `yarl.URL`.
 
-### [SECURITY] Webhook URLs logged at INFO level on every startup
-**File:** `__init__.py:71-74`
-**Problem:** Full webhook URLs are written to HA logs at INFO level. Log files are routinely shared in bug reports, exposing the URLs even though they're local-only.
-**Fix:** Demote to `DEBUG` level. Log only the count of registered webhooks at INFO.
-
 ### [BUG] Config flow uses `async_create_clientsession` — session is never properly closed
 **File:** `config_flow.py:56`
 **Problem:** `async_create_clientsession` creates a new session per config flow run. The `client.close()` call issues a logout HTTP request but does not close the underlying session. The correct pattern is to use `async_create_clientsession`, store a reference, and call `session.close()` explicitly in a try/finally after the auth check.
@@ -86,9 +81,6 @@ In `coordinator._async_update_data`, if re-auth succeeds but the second `categor
 
 ### `strings.json` and `translations/en.json` are manually kept in sync
 HA's tooling expects them to match. A pre-commit hook or CI check that diffs the two files would prevent drift.
-
-### `manifest.json` does not declare `webhook` as a dependency
-The integration depends on `homeassistant.components.webhook`. HA loads it early by default so this rarely matters in practice, but explicit declaration via `"dependencies": ["webhook"]` would make the dependency visible to hassfest.
 
 ### Disabled category `open_count` is still updated by polling
 `categorise_alarms()` returns all categories regardless of enabled/disabled state, and the coordinator updates `open_count` for all of them. A disabled category with open alarms on the controller will have a non-zero `open_count` internally, which is inconsistent.

--- a/custom_components/unifi_alerts/__init__.py
+++ b/custom_components/unifi_alerts/__init__.py
@@ -81,8 +81,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Re-register webhooks and reload options when the entry is updated
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
-    _LOGGER.info(
-        "UniFi Alerts set up. Webhook URLs: %s",
+    _LOGGER.info("UniFi Alerts set up. Registered %d webhook(s).", len(webhook_urls))
+    _LOGGER.debug(
+        "UniFi Alerts webhook URLs: %s",
         ", ".join(f"{cat}={url}" for cat, url in webhook_urls.items()),
     )
     return True

--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -3,7 +3,7 @@
   "name": "UniFi Alerts",
   "codeowners": ["@PHeonix25"],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["webhook"],
   "documentation": "https://github.com/PHeonix25/unifi_alerts",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",


### PR DESCRIPTION
- manifest.json: add "webhook" to dependencies so hassfest and HA's
  component loader see the explicit dependency on
  homeassistant.components.webhook.

- __init__.py: full webhook URLs (including ?token= bearer secret) were
  written to HA logs at INFO on every startup. Log files are routinely
  shared in bug reports. Now logs only the count at INFO; full URLs
  emitted at DEBUG for developers.

No test changes needed — 234 tests pass. Lint clean.

https://claude.ai/code/session_019AYZeeJqNUtRyrSYBT2NRa