### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,15 @@ jobs:
     name: Validate with hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: home-assistant/actions/hassfest@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: home-assistant/actions/hassfest@f6f29a7ee3fa0eccadf3620a7b9ee00ab54ec03b  # master
 
   hacs-preflight:
     name: HACS manifest pre-flight (local rules)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
       - name: Run HACS manifest checks
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: hacs-preflight
     steps:
-      - uses: actions/checkout@v6
-      - uses: hacs/action@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: hacs/action@dcb30e72781db3f207d5236b861172774ab0b485  # main
         with:
           category: integration
 
@@ -39,8 +39,8 @@ jobs:
     name: Lint & type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -61,8 +61,8 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
       - name: Install test dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     name: Package and publish release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Determine release type from tag
         id: release_type
@@ -55,7 +55,7 @@ jobs:
           cd ..
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@v2.6.1
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2.6.1
         with:
           files: unifi_alerts.zip
           prerelease: ${{ steps.release_type.outputs.prerelease == 'true' }}

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -17,7 +17,7 @@ jobs:
     name: Validate version format for branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Extract version from manifest
         id: version

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,14 @@
 # History
 
+## 2026-04-21 (session 11) — Pin CI action versions to commit SHAs
+
+- Pinned all `uses:` lines across `ci.yml`, `release.yml`, and `version-check.yml` to full 40-character commit SHAs.
+- Actions pinned: `actions/checkout@v6`, `actions/setup-python@v6`, `home-assistant/actions/hassfest@master`, `hacs/action@main`, `softprops/action-gh-release@v2.6.1`.
+- Each pinned line includes a trailing `# <tag-or-ref>` comment so the human-readable version remains visible.
+- Eliminates supply-chain risk from floating `@master` / `@main` refs silently picking up breaking upstream changes.
+- No source code changes; `make check` passes (only YAML workflow files modified).
+- Removed the `### CI action versions are floating` entry from `TODO.md`; ticked the corresponding item in `ROADMAP.md` v1.1.0 Tech debt.
+
 ## 2026-04-15 (session 10) — v1.1 security: credentials leak + unbounded webhook body
 
 ### Goal

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,7 +82,7 @@ Issues that are non-blocking for a first release but important for production qu
 
 ### Tech debt
 
-- [ ] Pin CI action versions to commit SHAs instead of `@master` / `@main` (`ci.yml`)
+- [x] Pin CI action versions to commit SHAs instead of `@master` / `@main` (`ci.yml`)
 - [ ] Config entry repair flow — surface a HA repair notification when auth fails post-setup (`homeassistant.helpers.issue_registry`)
 - [ ] Options flow: allow credentials and controller URL to be updated without re-adding integration
 - [ ] Service calls: `unifi_alerts.clear_category` and `unifi_alerts.clear_all` (`services.py`, `services.yaml`)

--- a/TODO.md
+++ b/TODO.md
@@ -50,5 +50,3 @@ The `_device_info()` helper function is duplicated identically across `binary_se
 ### Polling re-auth is fire-and-forget
 In `coordinator._async_update_data`, if re-auth succeeds but the second `categorise_alarms()` call fails for a different reason, the error path is the generic `CannotConnectError` branch which may give a misleading log message.
 
-### CI action versions are floating (`@master`, `@main`)
-`home-assistant/actions/hassfest@master` and `hacs/action@main` are not pinned to a SHA. A breaking upstream change or supply-chain compromise would silently affect CI. Pin to commit SHAs and update periodically.


### PR DESCRIPTION
## Summary

- Replace floating `@master`, `@main`, and tag refs across all three workflows (`ci.yml`, `release.yml`, `version-check.yml`) with pinned 40-char commit SHAs.
- Each pinned line retains a trailing comment (`# v6`, `# master`, etc.) so future updates stay reviewable at a glance.
- Eliminates the "breaking upstream change or supply-chain compromise silently lands in CI" risk flagged in v1.1.0 Tech debt.

Actions pinned:
- `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6)
- `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405` (v6)
- `home-assistant/actions/hassfest@f6f29a7ee3fa0eccadf3620a7b9ee00ab54ec03b` (master)
- `hacs/action@dcb30e72781db3f207d5236b861172774ab0b485` (main)
- `softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe` (v2.6.1)

## Test plan

- [ ] CI runs to completion on this PR with all pinned SHAs resolving successfully.
- [ ] `make check` passes locally (280 tests, no code changes).
- [ ] Verify the `# vN` / `# branch` trailing comment is present on every pinned `uses:` line.

https://claude.ai/code/session_01JbeaeLYzC76GkuD4ZL3U51