### PR TITLE
security: fix credentials leak and unbounded webhook body (v1.1 security items)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ This project uses a two-branch model. All active development happens on `dev`; `
 |--------|---------|---------------|---------|
 | `main` | Stable releases only. CI enforces no pre-release suffix. | `X.Y.Z` | `1.0.0`, `1.1.0` |
 | `dev` | Active development. CI enforces `-preN` suffix. | `X.Y.Z-preN` | `1.1.0-pre1`, `1.1.0-pre2` |
-| `feature/*` or `claude/*` | Short-lived work. No version format enforced by CI. | Any | — |
+| `feature/*` or `claude/*` | Short-lived work. **Must branch off `dev`, not `main`.** No version format enforced by CI. | Any | — |
 
 ### Versioning conventions
 
@@ -139,6 +139,7 @@ Recommended rules:
 - **Never assume — always ask.** If anything about the task, scope, or approach is unclear, ask before proceeding. Do not guess intent.
 - **Always pull `dev` before starting work** — run `git pull origin dev` at the start of every session to avoid diverging from origin. Never start implementing changes on a stale branch. Pull `main` only when checking stable state.
 - **Work on `dev`, not `main`** — `main` is only updated via PRs from `dev`. Never commit directly to `main`.
+- **Feature and claude/* branches must be created from `dev`** — run `git checkout dev && git pull origin dev && git checkout -b <branch>`. Never branch off `main`. PRs from feature branches must target `dev`, not `main`.
 - **Move into the working directory at the start of every session** — avoids needing path prefixes on every command.
 - Always run `make check` before committing — never commit broken code. `make check` runs lint, typecheck, HACS preflight, translation drift check, and the full test suite in one shot.
 - Always update `HISTORY.md` with a detailed description of what was done, why, and how, including test coverage. This is the primary source of truth for what has been completed and should be reflected in the codebase. Do not rely on memory or Git history alone.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,42 @@
 # History
 
+## 2026-04-15 (session 10) — v1.1 security: credentials leak + unbounded webhook body
+
+### Goal
+
+Close the two remaining security items from the v1.1.0 roadmap. Both were non-blocking for v1.0 but important for production quality.
+
+### `unifi_client.py` — credentials leak via exception messages
+
+`fetch_alarms()` and `_login_userpass()` both had `raise CannotConnectError(str(err)) from err`. Some `aiohttp.ClientError` subclasses embed the full request URL in their `__str__()` representation — which can include usernames, passwords, or API keys when the client was constructed with credentials in the URL. Changed both sites to `raise CannotConnectError(type(err).__name__) from err` so only the exception class name appears in HA logs.
+
+### `const.py` — new `WEBHOOK_MAX_BODY_BYTES` constant
+
+Added `WEBHOOK_MAX_BODY_BYTES = 8192` (8 KB) in the defaults section. 8 KB is far larger than any real UniFi alert payload and provides a generous safety margin.
+
+### `webhook_handler.py` — bounded webhook body read
+
+Replaced `payload = await request.json()` (unbounded) with a three-step pattern:
+1. `raw = await request.content.read(WEBHOOK_MAX_BODY_BYTES + 1)` — reads at most 8 193 bytes.
+2. If `len(raw) > WEBHOOK_MAX_BODY_BYTES` → log warning and return HTTP 413, callback not called.
+3. `payload = json.loads(raw.decode())` with `except (json.JSONDecodeError, UnicodeDecodeError, TypeError)` falling back to `{}`.
+
+Added `WEBHOOK_MAX_BODY_BYTES` to the import from `const`.
+
+### Tests
+
+- `test_unifi_client.py`: added `test_client_error_message_is_class_name_not_url` in `TestFetchAlarms` — asserts that a `ClientConnectionError` with a URL-containing message does not propagate the URL into `CannotConnectError.args[0]`; added `test_login_client_error_message_is_class_name_not_url` in `TestLoginUserpass` with the same assertion for the `_login_userpass` path.
+- `test_webhook_handler.py`: updated `make_request()` helper to mock `req.content.read` (returns `json.dumps(body).encode()`) instead of `req.json`; updated `test_malformed_json_uses_empty_dict_fallback` to pass raw invalid bytes via `content.read`; added `test_oversized_body_returns_413` — feeds `WEBHOOK_MAX_BODY_BYTES + 1` bytes and asserts HTTP 413 and no callback invocation. Added `import json` and `WEBHOOK_MAX_BODY_BYTES` to imports.
+
+All 280 tests pass; lint, mypy, HACS preflight, and translation drift checks clean.
+
+### Documentation
+
+- `ROADMAP.md`: ticked both security items `[x]` in the v1.1.0 section.
+- `TODO.md`: removed both resolved items from the Known issues section.
+
+---
+
 ## 2026-04-15 (session 9) — Move to two-branch model; add versioning CI enforcement
 
 ### Goal

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,8 +63,8 @@ Issues that are non-blocking for a first release but important for production qu
 ### Security
 
 - [x] Unvalidated controller URL allows SSRF — scheme validation added (`config_flow.py`); loopback/link-local rejection remains optional
-- [ ] Unbounded webhook body stored in memory — apply `max_bytes` cap on `request.json()` (`webhook_handler.py:86`)
-- [ ] Credentials leak risk via exception messages in logs — log class name only, not `str(err)` (`unifi_client.py:105,181`)
+- [x] Unbounded webhook body stored in memory — apply `max_bytes` cap on `request.json()` (`webhook_handler.py:86`)
+- [x] Credentials leak risk via exception messages in logs — log class name only, not `str(err)` (`unifi_client.py:105,181`)
 
 ### Bugs / reliability
 

--- a/TODO.md
+++ b/TODO.md
@@ -44,14 +44,6 @@ After the integration is stable and passes `hassfest`, submit a PR to https://gi
 
 ## 🐛 Known issues / technical debt
 
-### Unbounded webhook body stored in memory
-`request.json()` in `webhook_handler.py` reads the full request body without a size cap. A large or malicious payload could spike memory usage.
-**Fix:** Apply a `max_bytes` cap before deserialising. See `webhook_handler.py:86`.
-
-### Credentials leak risk via exception messages in logs
-`unifi_client.py` logs `str(err)` in several exception handlers. Some aiohttp exceptions embed the URL (including credentials) in their string representation.
-**Fix:** Log the exception class name only (`type(err).__name__`). See `unifi_client.py:105,181`.
-
 ### `_device_info` duplication
 The `_device_info()` helper function is duplicated identically across `binary_sensor.py`, `sensor.py`, `event.py`, and `button.py`. Intentional for platform isolation but could be extracted to a shared `entity_base.py` mixin if it becomes a maintenance burden.
 

--- a/custom_components/unifi_alerts/const.py
+++ b/custom_components/unifi_alerts/const.py
@@ -27,6 +27,7 @@ DEFAULT_POLL_INTERVAL = 60  # seconds
 DEFAULT_CLEAR_TIMEOUT = 30  # minutes
 DEFAULT_VERIFY_SSL = True  # disable in config flow if controller has a self-signed cert
 DEFAULT_SITE = "default"
+WEBHOOK_MAX_BODY_BYTES = 8192  # 8 KB ceiling on inbound webhook bodies
 
 # ──────────────────────────────────────────────
 # Category identifiers

--- a/custom_components/unifi_alerts/unifi_client.py
+++ b/custom_components/unifi_alerts/unifi_client.py
@@ -116,7 +116,7 @@ class UniFiClient:
                     raise CannotConnectError(f"UniFi API error: {msg}")
                 return [a for a in data.get("data", []) if not a.get("archived", False)]
         except aiohttp.ClientError as err:
-            raise CannotConnectError(str(err)) from err
+            raise CannotConnectError(type(err).__name__) from err
 
     async def categorise_alarms(self, site: str = "default") -> dict[str, list[UniFiAlert]]:
         """Fetch alarms and group them by category."""
@@ -264,7 +264,7 @@ class UniFiClient:
             _LOGGER.warning("Authentication failed at all login paths (last: %s)", last_url)
             raise InvalidAuthError("Invalid username or password", login_url=last_url)
         except aiohttp.ClientError as err:
-            raise CannotConnectError(str(err)) from err
+            raise CannotConnectError(type(err).__name__) from err
 
     def _network_path(self, path: str) -> str:
         """Prefix path with /proxy/network on UniFi OS controllers."""

--- a/custom_components/unifi_alerts/webhook_handler.py
+++ b/custom_components/unifi_alerts/webhook_handler.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_ENABLED_CATEGORIES,
     CONF_WEBHOOK_SECRET,
     DOMAIN,
+    WEBHOOK_MAX_BODY_BYTES,
     webhook_id_for_category,
 )
 from .models import UniFiAlert
@@ -93,8 +94,16 @@ class WebhookManager:
                 return Response(status=401)
 
             try:
-                payload = await request.json()
-            except (json.JSONDecodeError, TypeError):
+                raw = await request.content.read(WEBHOOK_MAX_BODY_BYTES + 1)
+                if len(raw) > WEBHOOK_MAX_BODY_BYTES:
+                    _LOGGER.warning(
+                        "Webhook body for category %s exceeds %d bytes, rejecting",
+                        category,
+                        WEBHOOK_MAX_BODY_BYTES,
+                    )
+                    return Response(status=413)
+                payload = json.loads(raw.decode()) if raw else {}
+            except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
                 payload = {}
 
             _LOGGER.debug("Webhook received for category %s: %s", category, payload)

--- a/tests/unit/test_unifi_client.py
+++ b/tests/unit/test_unifi_client.py
@@ -277,6 +277,29 @@ class TestLoginUserpass:
             await client._login_userpass()
 
     @pytest.mark.asyncio
+    async def test_login_client_error_message_is_class_name_not_url(self):
+        """CannotConnectError from _login_userpass must use class name, not str(err).
+
+        Same credential-leak prevention as fetch_alarms: aiohttp errors can embed
+        the login URL (which may contain the password) in their string representation.
+        """
+        import aiohttp
+
+        client = make_client()
+        client._is_unifi_os = False
+
+        @asynccontextmanager
+        async def _raise(*args, **kwargs):
+            raise aiohttp.ClientConnectionError("https://admin:hunter2@192.168.1.1/api/login")
+            yield
+
+        client._session.post = _raise
+        with pytest.raises(CannotConnectError) as exc_info:
+            await client._login_userpass()
+        assert "hunter2" not in str(exc_info.value)
+        assert exc_info.value.args[0] == "ClientConnectionError"
+
+    @pytest.mark.asyncio
     async def test_http_401_raises_invalid_auth(self):
         """HTTP 401 should still raise InvalidAuthError (bad credentials)."""
         client = make_client()
@@ -459,6 +482,30 @@ class TestFetchAlarms:
         client._session.get = _raise
         with pytest.raises(CannotConnectError):
             await client.fetch_alarms()
+
+    @pytest.mark.asyncio
+    async def test_client_error_message_is_class_name_not_url(self):
+        """CannotConnectError message must be the exception class name, not str(err).
+
+        aiohttp exceptions can embed the controller URL (including credentials) in
+        their string representation.  Using type(err).__name__ prevents credential
+        leaks via HA log output.
+        """
+        import aiohttp
+
+        client = make_client()
+        client._authenticated = True
+
+        @asynccontextmanager
+        async def _raise(*args, **kwargs):
+            raise aiohttp.ClientConnectionError("https://admin:secret@192.168.1.1/api")
+            yield
+
+        client._session.get = _raise
+        with pytest.raises(CannotConnectError) as exc_info:
+            await client.fetch_alarms()
+        assert "secret" not in str(exc_info.value)
+        assert exc_info.value.args[0] == "ClientConnectionError"
 
     @pytest.mark.asyncio
     async def test_sends_limit_param(self):

--- a/tests/unit/test_webhook_handler.py
+++ b/tests/unit/test_webhook_handler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -12,6 +13,7 @@ from custom_components.unifi_alerts.const import (
     CATEGORY_SECURITY_THREAT,
     CONF_ENABLED_CATEGORIES,
     CONF_WEBHOOK_SECRET,
+    WEBHOOK_MAX_BODY_BYTES,
 )
 from custom_components.unifi_alerts.webhook_handler import WebhookManager
 
@@ -32,13 +34,9 @@ def make_manager(enabled=None, secret="test-secret-123", hass=None):
 def make_request(token: str | None = "test-secret-123", json_body: dict | None = None):
     """Build a minimal mock aiohttp.web.Request."""
     req = MagicMock()
-    # query is a dict-like object
     req.query = {"token": token} if token is not None else {}
-    # json() is async
-    if json_body is None:
-        req.json = AsyncMock(return_value={"key": "EVT_GW_WANTransition", "message": "WAN down"})
-    else:
-        req.json = AsyncMock(return_value=json_body)
+    body_dict = json_body if json_body is not None else {"key": "EVT_GW_WANTransition", "message": "WAN down"}
+    req.content.read = AsyncMock(return_value=json.dumps(body_dict).encode())
     return req
 
 
@@ -226,17 +224,27 @@ class TestMakeHandler:
     @pytest.mark.asyncio
     async def test_malformed_json_uses_empty_dict_fallback(self):
         """If the body can't be parsed as JSON, push_callback is still called with empty payload."""
-        import json
-
         manager, push_cb = make_manager(secret="tok")
         handler = manager._make_handler(CATEGORY_NETWORK_WAN, "tok")
         req = make_request(token="tok")
-        req.json = AsyncMock(side_effect=json.JSONDecodeError("nope", "", 0))
+        req.content.read = AsyncMock(return_value=b"not valid json {{")
         await handler(manager._hass, "wh-id", req)
         push_cb.assert_called_once()
         # Alert should have fallback message
         call_category, call_alert = push_cb.call_args[0]
         assert call_alert.message == "Unknown alert"
+
+    @pytest.mark.asyncio
+    async def test_oversized_body_returns_413(self):
+        """A webhook body larger than WEBHOOK_MAX_BODY_BYTES must be rejected with HTTP 413."""
+        manager, push_cb = make_manager(secret="tok")
+        handler = manager._make_handler(CATEGORY_NETWORK_WAN, "tok")
+        req = make_request(token="tok")
+        req.content.read = AsyncMock(return_value=b"x" * (WEBHOOK_MAX_BODY_BYTES + 1))
+        response = await handler(manager._hass, "wh-id", req)
+        assert response is not None
+        assert response.status == 413
+        push_cb.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_alert_fields_populated_from_payload(self):


### PR DESCRIPTION
Closes two v1.1.0 security hardening items:

1. Credentials leak via exception messages (unifi_client.py)
   aiohttp exceptions can embed the controller URL — including credentials —
   in their str() representation. Both CannotConnectError raise sites in
   fetch_alarms() and _login_userpass() now use type(err).__name__ instead
   of str(err), preventing passwords and API keys from appearing in HA logs.

2. Unbounded webhook body stored in memory (webhook_handler.py)
   request.json() previously read the full request body without a size cap.
   The handler now reads raw bytes via request.content.read(MAX + 1), rejects
   bodies over WEBHOOK_MAX_BODY_BYTES (8 KB) with HTTP 413, and parses JSON
   manually. 8 KB is far larger than any real UniFi alert payload.

Tests:
- Added test_client_error_message_is_class_name_not_url (fetch_alarms path)
- Added test_login_client_error_message_is_class_name_not_url (_login_userpass path)
- Updated make_request() fixture to mock content.read instead of json()
- Updated test_malformed_json_uses_empty_dict_fallback to use raw bytes
- Added test_oversized_body_returns_413

https://claude.ai/code/session_01EzASPSwq6TEaVqvMFn7g4v