### PR TITLE
chore: move to two-branch model with versioning CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   validate:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,52 @@
 name: Release
 
+# Triggers on version tags pushed from either branch:
+#   main tags  → stable release:    v1.0.0, v1.1.0, v1.2.0
+#   dev tags   → pre-release:       v1.1.0-pre1, v1.1.0-pre2
+#
+# The workflow validates that the tag version exactly matches the version
+# in manifest.json before packaging to prevent mismatched releases.
+
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'           # stable:      v1.0.0, v1.1.0
+      - 'v[0-9]+.[0-9]+.[0-9]+-pre[0-9]+' # pre-release: v1.0.0-pre1, v1.1.0-pre2
 
 permissions:
   contents: write
 
 jobs:
   release:
-    name: Package and attach release asset
+    name: Package and publish release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Determine release type from tag
+        id: release_type
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          if echo "$TAG" | grep -qE '-pre[0-9]+$'; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "Release type: PRE-RELEASE ($TAG)"
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+            echo "Release type: STABLE ($TAG)"
+          fi
+
+      - name: Validate manifest version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          MANIFEST_VERSION=$(python3 -c "import json; print(json.load(open('custom_components/unifi_alerts/manifest.json'))['version'])")
+          if [ "$TAG_VERSION" != "$MANIFEST_VERSION" ]; then
+            echo "ERROR: tag version ($TAG_VERSION) does not match manifest version ($MANIFEST_VERSION)"
+            echo ""
+            echo "Update manifest.json to version $TAG_VERSION before tagging, or retag with v$MANIFEST_VERSION."
+            exit 1
+          fi
+          echo "OK: tag matches manifest version $MANIFEST_VERSION"
 
       - name: Create release zip
         run: |
@@ -24,5 +58,7 @@ jobs:
         uses: softprops/action-gh-release@v2.6.1
         with:
           files: unifi_alerts.zip
+          prerelease: ${{ steps.release_type.outputs.prerelease == 'true' }}
+          name: ${{ steps.release_type.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,53 @@
+name: Version Check
+
+# Enforces that manifest.json version is in the correct format for the target branch:
+#   main  → stable semver only:    X.Y.Z          (e.g. 1.0.0, 1.1.0)
+#   dev   → pre-release only:      X.Y.Z-preN     (e.g. 1.1.0-pre1, 1.1.0-pre2)
+#
+# Feature branches are not checked — any version is accepted while work is in progress.
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  version-format:
+    name: Validate version format for branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version from manifest
+        id: version
+        run: |
+          VERSION=$(python3 -c "import json; print(json.load(open('custom_components/unifi_alerts/manifest.json'))['version'])")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Manifest version: $VERSION"
+
+      - name: Validate version format for main
+        if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: main branch requires a stable semver version (X.Y.Z), got: $VERSION"
+            echo ""
+            echo "Pre-release suffixes (-preN, -alpha, -beta, etc.) are not allowed on main."
+            echo "Merge dev into main only after bumping the version to a stable semver."
+            exit 1
+          fi
+          echo "OK: $VERSION is a valid stable semver for main"
+
+      - name: Validate version format for dev
+        if: github.ref == 'refs/heads/dev' || github.base_ref == 'dev'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-pre[0-9]+$'; then
+            echo "ERROR: dev branch requires a pre-release version (X.Y.Z-preN), got: $VERSION"
+            echo ""
+            echo "Only the -preN suffix is accepted on dev (e.g. 1.1.0-pre1)."
+            echo "Bump to a stable version and merge to main when ready to release."
+            exit 1
+          fi
+          echo "OK: $VERSION is a valid pre-release version for dev"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,9 @@ tests/
   test_init.py                    # async_setup_entry / async_unload_entry lifecycle, teardown order
   test_entities.py                # all entity property methods: binary_sensor, sensor, event, button
 .github/workflows/
-  ci.yml                          # hassfest + hacs-preflight + HACS action + lint (ruff, mypy, translation drift) + pytest
-  release.yml                     # zips and attaches release asset on GitHub release
+  ci.yml                          # hassfest + hacs-preflight + HACS action + lint (ruff, mypy, translation drift) + pytest; runs on push/PR to main and dev
+  version-check.yml               # enforces version format per branch: main=X.Y.Z stable, dev=X.Y.Z-preN; runs on push/PR to main and dev
+  release.yml                     # triggered by version tags (v1.0.0 for stable, v1.0.0-pre1 for pre-release); validates tag matches manifest; marks GitHub release as pre-release automatically
 .githooks/
   pre-push                        # local gate: HACS preflight → translation drift → ruff → mypy → pytest; install with: git config core.hooksPath .githooks
 scripts/
@@ -86,10 +87,58 @@ README.md                         # user-facing install, setup, and contributing
 - All `const.py` additions go in the appropriate labelled section with a comment.
 - Tests use `MagicMock` / `AsyncMock` for the UniFi client — never make real HTTP calls in tests.
 
+## Branching strategy and versioning
+
+This project uses a two-branch model. All active development happens on `dev`; `main` is stable-only.
+
+### Branches
+
+| Branch | Purpose | Version format | Example |
+|--------|---------|---------------|---------|
+| `main` | Stable releases only. CI enforces no pre-release suffix. | `X.Y.Z` | `1.0.0`, `1.1.0` |
+| `dev` | Active development. CI enforces `-preN` suffix. | `X.Y.Z-preN` | `1.1.0-pre1`, `1.1.0-pre2` |
+| `feature/*` or `claude/*` | Short-lived work. No version format enforced by CI. | Any | — |
+
+### Versioning conventions
+
+- **Minor bumps on main:** releases from `main` increment the minor version (`1.0.0 → 1.1.0 → 1.2.0`). Patch releases (`1.0.1`) are reserved for critical hotfixes.
+- **Pre-release sequence on dev:** each tagged checkpoint on `dev` increments the pre-release counter (`1.1.0-pre1 → 1.1.0-pre2`). The base version (`1.1.0`) matches the *next* planned minor release on `main`.
+- **`manifest.json` is the single source of truth** for the version — the release workflow validates the pushed tag matches it exactly.
+
+### Release workflow
+
+```
+dev  ──┬── (work) ──► tag v1.1.0-pre1  ──► GitHub pre-release  (automated)
+       │
+       ├── (work) ──► tag v1.1.0-pre2  ──► GitHub pre-release  (automated)
+       │
+       └── bump manifest to 1.1.0
+            └─► merge PR to main
+                 └─► tag v1.1.0  ──► GitHub stable release  (automated)
+```
+
+1. **Development:** work on `dev`. Version in manifest stays at `X.Y.Z-preN`.
+2. **Pre-release checkpoint:** bump the `N` in manifest (e.g. `pre1 → pre2`), commit, push, then push the tag `vX.Y.Z-preN`. GitHub Actions creates a pre-release automatically.
+3. **Stable release:** bump manifest from `X.Y.Z-preN` to `X.Y.Z`, open a PR from `dev` to `main`. After merge, tag `vX.Y.Z` on `main`. GitHub Actions creates a stable release.
+4. **Start next cycle:** on `dev`, bump manifest to `X.(Y+1).0-pre1` and continue.
+
+### CI enforcement
+
+- `version-check.yml` blocks pushes and PRs that violate the format for the target branch.
+- `release.yml` fails if the pushed tag does not exactly match `manifest.json`.
+- Never manually create a GitHub release — always push a version tag and let the workflow do it.
+
+### Branch protection (configure once in GitHub Settings → Branches)
+
+Recommended rules:
+- **`main`:** require PR, require status checks (`CI / *`, `Version Check / *`), no direct push, no force-push.
+- **`dev`:** require status checks (`CI / *`, `Version Check / *`), allow direct push (for version bumps), no force-push.
+
 ## Working style
 
 - **Never assume — always ask.** If anything about the task, scope, or approach is unclear, ask before proceeding. Do not guess intent.
-- **Always pull `main` before starting work** — run `git pull origin main` at the start of every session to avoid diverging from origin. Never start implementing changes on a stale branch.
+- **Always pull `dev` before starting work** — run `git pull origin dev` at the start of every session to avoid diverging from origin. Never start implementing changes on a stale branch. Pull `main` only when checking stable state.
+- **Work on `dev`, not `main`** — `main` is only updated via PRs from `dev`. Never commit directly to `main`.
 - **Move into the working directory at the start of every session** — avoids needing path prefixes on every command.
 - Always run `make check` before committing — never commit broken code. `make check` runs lint, typecheck, HACS preflight, translation drift check, and the full test suite in one shot.
 - Always update `HISTORY.md` with a detailed description of what was done, why, and how, including test coverage. This is the primary source of truth for what has been completed and should be reflected in the codebase. Do not rely on memory or Git history alone.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,48 @@
 # History
 
+## 2026-04-15 (session 9) — Move to two-branch model; add versioning CI enforcement
+
+### Goal
+
+Transition from trunk-driven development to a two-branch model (`main` = stable, `dev` = active pre-release development), add CI that enforces the correct version format on each branch, and update release automation so tags drive publishing rather than manual GitHub UI releases.
+
+### `.github/workflows/version-check.yml` (new)
+
+New workflow triggered on push and PR to `main` and `dev`. Extracts the version from `manifest.json` and:
+- On `main` (or a PR targeting `main`): validates the version matches `^[0-9]+\.[0-9]+\.[0-9]+$` (stable semver, no suffix). Fails with a clear message if a pre-release suffix is present.
+- On `dev` (or a PR targeting `dev`): validates the version matches `^[0-9]+\.[0-9]+\.[0-9]+-pre[0-9]+$`. Fails if the version is stable or uses a non-standard suffix.
+- Feature branches (`claude/*`, `feature/*`) are not checked — any version is accepted.
+
+### `.github/workflows/release.yml` (updated)
+
+Switched trigger from `release: types: [published]` to `push: tags` matching `v*.*.*` (stable) and `v*.*.*-pre*` (pre-release). New behaviour:
+1. Detects whether the tag is a pre-release by checking for a `-pre` suffix.
+2. Validates that the pushed tag version exactly matches the `version` field in `manifest.json`. Fails fast with a descriptive error if they diverge.
+3. Creates the release zip as before.
+4. Calls `softprops/action-gh-release` with `prerelease: true` for pre-release tags and `prerelease: false` for stable tags — the GitHub release type is now automatic, not manual.
+
+### `.github/workflows/ci.yml` (updated)
+
+Added `dev` to `pull_request.branches` so CI runs on PRs targeting `dev` as well as `main`. (Push triggers for `dev` were already present.)
+
+### `manifest.json` (version bump)
+
+Bumped version from `1.0.0-pre3` to `1.0.0`. All v1.0.0 blockers were resolved in sessions 1–8; this marks the first stable release on `main`.
+
+### `dev` branch (created)
+
+Created `dev` branch from the post-merge state of `main`. Bumped `manifest.json` on `dev` to `1.1.0-pre1` to start the next development cycle. All v1.1.0 work (security hardening, reliability, QA) proceeds on `dev` under that version prefix.
+
+### Documentation
+
+- **`CLAUDE.md`**: added "Branching strategy and versioning" section documenting the two-branch model, version conventions, the release workflow diagram, CI enforcement, and recommended branch protection rules. Updated "Working style" to say pull `dev` (not `main`) at the start of each session, and to note that `main` is only updated via PRs.
+- **`ROADMAP.md`**: updated current status blurb; marked v1.0.0 as released; added an "Infrastructure" subsection to v1.1.0 ticking off the branch model and CI versioning work.
+- **`TODO.md`**: no items removed or added (branch setup was not in the backlog; all relevant changes are now live).
+
+### No test changes
+
+No production code was modified. CI workflow changes are validated by the GitHub Actions runner, not by the local pytest suite.
+
 ## 2026-04-11 (session 8) — Fix silent api.err.InvalidObject: persist UniFi OS detection + validate alarm endpoint at setup
 
 ### Root cause

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,11 +2,13 @@
 
 This file maps TODO items to planned releases. Items within each release are ordered by priority — complete them top-to-bottom. Check off each item as it is merged to `main`.
 
-> **Current status:** v1.0.0-pre3 ready to tag. All v1.0.0 blockers resolved. Remaining open items target v1.1.0 (security hardening, reliability). CI is green.
+> **Branching model:** all development happens on `dev` (pre-release versions: `X.Y.Z-preN`). Stable releases are tagged on `main` after a PR merge. See `CLAUDE.md § Branching strategy and versioning` for the full workflow.
+
+> **Current status:** v1.0.0 released. Branch model + CI versioning enforcement in place. Active development continues on `dev` targeting v1.1.0.
 
 ---
 
-## v1.0.0 — First stable release
+## v1.0.0 — First stable release ✓
 
 All blocking bugs, security issues, and UX gaps that will immediately affect new users.
 
@@ -50,7 +52,13 @@ All blocking bugs, security issues, and UX gaps that will immediately affect new
 
 ## v1.1.0 — Security hardening + reliability
 
-Issues that are non-blocking for a first release but important for production quality.
+Issues that are non-blocking for a first release but important for production quality. Development for this release happens on `dev` under version `1.1.0-preN`.
+
+### Infrastructure (completed as part of v1.0.0 → v1.1.0 transition)
+
+- [x] Move to two-branch model (`main` = stable, `dev` = pre-release)
+- [x] Add `version-check.yml` CI: enforce `X.Y.Z` on `main`, `X.Y.Z-preN` on `dev`
+- [x] Update `release.yml` CI: trigger on tags, auto-detect pre-release, validate tag vs manifest
 
 ### Security
 

--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": ["aiohttp>=3.9.0"],
-  "version": "1.0.0-pre3"
+  "version": "1.0.0"
 }


### PR DESCRIPTION
- Add version-check.yml: enforces X.Y.Z on main, X.Y.Z-preN on dev
- Update release.yml: trigger on tags, auto-detect pre-release vs stable,
  validate tag matches manifest.json before packaging
- Update ci.yml: add dev to pull_request target branches
- Bump manifest.json to 1.0.0 (all v1.0.0 blockers resolved)
- Document branching strategy, version conventions and release flow in CLAUDE.md
- Update ROADMAP.md current status and add v1.1.0 infrastructure items
- Record session in HISTORY.md

https://claude.ai/code/session_01CXbpFCeKHBwRkhWWAUto5a