### PR TITLE
fix: distinguish re-auth failure from post-re-auth update failure

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,16 @@
 # History
 
+## 2026-04-21 (session 11) — Distinguish re-auth failure from post-re-auth update failure in polling
+
+- **`coordinator.py`**: split the single `except (InvalidAuthError, CannotConnectError)` retry handler into two separate `try/except` blocks — one around `authenticate()` and one around the retried `categorise_alarms()` call.
+- Re-auth failures (`InvalidAuthError` or `CannotConnectError` from `authenticate()`) now raise `ConfigEntryAuthFailed` so HA can surface the reauth flow to the user; log message is "Re-authentication failed; credentials may have changed".
+- Post-re-auth poll failures (`CannotConnectError` from the second `categorise_alarms()`) now raise `UpdateFailed` with "Cannot reach UniFi controller after re-authentication" — clearly distinguishable from the first-pass "Cannot reach UniFi controller" message.
+- Added `ConfigEntryAuthFailed` import from `homeassistant.exceptions`.
+- **`tests/unit/test_coordinator.py`**: replaced the old `test_invalid_auth_on_retry_raises_update_failed` test with three new tests in `TestPollingErrorPaths`: re-auth `InvalidAuthError` → `ConfigEntryAuthFailed`; re-auth `CannotConnectError` → `ConfigEntryAuthFailed`; re-auth succeeds but retry fails → `UpdateFailed` containing "after re-authentication".
+- All 282 tests pass; lint, mypy, HACS preflight, and translation drift checks clean.
+
+---
+
 ## 2026-04-15 (session 10) — v1.1 security: credentials leak + unbounded webhook body
 
 ### Goal

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,7 +69,7 @@ Issues that are non-blocking for a first release but important for production qu
 ### Bugs / reliability
 
 - [x] No pagination on `/alarm` endpoint — `limit=200` added (`unifi_client.py:92`)
-- [ ] Polling re-auth is fire-and-forget — misleading log message when re-auth succeeds but second poll fails for a different reason (`coordinator.py`)
+- [x] Polling re-auth is fire-and-forget — misleading log message when re-auth succeeds but second poll fails for a different reason (`coordinator.py`)
 
 ### UX / Documentation
 

--- a/TODO.md
+++ b/TODO.md
@@ -47,8 +47,5 @@ After the integration is stable and passes `hassfest`, submit a PR to https://gi
 ### `_device_info` duplication
 The `_device_info()` helper function is duplicated identically across `binary_sensor.py`, `sensor.py`, `event.py`, and `button.py`. Intentional for platform isolation but could be extracted to a shared `entity_base.py` mixin if it becomes a maintenance burden.
 
-### Polling re-auth is fire-and-forget
-In `coordinator._async_update_data`, if re-auth succeeds but the second `categorise_alarms()` call fails for a different reason, the error path is the generic `CannotConnectError` branch which may give a misleading log message.
-
 ### CI action versions are floating (`@master`, `@main`)
 `home-assistant/actions/hassfest@master` and `hacs/action@main` are not pinned to a SHA. A breaking upstream change or supply-chain compromise would silently affect CI. Pin to commit SHAs and update periodically.

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from typing import Any
 
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -75,9 +76,19 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
             _LOGGER.warning("Auth expired, re-authenticating: %s", err)
             try:
                 await self._client.authenticate()
+            except (InvalidAuthError, CannotConnectError) as reauth_err:
+                _LOGGER.error(
+                    "Re-authentication failed; credentials may have changed: %s", reauth_err
+                )
+                raise ConfigEntryAuthFailed(
+                    f"Re-authentication failed; credentials may have changed: {reauth_err}"
+                ) from reauth_err
+            try:
                 categorised = await self._client.categorise_alarms(self._site)
-            except (InvalidAuthError, CannotConnectError) as retry_err:
-                raise UpdateFailed(f"UniFi auth failed: {retry_err}") from retry_err
+            except CannotConnectError as retry_err:
+                raise UpdateFailed(
+                    f"Cannot reach UniFi controller after re-authentication: {retry_err}"
+                ) from retry_err
         except CannotConnectError as err:
             raise UpdateFailed(f"Cannot reach UniFi controller: {err}") from err
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -318,9 +318,9 @@ class TestPollingErrorPaths:
         client.authenticate.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_invalid_auth_on_retry_raises_update_failed(self):
-        """If re-auth also fails, UpdateFailed must be raised."""
-        from homeassistant.helpers.update_coordinator import UpdateFailed
+    async def test_reauth_raises_invalid_auth_raises_config_entry_auth_failed(self):
+        """If re-auth itself raises InvalidAuthError, ConfigEntryAuthFailed must be raised."""
+        from homeassistant.exceptions import ConfigEntryAuthFailed
 
         from custom_components.unifi_alerts.unifi_client import InvalidAuthError
 
@@ -342,8 +342,71 @@ class TestPollingErrorPaths:
             CONF_CLEAR_TIMEOUT: 30,
         }
         coord = UniFiAlertsCoordinator(hass, client, config)
-        with pytest.raises(UpdateFailed):
+        with pytest.raises(ConfigEntryAuthFailed):
             await coord._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_reauth_raises_cannot_connect_raises_config_entry_auth_failed(self):
+        """If re-auth raises CannotConnectError, ConfigEntryAuthFailed must be raised."""
+        from homeassistant.exceptions import ConfigEntryAuthFailed
+
+        from custom_components.unifi_alerts.unifi_client import CannotConnectError, InvalidAuthError
+
+        hass = MagicMock()
+
+        def _create_task(coro, **kwargs):
+            coro.close()
+            return MagicMock()
+
+        hass.async_create_task = _create_task
+        hass.async_create_background_task = _create_task
+        client = MagicMock()
+        client.categorise_alarms = AsyncMock(side_effect=InvalidAuthError("expired"))
+        client.authenticate = AsyncMock(side_effect=CannotConnectError("unreachable during reauth"))
+
+        config = {
+            CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+            CONF_POLL_INTERVAL: 60,
+            CONF_CLEAR_TIMEOUT: 30,
+        }
+        coord = UniFiAlertsCoordinator(hass, client, config)
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coord._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_reauth_succeeds_but_retry_fails_raises_update_failed_with_distinctive_message(
+        self,
+    ):
+        """Re-auth succeeds but retried categorise_alarms fails → UpdateFailed with 'after re-authentication'."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        from custom_components.unifi_alerts.unifi_client import CannotConnectError, InvalidAuthError
+
+        hass = MagicMock()
+
+        def _create_task(coro, **kwargs):
+            coro.close()
+            return MagicMock()
+
+        hass.async_create_task = _create_task
+        hass.async_create_background_task = _create_task
+        client = MagicMock()
+        # First categorise_alarms call fails with auth error; re-auth succeeds; second call fails
+        client.categorise_alarms = AsyncMock(
+            side_effect=[InvalidAuthError("expired"), CannotConnectError("controller 500")]
+        )
+        client.authenticate = AsyncMock()  # re-auth succeeds
+
+        config = {
+            CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+            CONF_POLL_INTERVAL: 60,
+            CONF_CLEAR_TIMEOUT: 30,
+        }
+        coord = UniFiAlertsCoordinator(hass, client, config)
+        with pytest.raises(UpdateFailed) as exc_info:
+            await coord._async_update_data()
+
+        assert "after re-authentication" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_cannot_connect_raises_update_failed(self):


### PR DESCRIPTION
## Summary

- Re-auth failures (`authenticate()` raising `InvalidAuthError` or `CannotConnectError`) now raise `ConfigEntryAuthFailed` so HA triggers the reauth flow with a clear "credentials may have changed" log message.
- Post-re-auth poll failures (second `categorise_alarms()` fails after successful re-auth) now raise `UpdateFailed` with "after re-authentication" in the message — unambiguously distinct from the first-pass connection error.
- Removed the old combined `except (InvalidAuthError, CannotConnectError)` handler that silently swallowed the distinction.

## Test plan

- [ ] `test_reauth_raises_invalid_auth_raises_config_entry_auth_failed` — re-auth `InvalidAuthError` → `ConfigEntryAuthFailed`
- [ ] `test_reauth_raises_cannot_connect_raises_config_entry_auth_failed` — re-auth `CannotConnectError` → `ConfigEntryAuthFailed`
- [ ] `test_reauth_succeeds_but_retry_fails_raises_update_failed_with_distinctive_message` — re-auth succeeds, second poll fails → `UpdateFailed` containing "after re-authentication"
- [ ] All 282 tests pass (`make check` clean)

https://claude.ai/code/session_01JbeaeLYzC76GkuD4ZL3U51