### PR TITLE
feat: multi-site support, API key doc fix, test coverage gaps, aiohttp/SSRF/API key path fixes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,34 @@
 # History
 
+## 2026-04-10 (session 4) — API key docs, test coverage gaps, multi-site support (253 tests)
+
+Addressed three more high-priority items from `TODO.md`. All checks pass.
+
+### `TODO.md` — stale item cleanup
+- Removed four items already resolved in prior sessions whose removal was recorded in HISTORY.md but not actually applied to the file: "Config flow repopulates old username/password", "API key and password fields are plaintext", "Tighten bare except Exception in webhook handler", "Disabled category open_count is still updated by polling".
+
+### API key instructions — config flow, README, UNIFI.md
+- `strings.json` + `translations/en.json`: replaced the single hard-coded path ("Settings → Admins & Users → API Keys") with a version-agnostic instruction noting the path varies by firmware and listing both common paths ("Settings → Admins & Users → API Keys" or "Integrations → New API Key"). Links to README for device-specific instructions.
+- `README.md`: updated setup step 2 to reference new "Generating an API key" section; added that section with a table of per-firmware navigation paths and a note to use a dedicated non-MFA account.
+- `UNIFI.md`: removed two stale references to the now-resolved API key path bug in `TODO.md`.
+
+### Missing test coverage — 9 new tests
+- `test_config_flow.py`: added `test_categories_step_saves_poll_interval_and_clear_timeout`, `test_categories_step_accepts_boundary_poll_intervals` (parametrised: 10, 3600), `test_categories_step_accepts_boundary_clear_timeouts` (parametrised: 1, 1440), `test_options_flow_saves_submitted_values`, `test_options_flow_rejects_all_disabled`.
+- These cover: poll_interval and clear_timeout are stored in `_entry_data`; vol.Range boundary values are accepted; options flow submits and persists selected values; options flow rejects all-disabled with correct error.
+
+### Multi-site support — `CONF_SITE` / `DEFAULT_SITE`
+- `const.py`: added `CONF_SITE = "site"` and `DEFAULT_SITE = "default"`.
+- `config_flow.py`: added optional `site` field (default `"default"`) to both the categories step and the options flow init step; stored in `_entry_data` and options `data`.
+- `coordinator.py`: reads `CONF_SITE` from config (falls back to `DEFAULT_SITE`); passes the site name to `categorise_alarms()` on every poll cycle.
+- `strings.json` + `translations/en.json`: added `"site"` label to both the categories step and the options init step.
+- `test_coordinator.py`: added `TestSiteConfig` (2 tests): coordinator passes configured site to `categorise_alarms`; defaults to `"default"` when absent.
+
+### `TODO.md` — resolved items removed
+- Removed: API key instructions, multi-site support.
+- Updated: remaining test coverage gap now reduced to end-to-end integration tests only.
+
+---
+
 ## 2026-04-10 (session 3) — 4 high-priority bugfixes: session ownership, SSRF, API key path, pagination (244 tests)
 
 Addressed the top four items from `TODO.md`. All checks pass: lint, mypy, HACS preflight, translation drift, 244 tests.

--- a/README.md
+++ b/README.md
@@ -52,13 +52,31 @@ Copy `custom_components/unifi_alerts/` into your HA `config/custom_components/` 
 
 1. Go to **Settings → Devices & Services → Add Integration** → search **UniFi Alerts**
 2. Enter your controller URL (e.g. `https://192.168.1.1`) and credentials
-   - **API key** (UDM Pro, UCG Ultra, and other UniFi OS devices): generate one in **Settings → Admins & Users → API Keys**, leave Username/Password blank
+   - **API key** (UDM Pro, UCG Ultra, and other UniFi OS devices): generate one in the UniFi OS web UI (see [Generating an API key](#generating-an-api-key) below), leave Username/Password blank
    - **Username / password** (older controllers, Cloud Key): fill in Username and Password, leave API Key blank
 3. Select the alert categories you want to monitor (see table above — client/device categories are noisy by default)
 4. Configure polling interval and auto-clear timeout
 5. **Copy the webhook URLs** shown on the final screen into UniFi Alarm Manager (see next section). Click **Submit** to save — the integration is not created until you click Submit.
 
 > You can always retrieve your webhook URLs later from **Settings → Devices & Services → UniFi Alerts → Configure**.
+
+---
+
+## Generating an API key
+
+API keys are supported on **UniFi OS consoles only** (UDM, UDM Pro, UDM SE, UCG-Ultra, Cloud Key Gen2+). They are not available on self-hosted (Linux/Windows) controllers.
+
+The navigation path to create a key varies by firmware version:
+
+| Firmware / UI version | Path |
+|---|---|
+| Network Application 8.x+ | **Settings → Admins & Users → API Keys → Create** |
+| Some UCG / UDM firmware | **Integrations → API → New API Key** |
+| Older Cloud Key Gen2+ | **Settings → Control Plane → API Keys** |
+
+If you cannot find the option, try each path in order. The key is only displayed once at creation — copy it immediately and paste it into the integration setup.
+
+> **Tip:** Create a dedicated read-only local admin account for the integration. Do not use a cloud account or an account with MFA enabled — non-interactive login will break.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -70,6 +70,3 @@ In `coordinator._async_update_data`, if re-auth succeeds but the second `categor
 
 ### CI action versions are floating (`@master`, `@main`)
 `home-assistant/actions/hassfest@master` and `hacs/action@main` are not pinned to a SHA. A breaking upstream change or supply-chain compromise would silently affect CI. Pin to commit SHAs and update periodically.
-
-### CI action versions are floating (`@master`, `@main`)
-`home-assistant/actions/hassfest@master` and `hacs/action@main` are not pinned to a SHA. A breaking upstream change or supply-chain compromise would silently affect CI. Pin to commit SHAs and update periodically.

--- a/TODO.md
+++ b/TODO.md
@@ -12,31 +12,6 @@ Prioritised backlog. Items are grouped by type. Work top-to-bottom within each g
 - Replace the single hard-coded path in the config flow description with a version-agnostic instruction such as: *"Generate an API key in the UniFi OS web UI — the exact location varies by firmware version. Common paths: **Settings → Admins & Users → API Keys** or **Integrations → New API Key**. Refer to the [integration README] for device-specific instructions."*
 - Add a dedicated "Generating an API key" section to `README.md` with per-device navigation paths so users can find it outside the config flow UI.
 
-### [BUG] Config flow repopulates old username/password after switching to API key
-**File:** `config_flow.py:76-90`
-**Problem:** On a failed submission, the schema is rebuilt with `default=user_input.get(...)` for each field. However, HA's config flow frontend can retain or pre-fill field values from a prior schema render. If the user first submits username + password (form repopulates both), then clears those fields and submits with only an API key, the re-displayed form shows all three values — the old username/password are restored even though the user blanked them.
-**Root cause:** Setting `default=user_input.get(CONF_USERNAME, "")` when the user submitted an empty string may interact with HA's `suggested_value` mechanism or frontend caching in a way that restores prior values instead of showing the current empty submission.
-**Fix:** Explicitly omit keys with empty-string values from the schema defaults (use `vol.UNDEFINED` or omit the `default` argument) so HA treats them as truly blank rather than pre-filled. Only pass a non-empty default if the submitted value is a non-empty string:
-```python
-vol.Optional(CONF_USERNAME, **({"default": v} if (v := user_input.get(CONF_USERNAME, "")) else {})): str
-```
-Alternatively, use `description={"suggested_value": ...}` instead of `default=` which gives the frontend a weaker hint that the user can override.
-
-### [BUG] API key and password fields are plaintext — sensitive values visible on screen
-**File:** `config_flow.py:83-84, 96-97`
-**Problem:** Both `CONF_API_KEY` and `CONF_PASSWORD` are declared as plain `str` in the vol schema. HA renders them as unmasked text inputs, so credentials are visible to anyone who can see the screen. Neither field gets the browser's password-field treatment (masked input with an unmask toggle).
-**Fix:** Replace the bare `str` type with `TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))` for both fields. HA's frontend renders password-type selectors as masked inputs with a built-in show/hide toggle, satisfying the requirement to let the user reveal the value to verify a paste. Import from `homeassistant.helpers.selector`:
-```python
-from homeassistant.helpers.selector import TextSelector, TextSelectorConfig, TextSelectorType
-
-_PASSWORD_SELECTOR = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
-
-# In both schema branches:
-vol.Optional(CONF_PASSWORD): _PASSWORD_SELECTOR,
-vol.Optional(CONF_API_KEY): _PASSWORD_SELECTOR,
-```
-Apply in both the initial schema and the error-repopulation schema (lines 83-84 and 96-97).
-
 ### Integration tests with the `hass` fixture
 **Problem:** The current test suite uses plain mocks and does not exercise the HA setup lifecycle. Config flow, entity creation, coordinator wiring, and webhook dispatch are all untested end-to-end.
 **Fix:** Set up `pytest_homeassistant_custom_component` properly in `conftest.py` and add tests for:
@@ -46,15 +21,9 @@ Apply in both the initial schema and the error-repopulation schema (lines 83-84 
 - GET health-check → no spurious alert dispatched
 **Reference:** See `TESTING.md` for fixture pattern.
 
-### Remaining test coverage gaps (plain-mock layer now complete — see HISTORY.md 2026-04-09)
-All source modules now have plain-mock unit test coverage (234 tests). Remaining gaps:
-- **Options flow form submission** — only the init form display is tested; saving updated values is not.
-- **Config flow categories step submission** — poll interval / clear timeout validation and edge values (10, 3600, 1, 1440) not covered.
+### Remaining test coverage gaps
+Plain-mock unit layer is complete (253 tests). Remaining gap:
 - **End-to-end integration tests** — still require full `hass` fixture setup (see item above).
-
-### Multi-site support
-**Problem:** `UniFiClient.fetch_alarms()` hardcodes `site="default"`. Users with multi-site UniFi deployments cannot monitor secondary sites. Currently a silent failure with no user-facing explanation.
-**Fix:** Add a `CONF_SITE` config entry key, defaulting to `"default"`. Expose it as an optional field in the config flow. Pass it through to `fetch_alarms()`. Add a README note: "Currently only the default UniFi site is supported. Multi-site support is planned."
 
 ### Verify update-in-place works without HA reboot
 **Problem:** Unknown whether updating the integration (e.g. via HACS or copying files) requires a full Home Assistant restart, or whether reloading the config entry is sufficient. A reboot requirement would be a significant friction point for self-hosted users pushing frequent updates.
@@ -99,11 +68,8 @@ The `_device_info()` helper function is duplicated identically across `binary_se
 ### Polling re-auth is fire-and-forget
 In `coordinator._async_update_data`, if re-auth succeeds but the second `categorise_alarms()` call fails for a different reason, the error path is the generic `CannotConnectError` branch which may give a misleading log message.
 
-### Disabled category `open_count` is still updated by polling
-`categorise_alarms()` returns all categories regardless of enabled/disabled state, and the coordinator updates `open_count` for all of them. A disabled category with open alarms on the controller will have a non-zero `open_count` internally, which is inconsistent.
-
 ### CI action versions are floating (`@master`, `@main`)
 `home-assistant/actions/hassfest@master` and `hacs/action@main` are not pinned to a SHA. A breaking upstream change or supply-chain compromise would silently affect CI. Pin to commit SHAs and update periodically.
 
-### Tighten bare `except Exception` in webhook handler
-`webhook_handler.py:96` catches bare `except Exception` where only `json.JSONDecodeError` and `TypeError` are expected. Replace with `except (json.JSONDecodeError, TypeError):` to avoid masking unexpected errors.
+### CI action versions are floating (`@master`, `@main`)
+`home-assistant/actions/hassfest@master` and `hacs/action@main` are not pinned to a SHA. A breaking upstream change or supply-chain compromise would silently affect CI. Pin to commit SHAs and update periodically.

--- a/UNIFI.md
+++ b/UNIFI.md
@@ -21,7 +21,7 @@ The `x-csrf-token` heuristic is fragile. It fails in several common real-world c
 - **UCG-Ultra firmware**: Some UCG-Ultra firmware versions do not set `x-csrf-token` on the `/` response, causing detection to fail on the device itself (no proxy involved).
 - **HTTP→HTTPS redirect**: The detection request follows redirects (`allow_redirects=True`), but if the final destination doesn't serve `x-csrf-token` (e.g. a landing page or portal), detection still returns `False`.
 
-**Critical implication:** API keys are **UniFi OS-only** — they cannot be generated or used on self-hosted (classic) controllers. If a user has supplied an API key in the config, the controller is UniFi OS by definition. The code must not route API key verification requests through the legacy `/api/s/...` path regardless of what detection returns. See the bug in `TODO.md`: *UCG-Ultra: OS detection fails → API key verification hits wrong endpoint (404)*.
+**Critical implication:** API keys are **UniFi OS-only** — they cannot be generated or used on self-hosted (classic) controllers. If a user has supplied an API key in the config, the controller is UniFi OS by definition. The code must not route API key verification requests through the legacy `/api/s/...` path regardless of what detection returns. `_verify_api_key()` hardcodes the `/proxy/network` prefix for this reason.
 
 ## Authentication
 
@@ -68,7 +68,7 @@ GET /proxy/network/api/s/default/self
 X-API-Key: your-key-here
 ```
 
-This endpoint **always** requires the `/proxy/network` prefix — it does not exist at `/api/s/default/self`. If `_detect_unifi_os()` returns `False` (detection failed), `_verify_api_key()` will incorrectly call the non-prefixed path and receive a 404. See `TODO.md` for the tracked bug and fix options.
+This endpoint **always** requires the `/proxy/network` prefix — it does not exist at `/api/s/default/self`. `_verify_api_key()` hardcodes the `/proxy/network` prefix and does not rely on `_detect_unifi_os()`, so it works correctly even when detection returns a false negative.
 
 > **Note on newer API (v2):** UniFi Network Application 8.x introduced a newer REST API under `/proxy/network/v2/api/`. For example, `GET /proxy/network/v2/api/site` lists all sites. The alarm endpoint remains at the classic `/proxy/network/api/s/{site}/alarm` path as of the time of writing, but this may change in future firmware versions. The v2 API may be a better verification target if the `self` endpoint is deprecated.
 

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -24,11 +24,13 @@ from .const import (
     CONF_ENABLED_CATEGORIES,
     CONF_PASSWORD,
     CONF_POLL_INTERVAL,
+    CONF_SITE,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
     CONF_WEBHOOK_SECRET,
     DEFAULT_CLEAR_TIMEOUT,
     DEFAULT_POLL_INTERVAL,
+    DEFAULT_SITE,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
     webhook_id_for_category,
@@ -138,6 +140,7 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_ENABLED_CATEGORIES: enabled,
                     CONF_POLL_INTERVAL: user_input.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL),
                     CONF_CLEAR_TIMEOUT: user_input.get(CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT),
+                    CONF_SITE: user_input.get(CONF_SITE, DEFAULT_SITE),
                     CONF_AUTH_METHOD: self._detected_auth_method,
                 }
                 return await self.async_step_finish()
@@ -155,6 +158,7 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
         fields[vol.Optional(CONF_CLEAR_TIMEOUT, default=DEFAULT_CLEAR_TIMEOUT)] = vol.All(
             int, vol.Range(min=1, max=1440)
         )
+        fields[vol.Optional(CONF_SITE, default=DEFAULT_SITE)] = str
 
         schema = vol.Schema(fields)
         return self.async_show_form(
@@ -216,6 +220,7 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
                         CONF_CLEAR_TIMEOUT: user_input.get(
                             CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT
                         ),
+                        CONF_SITE: user_input.get(CONF_SITE, DEFAULT_SITE),
                     },
                 )
 
@@ -231,6 +236,10 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
             CONF_CLEAR_TIMEOUT,
             self._config_entry.data.get(CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT),
         )
+        current_site: str = self._config_entry.options.get(
+            CONF_SITE,
+            self._config_entry.data.get(CONF_SITE, DEFAULT_SITE),
+        )
 
         fields: dict = {}
         for cat in ALL_CATEGORIES:
@@ -241,6 +250,7 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
         fields[vol.Optional(CONF_CLEAR_TIMEOUT, default=current_clear)] = vol.All(
             int, vol.Range(min=1, max=1440)
         )
+        fields[vol.Optional(CONF_SITE, default=current_site)] = str
 
         secret: str = self._config_entry.data.get(CONF_WEBHOOK_SECRET, "")
         for cat in ALL_CATEGORIES:

--- a/custom_components/unifi_alerts/const.py
+++ b/custom_components/unifi_alerts/const.py
@@ -17,6 +17,7 @@ CONF_CLEAR_TIMEOUT = "clear_timeout"
 CONF_ENABLED_CATEGORIES = "enabled_categories"
 CONF_VERIFY_SSL = "verify_ssl"
 CONF_WEBHOOK_SECRET = "webhook_secret"
+CONF_SITE = "site"
 
 AUTH_METHOD_USERPASS = "userpass"
 AUTH_METHOD_APIKEY = "apikey"
@@ -24,6 +25,7 @@ AUTH_METHOD_APIKEY = "apikey"
 DEFAULT_POLL_INTERVAL = 60  # seconds
 DEFAULT_CLEAR_TIMEOUT = 30  # minutes
 DEFAULT_VERIFY_SSL = True  # disable in config flow if controller has a self-signed cert
+DEFAULT_SITE = "default"
 
 # ──────────────────────────────────────────────
 # Category identifiers

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -15,8 +15,10 @@ from .const import (
     CONF_CLEAR_TIMEOUT,
     CONF_ENABLED_CATEGORIES,
     CONF_POLL_INTERVAL,
+    CONF_SITE,
     DEFAULT_CLEAR_TIMEOUT,
     DEFAULT_POLL_INTERVAL,
+    DEFAULT_SITE,
     DOMAIN,
 )
 from .models import CategoryState, UniFiAlert
@@ -51,6 +53,7 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         self._config = config
         self._clear_timeout_minutes: int = config.get(CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT)
         self._enabled_categories: list[str] = config.get(CONF_ENABLED_CATEGORIES, ALL_CATEGORIES)
+        self._site: str = config.get(CONF_SITE, DEFAULT_SITE)
 
         # Category state is long-lived; do NOT reset between coordinator refreshes
         self._category_states: dict[str, CategoryState] = {
@@ -66,13 +69,13 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
     async def _async_update_data(self) -> dict[str, CategoryState]:
         """Fetch open alarm counts from the controller (polling path)."""
         try:
-            categorised = await self._client.categorise_alarms()
+            categorised = await self._client.categorise_alarms(self._site)
         except InvalidAuthError as err:
             # Re-authenticate once then retry
             _LOGGER.warning("Auth expired, re-authenticating: %s", err)
             try:
                 await self._client.authenticate()
-                categorised = await self._client.categorise_alarms()
+                categorised = await self._client.categorise_alarms(self._site)
             except (InvalidAuthError, CannotConnectError) as retry_err:
                 raise UpdateFailed(f"UniFi auth failed: {retry_err}") from retry_err
         except CannotConnectError as err:

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Connect to UniFi Controller",
-        "description": "Enter your UniFi Network controller address and credentials. The integration will auto-detect which method to use.\n\n**API key** (UniFi OS consoles — UDM Pro, UCG Ultra, etc.): leave Username and Password blank. Generate an API key in the UniFi OS web UI — the exact location varies by firmware version. Common paths: **Settings → Admins & Users → API Keys** or **Integrations → New API Key**. See the [README](https://github.com/PHeonix25/unifi_alerts) for device-specific instructions.\n\n**Username / password** (older controllers or Cloud Key): fill in Username and Password, leave API Key blank.\n\nSSL verification is enabled by default. Disable it only if your controller uses a self-signed certificate.",
+        "description": "Enter your UniFi Network controller address and credentials. The integration will auto-detect which method to use.\n\n**API key** (UniFi OS consoles — UDM Pro, UCG Ultra, etc.): leave Username and Password blank. Generate an API key in the UniFi OS web UI — the exact location varies by firmware version. Common paths: **Settings → Admins & Users → API Keys** or **Integrations → New API Key**. See the integration README on GitHub for device-specific instructions.\n\n**Username / password** (older controllers or Cloud Key): fill in Username and Password, leave API Key blank.\n\nSSL verification is enabled by default. Disable it only if your controller uses a self-signed certificate.",
         "data": {
           "controller_url": "Controller URL (e.g. https://192.168.1.1)",
           "username": "Username (leave blank if using API key)",

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Connect to UniFi Controller",
-        "description": "Enter your UniFi Network controller address and credentials. The integration will auto-detect which method to use.\n\n**API key** (UniFi OS consoles — UDM Pro, UCG Ultra, etc.): leave Username and Password blank. Generate a key in **Settings → Admins & Users → API Keys**.\n\n**Username / password** (older controllers or Cloud Key): fill in Username and Password, leave API Key blank.\n\nSSL verification is enabled by default. Disable it only if your controller uses a self-signed certificate.",
+        "description": "Enter your UniFi Network controller address and credentials. The integration will auto-detect which method to use.\n\n**API key** (UniFi OS consoles — UDM Pro, UCG Ultra, etc.): leave Username and Password blank. Generate an API key in the UniFi OS web UI — the exact location varies by firmware version. Common paths: **Settings → Admins & Users → API Keys** or **Integrations → New API Key**. See the [README](https://github.com/PHeonix25/unifi_alerts) for device-specific instructions.\n\n**Username / password** (older controllers or Cloud Key): fill in Username and Password, leave API Key blank.\n\nSSL verification is enabled by default. Disable it only if your controller uses a self-signed certificate.",
         "data": {
           "controller_url": "Controller URL (e.g. https://192.168.1.1)",
           "username": "Username (leave blank if using API key)",
@@ -24,7 +24,8 @@
           "cat_security_firewall": "Security: Firewall block",
           "cat_power": "Power: PoE / power loss",
           "poll_interval": "Polling interval (seconds)",
-          "clear_timeout": "Auto-clear timeout (minutes)"
+          "clear_timeout": "Auto-clear timeout (minutes)",
+          "site": "UniFi site name (leave as \"default\" for single-site setups)"
         }
       },
       "finish": {
@@ -67,6 +68,7 @@
           "cat_power": "Power: PoE / power loss",
           "poll_interval": "Polling interval (seconds)",
           "clear_timeout": "Auto-clear timeout (minutes)",
+          "site": "UniFi site name",
           "webhook_url_network_device": "Network: Device offline/online webhook URL",
           "webhook_url_network_wan": "Network: WAN offline/latency webhook URL",
           "webhook_url_network_client": "Network: Client connect/disconnect webhook URL",

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Connect to UniFi Controller",
-        "description": "Enter your UniFi Network controller address and credentials. The integration will auto-detect which method to use.\n\n**API key** (UniFi OS consoles — UDM Pro, UCG Ultra, etc.): leave Username and Password blank. Generate an API key in the UniFi OS web UI — the exact location varies by firmware version. Common paths: **Settings → Admins & Users → API Keys** or **Integrations → New API Key**. See the [README](https://github.com/PHeonix25/unifi_alerts) for device-specific instructions.\n\n**Username / password** (older controllers or Cloud Key): fill in Username and Password, leave API Key blank.\n\nSSL verification is enabled by default. Disable it only if your controller uses a self-signed certificate.",
+        "description": "Enter your UniFi Network controller address and credentials. The integration will auto-detect which method to use.\n\n**API key** (UniFi OS consoles — UDM Pro, UCG Ultra, etc.): leave Username and Password blank. Generate an API key in the UniFi OS web UI — the exact location varies by firmware version. Common paths: **Settings → Admins & Users → API Keys** or **Integrations → New API Key**. See the integration README on GitHub for device-specific instructions.\n\n**Username / password** (older controllers or Cloud Key): fill in Username and Password, leave API Key blank.\n\nSSL verification is enabled by default. Disable it only if your controller uses a self-signed certificate.",
         "data": {
           "controller_url": "Controller URL (e.g. https://192.168.1.1)",
           "username": "Username (leave blank if using API key)",

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Connect to UniFi Controller",
-        "description": "Enter your UniFi Network controller address and credentials. The integration will auto-detect which method to use.\n\n**API key** (UniFi OS consoles — UDM Pro, UCG Ultra, etc.): leave Username and Password blank. Generate a key in **Settings → Admins & Users → API Keys**.\n\n**Username / password** (older controllers or Cloud Key): fill in Username and Password, leave API Key blank.\n\nSSL verification is enabled by default. Disable it only if your controller uses a self-signed certificate.",
+        "description": "Enter your UniFi Network controller address and credentials. The integration will auto-detect which method to use.\n\n**API key** (UniFi OS consoles — UDM Pro, UCG Ultra, etc.): leave Username and Password blank. Generate an API key in the UniFi OS web UI — the exact location varies by firmware version. Common paths: **Settings → Admins & Users → API Keys** or **Integrations → New API Key**. See the [README](https://github.com/PHeonix25/unifi_alerts) for device-specific instructions.\n\n**Username / password** (older controllers or Cloud Key): fill in Username and Password, leave API Key blank.\n\nSSL verification is enabled by default. Disable it only if your controller uses a self-signed certificate.",
         "data": {
           "controller_url": "Controller URL (e.g. https://192.168.1.1)",
           "username": "Username (leave blank if using API key)",
@@ -24,7 +24,8 @@
           "cat_security_firewall": "Security: Firewall block",
           "cat_power": "Power: PoE / power loss",
           "poll_interval": "Polling interval (seconds)",
-          "clear_timeout": "Auto-clear timeout (minutes)"
+          "clear_timeout": "Auto-clear timeout (minutes)",
+          "site": "UniFi site name (leave as \"default\" for single-site setups)"
         }
       },
       "finish": {
@@ -67,6 +68,7 @@
           "cat_power": "Power: PoE / power loss",
           "poll_interval": "Polling interval (seconds)",
           "clear_timeout": "Auto-clear timeout (minutes)",
+          "site": "UniFi site name",
           "webhook_url_network_device": "Network: Device offline/online webhook URL",
           "webhook_url_network_wan": "Network: WAN offline/latency webhook URL",
           "webhook_url_network_client": "Network: Client connect/disconnect webhook URL",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -397,3 +397,132 @@ async def test_user_step_initial_load_uses_hardcoded_defaults() -> None:
                 schema_defaults[str(k)] = k.default()
     assert schema_defaults.get(CONF_CONTROLLER_URL) == "https://192.168.1.1"
     assert schema_defaults.get(CONF_VERIFY_SSL) == DEFAULT_VERIFY_SSL
+
+
+# ---------------------------------------------------------------------------
+# Categories step — boundary-value and validation coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_categories_step_saves_poll_interval_and_clear_timeout() -> None:
+    """Submitted poll_interval and clear_timeout must be stored in _entry_data."""
+    from custom_components.unifi_alerts.const import CONF_CLEAR_TIMEOUT, CONF_POLL_INTERVAL
+
+    flow = _make_flow()
+    flow._controller_url = "https://192.168.1.1"
+    flow._detected_auth_method = "userpass"
+    flow._credentials = {CONF_WEBHOOK_SECRET: "s"}
+    flow.async_step_finish = AsyncMock(return_value={"type": "form", "step_id": "finish"})
+
+    cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+    cat_input[CONF_POLL_INTERVAL] = 120
+    cat_input[CONF_CLEAR_TIMEOUT] = 30
+
+    await flow.async_step_categories(cat_input)
+
+    assert flow._entry_data[CONF_POLL_INTERVAL] == 120
+    assert flow._entry_data[CONF_CLEAR_TIMEOUT] == 30
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("poll_interval", [10, 3600])
+async def test_categories_step_accepts_boundary_poll_intervals(poll_interval: int) -> None:
+    """poll_interval boundary values 10 and 3600 must be accepted without error."""
+    from custom_components.unifi_alerts.const import CONF_POLL_INTERVAL
+
+    flow = _make_flow()
+    flow._controller_url = "https://192.168.1.1"
+    flow._detected_auth_method = "userpass"
+    flow._credentials = {CONF_WEBHOOK_SECRET: "s"}
+    flow.async_step_finish = AsyncMock(return_value={"type": "form", "step_id": "finish"})
+
+    cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+    cat_input[CONF_POLL_INTERVAL] = poll_interval
+
+    result = await flow.async_step_categories(cat_input)
+
+    assert result["step_id"] == "finish"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("clear_timeout", [1, 1440])
+async def test_categories_step_accepts_boundary_clear_timeouts(clear_timeout: int) -> None:
+    """clear_timeout boundary values 1 and 1440 must be accepted without error."""
+    from custom_components.unifi_alerts.const import CONF_CLEAR_TIMEOUT
+
+    flow = _make_flow()
+    flow._controller_url = "https://192.168.1.1"
+    flow._detected_auth_method = "userpass"
+    flow._credentials = {CONF_WEBHOOK_SECRET: "s"}
+    flow.async_step_finish = AsyncMock(return_value={"type": "form", "step_id": "finish"})
+
+    cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+    cat_input[CONF_CLEAR_TIMEOUT] = clear_timeout
+
+    result = await flow.async_step_categories(cat_input)
+
+    assert result["step_id"] == "finish"
+
+
+# ---------------------------------------------------------------------------
+# Options flow — form submission (saving updated values)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_options_flow_saves_submitted_values() -> None:
+    """Submitting the options flow must persist the selected categories and intervals."""
+    from custom_components.unifi_alerts.const import CONF_CLEAR_TIMEOUT, CONF_POLL_INTERVAL, CONF_SITE
+
+    config_entry = MagicMock()
+    config_entry.data = {
+        CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+        CONF_WEBHOOK_SECRET: "sec",
+        CONF_POLL_INTERVAL: 60,
+        CONF_CLEAR_TIMEOUT: 5,
+    }
+    config_entry.options = {}
+
+    flow = UniFiAlertsOptionsFlow(config_entry)
+    flow.hass = MagicMock()
+    flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+    # Only enable first category; set custom poll, clear, and site values
+    first_cat = ALL_CATEGORIES[0]
+    user_input = {f"cat_{cat}": (cat == first_cat) for cat in ALL_CATEGORIES}
+    user_input[CONF_POLL_INTERVAL] = 300
+    user_input[CONF_CLEAR_TIMEOUT] = 60
+    user_input[CONF_SITE] = "secondary"
+
+    result = await flow.async_step_init(user_input)
+
+    assert result["type"] == "create_entry"
+    saved = flow.async_create_entry.call_args.kwargs["data"]
+    assert saved[CONF_ENABLED_CATEGORIES] == [first_cat]
+    assert saved[CONF_POLL_INTERVAL] == 300
+    assert saved[CONF_CLEAR_TIMEOUT] == 60
+    assert saved[CONF_SITE] == "secondary"
+
+
+@pytest.mark.asyncio
+async def test_options_flow_rejects_all_disabled() -> None:
+    """Options flow must show error when all categories are unchecked."""
+    config_entry = MagicMock()
+    config_entry.data = {CONF_ENABLED_CATEGORIES: ALL_CATEGORIES, CONF_WEBHOOK_SECRET: "s"}
+    config_entry.options = {}
+
+    flow = UniFiAlertsOptionsFlow(config_entry)
+    flow.hass = MagicMock()
+    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "init"})
+
+    all_off = {f"cat_{cat}": False for cat in ALL_CATEGORIES}
+    with patch(
+        "custom_components.unifi_alerts.config_flow.async_generate_url",
+        return_value="http://ha.local/webhook/x",
+    ):
+        result = await flow.async_step_init(all_off)
+
+    assert result["step_id"] == "init"
+    call_kwargs = flow.async_show_form.call_args.kwargs
+    assert call_kwargs["errors"] == {"base": "at_least_one_category"}

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -463,3 +463,53 @@ class TestAutoClear:
             await coord._auto_clear(CATEGORY_NETWORK_WAN, 0)
 
         coord.async_set_updated_data.assert_not_called()
+
+
+class TestSiteConfig:
+    """Tests for CONF_SITE threading through the coordinator."""
+
+    @pytest.mark.asyncio
+    async def test_coordinator_passes_site_to_categorise_alarms(self):
+        """Coordinator must forward the configured site name to categorise_alarms."""
+        from custom_components.unifi_alerts.const import CONF_SITE
+
+        hass = MagicMock()
+        hass.async_create_task = lambda coro, **kw: (coro.close() or MagicMock())
+
+        client = MagicMock()
+        client.categorise_alarms = AsyncMock(return_value={})
+
+        config = {
+            CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+            CONF_POLL_INTERVAL: 60,
+            CONF_CLEAR_TIMEOUT: 30,
+            CONF_SITE: "secondary",
+        }
+        coord = UniFiAlertsCoordinator(hass, client, config)
+        coord.async_set_updated_data = MagicMock()
+
+        await coord._async_update_data()
+
+        client.categorise_alarms.assert_awaited_once_with("secondary")
+
+    @pytest.mark.asyncio
+    async def test_coordinator_defaults_site_to_default(self):
+        """When CONF_SITE is absent, coordinator must use 'default'."""
+        hass = MagicMock()
+        hass.async_create_task = lambda coro, **kw: (coro.close() or MagicMock())
+
+        client = MagicMock()
+        client.categorise_alarms = AsyncMock(return_value={})
+
+        config = {
+            CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+            CONF_POLL_INTERVAL: 60,
+            CONF_CLEAR_TIMEOUT: 30,
+            # CONF_SITE intentionally absent
+        }
+        coord = UniFiAlertsCoordinator(hass, client, config)
+        coord.async_set_updated_data = MagicMock()
+
+        await coord._async_update_data()
+
+        client.categorise_alarms.assert_awaited_once_with("default")


### PR DESCRIPTION
## Summary

Two commits addressing 8 TODO items across two sessions:

### Session 3 (`fix:` commit) — 4 bug fixes (244 tests)
- **aiohttp session ownership** — replaced `async_create_clientsession` + manual `close()` with `async with aiohttp.ClientSession()` in the config flow, eliminating the HA deprecation warning on every setup
- **SSRF protection** — validate controller URL scheme (`http`/`https` only) before any network call; invalid schemes show a field-level error immediately
- **API key endpoint path** — `_verify_api_key` now always uses `/proxy/network` prefix (API keys are OS-only); catches 404 with a clear `CannotConnectError`; `_detect_unifi_os` adds a `/api/system` fallback probe for UCG-Ultra / reverse-proxy setups
- **Alarm pagination** — `fetch_alarms` sends `limit=200` to cap poll payload size

### Session 4 (`feat:` commit) — multi-site, docs, test coverage (253 tests)
- **Multi-site support** — `CONF_SITE`/`DEFAULT_SITE` constants; optional `site` field in config flow categories step and options flow (both persisted); coordinator forwards the site name to `categorise_alarms()` on every poll
- **API key instructions** — config flow description now lists both firmware navigation paths; new "Generating an API key" section in README with per-firmware table; stale TODO references removed from UNIFI.md
- **Test coverage gaps closed** — categories step boundary values (10/3600, 1/1440); `_entry_data` content verified; options flow submit saves all values; options flow rejects all-disabled
- **TODO.md cleanup** — removed 4 items already fixed in prior sessions but not deleted from the file

## Test plan

- [ ] `make check` passes (253 tests, lint, mypy, HACS preflight, translation drift)
- [ ] Config flow: entering `ftp://192.168.1.1` shows field-level error, no network call made
- [ ] Config flow: API key step description shows both navigation paths
- [ ] Config flow (categories step): `site` field visible, defaults to `default`
- [ ] Options flow: `site` field visible, persists on save
- [ ] Multi-site: changing site to a non-default value and saving causes polling to use that site name
- [ ] API key setup on UCG-Ultra / reverse-proxy: no longer returns 404 during auth

https://claude.ai/code/session_01PGEviUQynUPGCdWnJ9MDKT