### PR TITLE
Fix silent api.err.InvalidObject: persist UniFi OS detection and validate alarm endpoint at setup

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,40 @@
 # History
 
+## 2026-04-11 (session 8) — Fix silent api.err.InvalidObject: persist UniFi OS detection + validate alarm endpoint at setup
+
+### Root cause
+
+After a successful config flow, the polling path returned `{"meta":{"rc":"error","msg":"api.err.InvalidObject"},"data":[]}` from `/proxy/network/api/s/default/alarm?limit=200`. Two bugs combined to make this silent and unrecoverable:
+
+1. `fetch_alarms()` never validated `meta.rc` — `resp.raise_for_status()` only checks the HTTP status code, which is 200 even for API-level errors. The code then called `data.get("data", [])` on the error payload (which returns `[]`) and silently returned an empty list.
+2. `_is_unifi_os` was re-detected on every `authenticate()` call and never persisted to `entry.data`. If detection flips between config-flow time and post-install (e.g. a reverse proxy strips `x-csrf-token` intermittently), the client silently uses the wrong API path prefix, which causes `api.err.InvalidObject` from the controller.
+
+### `const.py` — new `CONF_IS_UNIFI_OS` constant
+
+Added `CONF_IS_UNIFI_OS = "is_unifi_os"` to the config entry key constants. This value is now stored in `entry.data` after setup and read back by `UniFiClient` on every subsequent load.
+
+### `unifi_client.py` — three changes
+
+1. **Import `CONF_IS_UNIFI_OS`** from `.const`.
+2. **Pre-load `_is_unifi_os` from config**: changed `self._is_unifi_os: bool = False` to `self._is_unifi_os: bool | None = config.get(CONF_IS_UNIFI_OS)`. `None` means "not yet detected"; a stored `True/False` skips detection on the next `authenticate()` call.
+3. **Skip re-detection when already known**: in `authenticate()`, wrapped `self._is_unifi_os = await self._detect_unifi_os()` in `if self._is_unifi_os is None:`. Backward-compatible — existing entries without the key fall back to fresh detection as before.
+4. **Validate `meta.rc` in `fetch_alarms()`**: after `data = await resp.json()`, check `data.get("meta", {}).get("rc") != "ok"` and raise `CannotConnectError(f"UniFi API error: {msg}")` if the API reports an error. Propagates through the coordinator's existing `CannotConnectError → UpdateFailed` path and surfaces in the HA UI.
+
+### `config_flow.py` — validate alarm endpoint + store detected path
+
+1. **Call `await client.fetch_alarms()`** immediately after `await client.authenticate()` in `async_step_user()`. The existing `except CannotConnectError` handler catches any API error and shows `"cannot_connect"` to the user before the entry is created.
+2. **Store `client._is_unifi_os`** in `self._credentials` as `CONF_IS_UNIFI_OS`. This flows through to `self._entry_data` (step 2) and then to `entry.data` (step 3), ensuring the detected path is stable for the lifetime of the entry.
+3. Added `CONF_IS_UNIFI_OS` to the import block.
+
+### `UNIFI.md` — document error response envelope
+
+Added an "Error responses" subsection to "Response structure" documenting the `meta.rc`/`meta.msg` pattern and noting that `fetch_alarms()` raises `CannotConnectError` on non-`"ok"` values.
+
+### Tests
+
+- `test_unifi_client.py`: updated all `fetch_alarms()` / `categorise_alarms()` test response bodies to include `"meta": {"rc": "ok"}`. Added `test_api_error_response_raises_cannot_connect` to `TestFetchAlarms`. Added `TestIsUnifiOsPersistence` class with five tests covering: `None` init when key absent, `True`/`False` pre-load from config, skip-detection when pre-loaded, and run-detection when `None`.
+- `test_config_flow.py`: updated `test_unique_id_set_to_normalised_url` and `test_no_duplicate_proceeds_to_categories` to mock `fetch_alarms` (now called in step 1). Added `test_step_user_fetch_alarms_failure_shows_cannot_connect` and `test_conf_is_unifi_os_stored_in_credentials`.
+
 ## 2026-04-10 (session 7) — Release prep: ROADMAP/TODO tidy-up, version bump to 1.0.0-pre3
 
 Prepared the repository for the `1.0.0-pre3` tag.

--- a/UNIFI.md
+++ b/UNIFI.md
@@ -108,6 +108,21 @@ Default site name is `default`. Multi-site deployments are not currently support
 
 The integration filters to `archived: false` records only. Archived alarms are ones the user has dismissed in the UniFi UI.
 
+#### Error responses
+
+The controller returns HTTP 200 even for application-level errors. The `meta.rc` field distinguishes success from failure:
+
+```json
+{
+  "meta": {"rc": "error", "msg": "api.err.InvalidObject"},
+  "data": []
+}
+```
+
+`meta.rc` is `"ok"` on success and `"error"` on failure. `meta.msg` contains a machine-readable error code (e.g. `api.err.InvalidObject` for an unrecognised object reference or invalid site name).
+
+`fetch_alarms()` checks `meta.rc` after parsing the JSON body and raises `CannotConnectError` if it is not `"ok"`. This propagates as `UpdateFailed` in the coordinator and is surfaced as an integration error in Home Assistant.
+
 ### Field reliability
 
 | Field | Reliability | Notes |

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_CLEAR_TIMEOUT,
     CONF_CONTROLLER_URL,
     CONF_ENABLED_CATEGORIES,
+    CONF_IS_UNIFI_OS,
     CONF_PASSWORD,
     CONF_POLL_INTERVAL,
     CONF_SITE,
@@ -66,9 +67,11 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                     client = UniFiClient(session, url, user_input)
                     try:
                         auth_method = await client.authenticate()
+                        await client.fetch_alarms()  # validate alarm endpoint reachable
                     except InvalidAuthError:
                         errors["base"] = "invalid_auth"
-                    except CannotConnectError:
+                    except CannotConnectError as err:
+                        _LOGGER.error("Cannot reach alarm endpoint: %s", err)
                         errors["base"] = "cannot_connect"
                     except Exception:  # noqa: BLE001
                         _LOGGER.exception("Unexpected error during auth")
@@ -79,6 +82,7 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                         self._credentials = {
                             **user_input,
                             CONF_WEBHOOK_SECRET: secrets.token_urlsafe(32),
+                            CONF_IS_UNIFI_OS: client._is_unifi_os,
                         }
                         return await self.async_step_categories()
 

--- a/custom_components/unifi_alerts/const.py
+++ b/custom_components/unifi_alerts/const.py
@@ -18,6 +18,7 @@ CONF_ENABLED_CATEGORIES = "enabled_categories"
 CONF_VERIFY_SSL = "verify_ssl"
 CONF_WEBHOOK_SECRET = "webhook_secret"
 CONF_SITE = "site"
+CONF_IS_UNIFI_OS = "is_unifi_os"
 
 AUTH_METHOD_USERPASS = "userpass"
 AUTH_METHOD_APIKEY = "apikey"

--- a/custom_components/unifi_alerts/unifi_client.py
+++ b/custom_components/unifi_alerts/unifi_client.py
@@ -12,6 +12,7 @@ from .const import (
     AUTH_METHOD_USERPASS,
     CONF_API_KEY,
     CONF_AUTH_METHOD,
+    CONF_IS_UNIFI_OS,
     CONF_PASSWORD,
     CONF_USERNAME,
     CONF_VERIFY_SSL,
@@ -59,7 +60,7 @@ class UniFiClient:
         self._session = session
         self._base = controller_url.rstrip("/")
         self._config = config
-        self._is_unifi_os: bool = False
+        self._is_unifi_os: bool | None = config.get(CONF_IS_UNIFI_OS)
         self._auth_method: str | None = None
         self._authenticated: bool = False
 
@@ -67,7 +68,8 @@ class UniFiClient:
 
     async def authenticate(self) -> str:
         """Detect controller type and authenticate. Returns the auth method used."""
-        self._is_unifi_os = await self._detect_unifi_os()
+        if self._is_unifi_os is None:
+            self._is_unifi_os = await self._detect_unifi_os()
 
         method = self._config.get(CONF_AUTH_METHOD)
 
@@ -109,6 +111,9 @@ class UniFiClient:
                     raise InvalidAuthError("Session expired")
                 resp.raise_for_status()
                 data = await resp.json()
+                if data.get("meta", {}).get("rc") != "ok":
+                    msg = data.get("meta", {}).get("msg", "unknown error")
+                    raise CannotConnectError(f"UniFi API error: {msg}")
                 return [a for a in data.get("data", []) if not a.get("archived", False)]
         except aiohttp.ClientError as err:
             raise CannotConnectError(str(err)) from err

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -75,6 +75,7 @@ async def test_unique_id_set_to_normalised_url() -> None:
     ):
         instance = mock_cls.return_value
         instance.authenticate = AsyncMock(return_value="userpass")
+        instance.fetch_alarms = AsyncMock(return_value=[])
 
         await flow.async_step_user({**_VALID_INPUT, CONF_CONTROLLER_URL: "https://192.168.1.1/"})
 
@@ -138,6 +139,7 @@ async def test_no_duplicate_proceeds_to_categories() -> None:
     ):
         instance = mock_cls.return_value
         instance.authenticate = AsyncMock(return_value="userpass")
+        instance.fetch_alarms = AsyncMock(return_value=[])
 
         result = await flow.async_step_user(_VALID_INPUT)
 
@@ -505,6 +507,60 @@ async def test_options_flow_saves_submitted_values() -> None:
     assert saved[CONF_POLL_INTERVAL] == 300
     assert saved[CONF_CLEAR_TIMEOUT] == 60
     assert saved[CONF_SITE] == "secondary"
+
+
+@pytest.mark.asyncio
+async def test_step_user_fetch_alarms_failure_shows_cannot_connect() -> None:
+    """If fetch_alarms() raises CannotConnectError after successful auth, show cannot_connect error."""
+    from custom_components.unifi_alerts.unifi_client import CannotConnectError
+
+    flow = _make_flow()
+    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
+
+    with (
+        patch(
+            "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+            return_value=_make_session_mock(),
+        ),
+        patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+    ):
+        instance = mock_cls.return_value
+        instance.authenticate = AsyncMock(return_value="userpass")
+        instance.fetch_alarms = AsyncMock(
+            side_effect=CannotConnectError("UniFi API error: api.err.InvalidObject")
+        )
+
+        result = await flow.async_step_user(_VALID_INPUT)
+
+    assert result["step_id"] == "user"
+    call_kwargs = flow.async_show_form.call_args.kwargs
+    assert call_kwargs["errors"] == {"base": "cannot_connect"}
+
+
+@pytest.mark.asyncio
+async def test_conf_is_unifi_os_stored_in_credentials() -> None:
+    """CONF_IS_UNIFI_OS must be stored in _credentials after a successful step 1."""
+    from custom_components.unifi_alerts.const import CONF_IS_UNIFI_OS
+
+    flow = _make_flow()
+    flow.async_step_categories = AsyncMock(return_value={"type": "form", "step_id": "categories"})
+
+    with (
+        patch(
+            "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+            return_value=_make_session_mock(),
+        ),
+        patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+    ):
+        instance = mock_cls.return_value
+        instance.authenticate = AsyncMock(return_value="userpass")
+        instance.fetch_alarms = AsyncMock(return_value=[])
+        instance._is_unifi_os = True  # simulate a detected UniFi OS controller
+
+        await flow.async_step_user(_VALID_INPUT)
+
+    assert CONF_IS_UNIFI_OS in flow._credentials
+    assert flow._credentials[CONF_IS_UNIFI_OS] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_unifi_client.py
+++ b/tests/unit/test_unifi_client.py
@@ -411,10 +411,11 @@ class TestFetchAlarms:
         client._authenticated = True
         client._is_unifi_os = False
         body = {
+            "meta": {"rc": "ok"},
             "data": [
                 {"key": "EVT_GW_WANTransition", "archived": False},
                 {"key": "EVT_AP_Disconnected", "archived": True},  # should be filtered
-            ]
+            ],
         }
         ctx, _ = _make_json_response(200, body)
         client._session.get = ctx
@@ -427,7 +428,7 @@ class TestFetchAlarms:
         client = make_client()
         client._authenticated = True
         client._is_unifi_os = False
-        body = {"data": [{"key": "EVT_GW_WANTransition", "archived": True}]}
+        body = {"meta": {"rc": "ok"}, "data": [{"key": "EVT_GW_WANTransition", "archived": True}]}
         ctx, _ = _make_json_response(200, body)
         client._session.get = ctx
         alarms = await client.fetch_alarms()
@@ -475,7 +476,7 @@ class TestFetchAlarms:
             resp.status = 200
             resp.headers = {}
             resp.raise_for_status = MagicMock()
-            resp.json = AsyncMock(return_value={"data": []})
+            resp.json = AsyncMock(return_value={"meta": {"rc": "ok"}, "data": []})
             yield resp
 
         client._session.get = _tracking_get
@@ -484,13 +485,30 @@ class TestFetchAlarms:
         assert captured_kwargs.get("params") == {"limit": 200}
 
     @pytest.mark.asyncio
+    async def test_api_error_response_raises_cannot_connect(self):
+        """HTTP 200 with meta.rc != 'ok' must raise CannotConnectError.
+
+        The UniFi controller returns HTTP 200 even for API-level errors; only
+        meta.rc distinguishes success from failure.  Silently returning [] would
+        hide misconfigured site names and similar problems from the user.
+        """
+        client = make_client()
+        client._authenticated = True
+        client._is_unifi_os = False
+        body = {"meta": {"rc": "error", "msg": "api.err.InvalidObject"}, "data": []}
+        ctx, _ = _make_json_response(200, body)
+        client._session.get = ctx
+        with pytest.raises(CannotConnectError, match="api.err.InvalidObject"):
+            await client.fetch_alarms()
+
+    @pytest.mark.asyncio
     async def test_not_authenticated_calls_authenticate_first(self):
         """fetch_alarms must call authenticate() when not yet authenticated."""
         client = make_client()
         client._authenticated = False
         # authenticate() is called; after it the client should be marked as authenticated
         # so we patch authenticate to set _authenticated=True and return
-        body = {"data": [{"key": "EVT_GW_WANTransition", "archived": False}]}
+        body = {"meta": {"rc": "ok"}, "data": [{"key": "EVT_GW_WANTransition", "archived": False}]}
         ctx, _ = _make_json_response(200, body)
         client._session.get = ctx
 
@@ -515,11 +533,12 @@ class TestCategoriseAlarms:
         client._authenticated = True
         client._is_unifi_os = False
         body = {
+            "meta": {"rc": "ok"},
             "data": [
                 {"key": "EVT_GW_WANTransition", "msg": "WAN down", "archived": False},
                 {"key": "EVT_IPS_ThreatDetected", "msg": "Threat", "archived": False},
                 {"key": "EVT_GW_Failover", "msg": "Failover", "archived": False},
-            ]
+            ],
         }
         ctx, _ = _make_json_response(200, body)
         client._session.get = ctx
@@ -539,9 +558,10 @@ class TestCategoriseAlarms:
         client._authenticated = True
         client._is_unifi_os = False
         body = {
+            "meta": {"rc": "ok"},
             "data": [
                 {"key": "EVT_UNKNOWN_THING", "msg": "who knows", "archived": False},
-            ]
+            ],
         }
         ctx, _ = _make_json_response(200, body)
         client._session.get = ctx
@@ -553,7 +573,7 @@ class TestCategoriseAlarms:
         client = make_client()
         client._authenticated = True
         client._is_unifi_os = False
-        ctx, _ = _make_json_response(200, {"data": []})
+        ctx, _ = _make_json_response(200, {"meta": {"rc": "ok"}, "data": []})
         client._session.get = ctx
         result = await client.categorise_alarms()
         assert result == {}
@@ -661,3 +681,74 @@ class TestClose:
         client._session.post = AsyncMock()
         await client.close()
         client._session.post.assert_not_awaited()
+
+
+class TestIsUnifiOsPersistence:
+    """Tests for the CONF_IS_UNIFI_OS persistence behaviour."""
+
+    def test_is_unifi_os_none_when_not_in_config(self):
+        """When CONF_IS_UNIFI_OS is absent from config, _is_unifi_os starts as None."""
+        client = make_client()
+        assert client._is_unifi_os is None
+
+    def test_is_unifi_os_loaded_from_config_true(self):
+        """When CONF_IS_UNIFI_OS=True is in config, _is_unifi_os is pre-set to True."""
+        from custom_components.unifi_alerts.const import CONF_IS_UNIFI_OS
+
+        client = make_client({**{"username": "admin", "password": "pw", "verify_ssl": False}, CONF_IS_UNIFI_OS: True})
+        assert client._is_unifi_os is True
+
+    def test_is_unifi_os_loaded_from_config_false(self):
+        """When CONF_IS_UNIFI_OS=False is in config, _is_unifi_os is pre-set to False."""
+        from custom_components.unifi_alerts.const import CONF_IS_UNIFI_OS
+
+        client = make_client({**{"username": "admin", "password": "pw", "verify_ssl": False}, CONF_IS_UNIFI_OS: False})
+        assert client._is_unifi_os is False
+
+    @pytest.mark.asyncio
+    async def test_skips_detection_when_is_unifi_os_in_config(self):
+        """authenticate() must not call _detect_unifi_os() when CONF_IS_UNIFI_OS is pre-set."""
+        from custom_components.unifi_alerts.const import AUTH_METHOD_APIKEY, CONF_IS_UNIFI_OS
+
+        config = {
+            "api_key": "test-key",
+            "auth_method": AUTH_METHOD_APIKEY,
+            "verify_ssl": False,
+            CONF_IS_UNIFI_OS: True,
+        }
+        client = make_client(config)
+        assert client._is_unifi_os is True
+
+        detection_calls: list[int] = []
+
+        async def _no_detect() -> bool:
+            detection_calls.append(1)
+            return False
+
+        client._detect_unifi_os = _no_detect  # type: ignore[method-assign]
+        client._verify_api_key = AsyncMock()
+        await client.authenticate()
+
+        assert detection_calls == [], "_detect_unifi_os must not be called when value is loaded from config"
+        assert client._is_unifi_os is True  # stored value preserved, not overwritten
+
+    @pytest.mark.asyncio
+    async def test_runs_detection_when_is_unifi_os_not_in_config(self):
+        """authenticate() must call _detect_unifi_os() when _is_unifi_os is None."""
+        from custom_components.unifi_alerts.const import AUTH_METHOD_APIKEY
+
+        client = make_client({"api_key": "test-key", "auth_method": AUTH_METHOD_APIKEY, "verify_ssl": False})
+        assert client._is_unifi_os is None
+
+        detection_calls: list[int] = []
+
+        async def _mock_detect() -> bool:
+            detection_calls.append(1)
+            return True
+
+        client._detect_unifi_os = _mock_detect  # type: ignore[method-assign]
+        client._verify_api_key = AsyncMock()
+        await client.authenticate()
+
+        assert len(detection_calls) == 1
+        assert client._is_unifi_os is True


### PR DESCRIPTION
Two bugs combined to silently discard the api.err.InvalidObject error returned by
the alarm endpoint after installation:

1. fetch_alarms() never checked meta.rc — HTTP 200 with an API-level error body
   passed raise_for_status() and returned [] without any log output or exception.
   Added meta.rc != "ok" check after resp.json(); raises CannotConnectError with
   the meta.msg value so the error surfaces through the coordinator's UpdateFailed
   path to the HA UI.

2. _is_unifi_os was re-detected on every authenticate() call and never persisted.
   If detection flips between config-flow time and post-install (e.g. reverse proxy
   strips x-csrf-token), the client silently uses the wrong API path prefix, which
   triggers api.err.InvalidObject from the controller. Added CONF_IS_UNIFI_OS to
   const.py; stored in entry.data during config flow step 1; restored from config
   in UniFiClient.__init__; authenticate() now skips _detect_unifi_os() when the
   value is already known.

Also added fetch_alarms() call at the end of config flow step 1 (after auth
succeeds) so this class of error is caught before the entry is created — the
existing cannot_connect error handler surfaces it to the user.

Tests: updated all fetch_alarms/categorise_alarms fixtures to include
meta.rc=ok; added TestIsUnifiOsPersistence class (5 tests); added
test_api_error_response_raises_cannot_connect; added
test_step_user_fetch_alarms_failure_shows_cannot_connect and
test_conf_is_unifi_os_stored_in_credentials. 277 tests pass.

https://claude.ai/code/session_01W1nsnZccYztKEgUAJHKNxC