### PR TITLE
docs: document aiohttp session lifecycle and UniFi OS detection bugs

### DIFF
--- a/HOMEASSISTANT.md
+++ b/HOMEASSISTANT.md
@@ -72,6 +72,35 @@ Platforms are declared in `PLATFORMS` in `__init__.py` and set up with `async_fo
 
 When adding a new platform: add it to `PLATFORMS`, create `{platform}.py`, implement `async_setup_entry`, and add corresponding tests.
 
+## aiohttp session lifecycle
+
+Two helpers exist; they have different ownership semantics:
+
+| Helper | Ownership | Close it? |
+|---|---|---|
+| `async_get_clientsession(hass)` | HA-owned shared session | **Never** |
+| `async_create_clientsession(hass)` | HA-owned dedicated session | **Never** — HA registers a cleanup handler that closes it on shutdown |
+
+Calling `await session.close()` on either will trigger a deprecation warning from `homeassistant.helpers.frame` and is treated as a bug by HA. The session will be closed automatically when the integration is unloaded or HA shuts down.
+
+If you need a truly short-lived session with explicit lifecycle control (e.g. a one-off auth check in a config flow), create a raw `aiohttp.ClientSession()` yourself and use it as an async context manager:
+
+```python
+# DO: own it explicitly
+async with aiohttp.ClientSession() as session:
+    client = UniFiClient(session, url, user_input)
+    auth_method = await client.authenticate()
+
+# DON'T: close an HA-managed session
+session = async_create_clientsession(hass)
+try:
+    ...
+finally:
+    await session.close()  # triggers HA warning
+```
+
+The config flow `async_step_user` currently does the wrong thing — see `TODO.md`.
+
 ## Config flow patterns
 
 - `async_show_form` returns a form to the user. The same step function is called again with `user_input` populated when the user submits.

--- a/TODO.md
+++ b/TODO.md
@@ -42,17 +42,20 @@ vol.Optional(CONF_API_KEY): _PASSWORD_SELECTOR,
 ```
 Apply in both the initial schema and the error-repopulation schema (lines 83-84 and 96-97).
 
-### [BUG] UCG-Ultra: OS detection fails → API key verification hits wrong endpoint (404)
-**File:** `unifi_client.py:133-170`
-**Reported by:** User during installation on UCG-Ultra
+### [BUG] OS detection fails → API key verification hits wrong endpoint (404)
+**File:** `unifi_client.py:141-178`
+**Reported by:** Confirmed occurring on UCG-Ultra, reverse-proxy setups (custom domain, Nginx/Caddy/Traefik), and any config where `x-csrf-token` is absent or stripped from the `/` response.
 **Error:** `ClientResponseError: 404, message='Not Found', url='.../api/s/default/self'`
-**Root cause:** `_detect_unifi_os()` relies solely on the presence of `x-csrf-token` in the response headers for `/`. On the UCG-Ultra (and possibly other newer UniFi OS consoles), this header is absent or the request fails, causing `_is_unifi_os` to be `False`. As a result, `_network_path()` does not prepend `/proxy/network`, and `_verify_api_key()` calls `/api/s/default/self` — a legacy non-OS endpoint that returns 404 on UniFi OS hardware.
-**Impact:** Setup is completely broken for any UniFi OS console where the detection heuristic fails. The 404 is not handled gracefully and bubbles up as `Unexpected error during auth`.
-**Fix options (pick one or combine):**
-1. After a 404 from `_verify_api_key`, retry with the OS path forced (`/proxy/network/api/s/default/self`) to auto-recover from a misdetected OS type.
-2. Improve `_detect_unifi_os` to also check for additional UCG-Ultra / UniFi OS signals (e.g. specific response body fields, `x-csrf-token` on a redirect destination, or a known OS-only endpoint like `/api/system`).
-3. Expose a manual "UniFi OS" toggle in the config flow so users can override detection when the heuristic fails.
-**Note:** The 404 should also be caught and re-raised as `InvalidAuthError` or `CannotConnectError` with a user-facing message instead of surfacing as a raw `ClientResponseError`.
+**Root cause (two compounding issues):**
+1. `_detect_unifi_os()` relies solely on `x-csrf-token` being present in the `/` response headers. This header is absent on UCG-Ultra firmware, stripped by reverse proxies, and missing if the `/` request follows a redirect to a page that doesn't set it. When detection fails, `_is_unifi_os = False`.
+2. `_verify_api_key()` calls `self._network_path('/api/s/default/self')`. When `_is_unifi_os` is `False`, `_network_path` returns the path unchanged — so the call goes to `/api/s/default/self` instead of `/proxy/network/api/s/default/self`. That legacy endpoint does not exist on UniFi OS hardware and returns 404.
+**Logic flaw:** API keys are UniFi OS-only — a user who supplies an API key by definition has a UniFi OS controller. `_verify_api_key()` should always use the `/proxy/network` prefix regardless of what `_detect_unifi_os()` returns. The current code trusts the detection result unconditionally, which is wrong here.
+**Impact:** Setup is completely broken for anyone accessing their UniFi OS controller via a reverse proxy / custom domain, or using a UCG-Ultra. The 404 bubbles up as `Unexpected error during auth` with no actionable message.
+**Fix (recommended — combine all three):**
+1. **Force the OS prefix in `_verify_api_key`:** Since API keys are OS-only, hardcode `/proxy/network` prefix there instead of calling `_network_path`. This is the minimal, correct fix.
+2. **Improve `_detect_unifi_os` fallback:** After the `x-csrf-token` check fails, probe a known UniFi OS-only endpoint (e.g. `GET /api/system`) and set `_is_unifi_os = True` if it returns 200. This fixes detection for the user/pass path too.
+3. **Catch 404 in `_verify_api_key` and raise a clear error:** Currently a 404 surfaces as an unhandled `ClientResponseError`. It should be caught and re-raised as `CannotConnectError("API key endpoint not found — check the controller URL and that UniFi OS is accessible")`.
+**Optional:** Expose a manual "This is a UniFi OS console" toggle in the config flow as an override for when all detection heuristics fail.
 
 ### [BUG] No pagination on `/alarm` endpoint — large backlogs block event loop
 **File:** `unifi_client.py:92-103`

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,25 @@ Prioritised backlog. Items are grouped by type. Work top-to-bottom within each g
 
 ## 🟡 High-value improvements
 
+### [BUG] Config flow closes HA-managed aiohttp session — deprecation warning on every setup
+**File:** `config_flow.py:59,80`
+**Error:** `Detected that custom integration 'unifi_alerts' closes the Home Assistant aiohttp session at config_flow.py, line 80: await session.close()`
+**Root cause:** `async_step_user` creates a session with `async_create_clientsession(self.hass)` (line 59), then explicitly calls `await session.close()` in the `finally` block (line 80). Sessions created with `async_create_clientsession` are HA-managed — HA registers its own cleanup handler and will close them on shutdown. Calling `close()` manually bypasses that contract and triggers a deprecation warning from `homeassistant.helpers.frame`.
+**Fix:** Replace `async_create_clientsession(self.hass)` with a raw `aiohttp.ClientSession()` used as an async context manager, so ownership is explicit and the integration fully controls the session lifetime:
+```python
+import aiohttp
+
+async with aiohttp.ClientSession() as session:
+    client = UniFiClient(session, url, user_input)
+    try:
+        auth_method = await client.authenticate()
+    except InvalidAuthError:
+        errors["base"] = "invalid_auth"
+    ...
+```
+Remove the `finally: await session.close()` block entirely — the context manager handles it. Also remove the `async_create_clientsession` import from `config_flow.py` if it's no longer used elsewhere.
+**Note:** The config flow only needs the session for the duration of the single auth check. A raw `aiohttp.ClientSession()` is appropriate here. `async_create_clientsession` provides a HA-shared cookie jar and SSL context that aren't needed in this short-lived context.
+
 ### [SECURITY] Unvalidated controller URL allows SSRF
 **File:** `config_flow.py:53,57`
 **Problem:** The controller URL field accepts any string and passes it directly to the HTTP client. A malicious or misconfigured user could supply an internal address (e.g. `http://localhost:8123/`) to probe internal services.

--- a/UNIFI.md
+++ b/UNIFI.md
@@ -11,7 +11,17 @@ The integration must handle two distinct controller environments:
 | **Self-hosted** (Linux/Windows software) | No `x-csrf-token` header on `/` | `/api/...` | Session cookie (user/pass only) |
 | **UniFi OS** (UDM, UDM Pro, UDM SE, UCG, UCG-Ultra, Cloud Key Gen2+) | `x-csrf-token` header present | `/proxy/network/api/...` | Session cookie **or** API key |
 
-Detection happens in `UniFiClient._detect_unifi_os()` by making a HEAD/GET to `/` and checking response headers.
+Detection happens in `UniFiClient._detect_unifi_os()` by making a GET to `/` and checking response headers.
+
+### Detection caveats and known failure modes
+
+The `x-csrf-token` heuristic is fragile. It fails in several common real-world configurations:
+
+- **Reverse proxy / custom domain**: Nginx, Caddy, Traefik, and similar proxies often strip or do not forward the `x-csrf-token` response header. A user accessing their controller at `https://unifi.example.com` via a reverse proxy will have detection return `False` even if the underlying hardware is a UDM or UCG.
+- **UCG-Ultra firmware**: Some UCG-Ultra firmware versions do not set `x-csrf-token` on the `/` response, causing detection to fail on the device itself (no proxy involved).
+- **HTTP→HTTPS redirect**: The detection request follows redirects (`allow_redirects=True`), but if the final destination doesn't serve `x-csrf-token` (e.g. a landing page or portal), detection still returns `False`.
+
+**Critical implication:** API keys are **UniFi OS-only** — they cannot be generated or used on self-hosted (classic) controllers. If a user has supplied an API key in the config, the controller is UniFi OS by definition. The code must not route API key verification requests through the legacy `/api/s/...` path regardless of what detection returns. See the bug in `TODO.md`: *UCG-Ultra: OS detection fails → API key verification hits wrong endpoint (404)*.
 
 ## Authentication
 
@@ -36,14 +46,31 @@ Logout: `POST /api/logout` (self-hosted) or `POST /api/auth/logout` (UniFi OS).
 
 ### API key (UniFi OS only)
 
-Generated in UniFi OS Settings → Control Plane → API Keys (or similar, varies by version). Stateless — no login/logout needed.
+API keys are stateless — no login/logout needed. They are generated in the UniFi OS web UI; the exact navigation path varies by firmware version:
+
+- **Newer firmware (Network Application 8.x+):** Settings → Admins & Users → API Keys
+- **Some firmware versions:** Integrations → New API Key
+- **Older firmware:** Settings → Control Plane → API Keys
+
+The API key inherits permissions from the admin account that created it.
+
+Usage — pass the key as a request header on every call:
 
 ```
 GET /proxy/network/api/s/default/alarm
 X-API-Key: your-key-here
 ```
 
-The API key inherits permissions from the admin account that created it.
+**Verification endpoint** (used during setup to confirm the key is valid):
+
+```
+GET /proxy/network/api/s/default/self
+X-API-Key: your-key-here
+```
+
+This endpoint **always** requires the `/proxy/network` prefix — it does not exist at `/api/s/default/self`. If `_detect_unifi_os()` returns `False` (detection failed), `_verify_api_key()` will incorrectly call the non-prefixed path and receive a 404. See `TODO.md` for the tracked bug and fix options.
+
+> **Note on newer API (v2):** UniFi Network Application 8.x introduced a newer REST API under `/proxy/network/v2/api/`. For example, `GET /proxy/network/v2/api/site` lists all sites. The alarm endpoint remains at the classic `/proxy/network/api/s/{site}/alarm` path as of the time of writing, but this may change in future firmware versions. The v2 API may be a better verification target if the `self` endpoint is deprecated.
 
 ### Auto-detect logic (in `UniFiClient.authenticate()`)
 


### PR DESCRIPTION
## Changes

### HOMEASSISTANT.md
- Added comprehensive section on aiohttp session lifecycle and ownership semantics
- Documented the difference between `async_get_clientsession()` (shared, HA-owned) and `async_create_clientsession()` (dedicated, HA-owned)
- Provided examples of correct patterns (raw `aiohttp.ClientSession()` with async context manager) vs incorrect patterns (manually closing HA-managed sessions)
- Noted that config flow currently violates these patterns

### TODO.md
- Added new high-priority bug: config flow closes HA-managed aiohttp session, triggering deprecation warnings on every setup
  - Root cause: `async_step_user` uses `async_create_clientsession()` then manually calls `await session.close()`
  - Recommended fix: use raw `aiohttp.ClientSession()` as context manager for one-off auth checks
- Updated UniFi OS detection bug with expanded root cause analysis:
  - Identified two compounding issues: fragile `x-csrf-token` detection heuristic + logic flaw in `_verify_api_key()`
  - Documented that API keys are UniFi OS-only, so verification should always use `/proxy/network` prefix
  - Provided three-part fix recommendation: force OS prefix, improve fallback detection, and catch 404 with clear error
  - Expanded affected configurations: reverse proxies, UCG-Ultra, redirects

### UNIFI.md
- Updated detection section with detailed caveats and known failure modes
- Documented how reverse proxies, UCG-Ultra firmware, and HTTP redirects cause detection to fail
- Added critical note linking detection failures to API key verification bug
- Expanded authentication section with:
  - UniFi OS settings paths for API key generation (varies by firmware version)
  - Proper verification endpoint documentation with `/proxy/network` prefix requirement
  - Warning about detection failure impact on API key verification
  - Note on v2 API as potential future verification target