### PR TITLE
docs(readme): add Lovelace card and automation examples

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,16 @@
 # History
 
+## 2026-04-21 (session 11) — README: Lovelace card and automation examples
+
+- Added `## Examples` section to `README.md` replacing the minimal one-liner automation stub.
+- Lovelace snippet: `entities` card mixing `binary_sensor.unifi_alerts_any_alert`, five per-category binary sensors, and `sensor.unifi_alerts_total_open_alerts`; only uses entity IDs actually produced by the integration.
+- Automation snippet: `platform: state` trigger on `event.unifi_alerts_security_threat` (correct for HA `EventEntity`); documents all seven event-data attributes (`message`, `category`, `device_name`, `alert_key`, `severity`, `site`, `received_at`) sourced directly from `event.py:_handle_coordinator_update`.
+- Clarified that UniFi Alerts uses HA Event entities (not the hass event bus) — the `event_type` used by `_trigger_event` is `alert_received` and is a per-entity event type, not a bus event.
+- `TODO.md`: removed both nice-to-have items for Lovelace and automation README examples.
+- `ROADMAP.md`: ticked both v1.1.0 UX / Documentation items.
+
+---
+
 ## 2026-04-15 (session 10) — v1.1 security: credentials leak + unbounded webhook body
 
 ### Goal

--- a/README.md
+++ b/README.md
@@ -119,22 +119,79 @@ Plus rollup entities:
 
 ---
 
-## Automation example
+## Examples
+
+### Lovelace / dashboard card
+
+The snippet below creates an **Entities card** showing network health at a glance: the rollup binary sensor lights up when any category is alerting, followed by per-category binary sensors and the total open-alarm count. Swap in only the categories you have enabled.
+
+```yaml
+type: entities
+title: UniFi Network Health
+entities:
+  # Rollup — any category alerting
+  - entity: binary_sensor.unifi_alerts_any_alert
+    name: Any Alert Active
+
+  # Per-category binary sensors (ON = alert active)
+  - entity: binary_sensor.unifi_alerts_network_device
+    name: Device Offline/Online
+  - entity: binary_sensor.unifi_alerts_network_wan
+    name: WAN Offline/Latency
+  - entity: binary_sensor.unifi_alerts_security_threat
+    name: Threat / IDS
+  - entity: binary_sensor.unifi_alerts_security_firewall
+    name: Firewall Block
+  - entity: binary_sensor.unifi_alerts_power
+    name: Power / PoE
+
+  # Total open-alarm count (polled from controller)
+  - entity: sensor.unifi_alerts_total_open_alerts
+    name: Total Open Alerts
+```
+
+> **Tip:** For a more compact view, replace `type: entities` with `type: glance`. Per-category message sensors (`sensor.unifi_alerts_<category>_last_message`) and open-count sensors (`sensor.unifi_alerts_<category>_open_count`) can be added the same way.
+
+---
+
+### Automation example
+
+UniFi Alerts uses Home Assistant **Event entities** (not the hass event bus). When an alert arrives the entity fires a single event of type `alert_received` and its state updates with the full payload as attributes. Trigger on the event entity using `platform: state`; the payload is available on `trigger.to_state.attributes`.
+
+The event data attributes are:
+
+| Attribute | Description |
+|---|---|
+| `message` | Human-readable alert text from UniFi |
+| `category` | Integration category slug (e.g. `security_threat`) |
+| `device_name` | UniFi device that raised the alert |
+| `alert_key` | Raw UniFi event key (e.g. `EVT_IPS_ThreatDetected`) |
+| `severity` | Severity string from the UniFi payload |
+| `site` | UniFi site name (default: `default`) |
+| `received_at` | ISO-8601 UTC timestamp |
 
 ```yaml
 automation:
   - alias: "Notify on UniFi security threat"
     trigger:
-      - platform: event
-        event_type: unifi_alerts_event
-        event_data:
-          category: security_threat
+      - platform: state
+        entity_id: event.unifi_alerts_security_threat
+    condition:
+      # Only act when the entity actually fired a new event (state changes on each alert)
+      - condition: template
+        value_template: "{{ trigger.to_state.state != 'unavailable' }}"
     action:
-      - service: notify.mobile_app_your_phone
+      - service: persistent_notification.create
         data:
-          title: "⚠️ UniFi Security Alert"
-          message: "{{ trigger.event.data.message }}"
+          title: "UniFi Security Alert"
+          message: >
+            {{ trigger.to_state.attributes.get('message', 'Unknown alert') }}
+            (device: {{ trigger.to_state.attributes.get('device_name', 'unknown') }},
+            key: {{ trigger.to_state.attributes.get('alert_key', '') }})
+          notification_id: "unifi_security_threat"
 ```
+
+> **Tip:** Replace `event.unifi_alerts_security_threat` with any per-category event entity (e.g. `event.unifi_alerts_network_device`, `event.unifi_alerts_power`). Swap `persistent_notification.create` for `notify.mobile_app_your_phone` or any other notify action.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,8 +73,8 @@ Issues that are non-blocking for a first release but important for production qu
 
 ### UX / Documentation
 
-- [ ] Lovelace / dashboard YAML example in README
-- [ ] Automation example in README — verify correct `event_type` and `event_data` schema
+- [x] Lovelace / dashboard YAML example in README
+- [x] Automation example in README — verify correct `event_type` and `event_data` schema
 
 ### QA
 

--- a/TODO.md
+++ b/TODO.md
@@ -24,12 +24,6 @@ If authentication fails after setup (e.g. password changed), HA should surface a
 ### Options flow: allow credentials to be updated without re-adding integration
 Currently the only way to change the controller URL or credentials is to delete and re-add the integration. Add a re-auth step to the options flow. Document the current limitation in the README as a workaround.
 
-### Lovelace card / dashboard example in README
-Add a simple Lovelace YAML snippet showing how to build a network health card using the binary sensors and count sensors. Reduces friction for new users.
-
-### Automation example in README
-Add a simple automation YAML example showing how to trigger on the `unifi_alerts` event entity. Verify the correct `event_type` and `event_data` schema before publishing.
-
 ### Service calls
 Expose `unifi_alerts.clear_category` and `unifi_alerts.clear_all` as HA services in addition to the button entities. This allows clearing alerts from automations without needing a button press.
 **File to create:** `services.py` (register with `hass.services.async_register`), `services.yaml` (service descriptions).


### PR DESCRIPTION
## Summary

- Replaces the minimal one-liner automation stub with a full `## Examples` section covering two common use cases.
- **Lovelace card:** `entities` card mixing `binary_sensor.unifi_alerts_any_alert`, five per-category binary sensors, and `sensor.unifi_alerts_total_open_alerts` — all entity IDs are exactly as produced by the integration.
- **Automation:** corrects the trigger to `platform: state` on `event.unifi_alerts_security_threat` (HA Event entities update state on each alert, they do not fire a hass bus event); documents all seven `alert_received` event-data attributes (`message`, `category`, `device_name`, `alert_key`, `severity`, `site`, `received_at`) sourced directly from `event.py`.

## Test plan

- [ ] `make check` passes (280 tests, lint, mypy, HACS preflight, translation drift) — verified locally before commit.
- [ ] Review Lovelace YAML: paste into HA dashboard editor and confirm it loads without errors.
- [ ] Review automation YAML: confirm `platform: state` trigger fires when a test webhook is delivered.
- [ ] Spot-check entity IDs against **Settings → Devices & Services → UniFi Alerts** after installing the integration.

https://claude.ai/code/session_01JbeaeLYzC76GkuD4ZL3U51