### PR TITLE
feat: reauth flow and issue_registry repair for expired credentials

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,14 @@
 # History
 
+## 2026-04-21 (session 11) — Config entry repair flow: reauth step + issue_registry
+
+- `__init__.py`: `async_setup_entry` now distinguishes `InvalidAuthError` (raises `ConfigEntryAuthFailed`, triggering HA's standard reauth flow) from generic connection failures (still `ConfigEntryNotReady`).
+- `config_flow.py`: added `async_step_reauth` and `async_step_reauth_confirm` implementing HA's reauth convention. The reauth step also calls `ir.async_create_issue(...)` so a repair card appears in Settings → Repairs, giving users a fixable notification even if the standard reauth prompt is dismissed.
+- On successful reauth the entry is updated, reloaded, and the repair issue is deleted via `ir.async_delete_issue(...)`. Invalid credentials or connection failures redisplay the form with `invalid_auth` / `cannot_connect` errors.
+- `strings.json` + `translations/en.json` (kept identical — CI enforces): added `config.step.reauth_confirm`, `config.abort.reauth_successful`, and `issues.auth_failed` (with `fix_flow.step.confirm`).
+- `tests/unit/test_config_flow.py`: new `TestReauthFlow` class with 7 tests covering reauth routing, issue creation, happy path, invalid_auth, cannot_connect, and "don't delete issue on failure".
+- 287 tests pass (280 → 287).
+
 ## 2026-04-15 (session 10) — v1.1 security: credentials leak + unbounded webhook body
 
 ### Goal

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,7 +83,7 @@ Issues that are non-blocking for a first release but important for production qu
 ### Tech debt
 
 - [ ] Pin CI action versions to commit SHAs instead of `@master` / `@main` (`ci.yml`)
-- [ ] Config entry repair flow — surface a HA repair notification when auth fails post-setup (`homeassistant.helpers.issue_registry`)
+- [x] Config entry repair flow — surface a HA repair notification when auth fails post-setup (`homeassistant.helpers.issue_registry`)
 - [ ] Options flow: allow credentials and controller URL to be updated without re-adding integration
 - [ ] Service calls: `unifi_alerts.clear_category` and `unifi_alerts.clear_all` (`services.py`, `services.yaml`)
 

--- a/TODO.md
+++ b/TODO.md
@@ -17,10 +17,6 @@ If a restart is required, investigate why (e.g. Python module caching, import-ti
 
 ## 🟢 Nice-to-have
 
-### Config entry repair flow
-If authentication fails after setup (e.g. password changed), HA should surface a repair notification prompting the user to re-enter credentials rather than just showing the entry as unavailable.
-**Reference:** `homeassistant.helpers.issue_registry` and `async_create_issue`.
-
 ### Options flow: allow credentials to be updated without re-adding integration
 Currently the only way to change the controller URL or credentials is to delete and re-add the integration. Add a re-auth step to the options flow. Document the current limitation in the README as a workaround.
 

--- a/custom_components/unifi_alerts/__init__.py
+++ b/custom_components/unifi_alerts/__init__.py
@@ -7,7 +7,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
@@ -19,7 +19,7 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import UniFiAlertsCoordinator
-from .unifi_client import UniFiClient
+from .unifi_client import InvalidAuthError, UniFiClient
 from .webhook_handler import WebhookManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -48,6 +48,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await client.authenticate()
+    except InvalidAuthError as err:
+        _LOGGER.error("Authentication failed for UniFi controller: %s", err)
+        raise ConfigEntryAuthFailed(f"Invalid credentials for UniFi controller: {err}") from err
     except Exception as err:  # noqa: BLE001
         _LOGGER.error("Failed to authenticate to UniFi controller: %s", err)
         raise ConfigEntryNotReady(f"Could not connect to UniFi controller: {err}") from err

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 from homeassistant.components.webhook import async_generate_url
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.core import callback
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.selector import TextSelector, TextSelectorConfig, TextSelectorType
 from yarl import URL
 
@@ -39,6 +40,19 @@ from .const import (
 from .unifi_client import CannotConnectError, InvalidAuthError, UniFiClient
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _create_auth_failed_issue(hass: Any, entry: Any) -> None:
+    """Create a repair issue in the HA issue registry when credentials fail post-setup."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"auth_failed_{entry.entry_id}",
+        is_fixable=True,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="auth_failed",
+        translation_placeholders={"name": entry.title},
+    )
 
 
 class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -192,6 +206,70 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="finish",
             data_schema=vol.Schema(fields),
+        )
+
+    # ── Reauth flow ───────────────────────────────────────────────────────
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
+        """Entry point called by HA when ConfigEntryAuthFailed is raised.
+
+        Creates a repair issue so users see a repair card even if the standard
+        reauth notification is missed.
+        """
+        self._reauth_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        # Surface a repair card in addition to the standard reauth prompt
+        if self._reauth_entry is not None:
+            _create_auth_failed_issue(self.hass, self._reauth_entry)
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Show credential form and validate new credentials on submit."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None and self._reauth_entry is not None:
+            entry = self._reauth_entry
+            url: str = entry.data.get(CONF_CONTROLLER_URL, "")
+            async with aiohttp.ClientSession() as session:
+                client = UniFiClient(session, url, user_input)
+                try:
+                    auth_method = await client.authenticate()
+                except InvalidAuthError:
+                    errors["base"] = "invalid_auth"
+                except CannotConnectError as err:
+                    _LOGGER.error("Cannot reach controller during reauth: %s", err)
+                    errors["base"] = "cannot_connect"
+                except Exception:  # noqa: BLE001
+                    _LOGGER.exception("Unexpected error during reauth")
+                    errors["base"] = "unknown"
+                else:
+                    # Merge updated credentials into the entry
+                    new_data = {
+                        **entry.data,
+                        **user_input,
+                        CONF_AUTH_METHOD: auth_method,
+                        CONF_IS_UNIFI_OS: client._is_unifi_os,
+                    }
+                    self.hass.config_entries.async_update_entry(entry, data=new_data)
+                    # Clear the repair issue now that auth is restored
+                    ir.async_delete_issue(self.hass, DOMAIN, f"auth_failed_{entry.entry_id}")
+                    await self.hass.config_entries.async_reload(entry.entry_id)
+                    return self.async_abort(reason="reauth_successful")
+
+        _password_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
+        _api_key_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
+        schema = vol.Schema(
+            {
+                vol.Optional(CONF_USERNAME): str,
+                vol.Optional(CONF_PASSWORD): _password_selector,
+                vol.Optional(CONF_API_KEY): _api_key_selector,
+            }
+        )
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=schema,
+            errors=errors,
         )
 
     @staticmethod

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -40,6 +40,15 @@
           "webhook_url_security_firewall": "Security: Firewall block webhook URL",
           "webhook_url_power": "Power: PoE / power loss webhook URL"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate UniFi Alerts",
+        "description": "Your UniFi controller credentials for **{name}** are no longer valid. Enter new credentials to restore the connection.",
+        "data": {
+          "username": "Username (leave blank if using API key)",
+          "password": "Password",
+          "api_key": "API Key (UniFi OS only — leave blank if using username/password)"
+        }
       }
     },
     "error": {
@@ -50,7 +59,22 @@
       "unknown": "An unexpected error occurred. Check the Home Assistant logs."
     },
     "abort": {
-      "already_configured": "This UniFi controller is already configured."
+      "already_configured": "This UniFi controller is already configured.",
+      "reauth_successful": "Re-authentication was successful. The integration has been reloaded."
+    }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "UniFi Alerts: authentication failed for {name}",
+      "description": "The credentials for **{name}** are no longer valid (e.g. the password or API key was changed). Click **Fix** to re-enter your credentials and restore the integration.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate UniFi Alerts",
+            "description": "Enter new credentials for **{name}** to restore the connection."
+          }
+        }
+      }
     }
   },
   "options": {

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -66,12 +66,11 @@
   "issues": {
     "auth_failed": {
       "title": "UniFi Alerts: authentication failed for {name}",
-      "description": "The credentials for **{name}** are no longer valid (e.g. the password or API key was changed). Click **Fix** to re-enter your credentials and restore the integration.",
       "fix_flow": {
         "step": {
           "confirm": {
             "title": "Re-authenticate UniFi Alerts",
-            "description": "Enter new credentials for **{name}** to restore the connection."
+            "description": "The credentials for **{name}** are no longer valid (e.g. the password or API key was changed). Enter new credentials to restore the connection."
           }
         }
       }

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -40,6 +40,15 @@
           "webhook_url_security_firewall": "Security: Firewall block webhook URL",
           "webhook_url_power": "Power: PoE / power loss webhook URL"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate UniFi Alerts",
+        "description": "Your UniFi controller credentials for **{name}** are no longer valid. Enter new credentials to restore the connection.",
+        "data": {
+          "username": "Username (leave blank if using API key)",
+          "password": "Password",
+          "api_key": "API Key (UniFi OS only — leave blank if using username/password)"
+        }
       }
     },
     "error": {
@@ -50,7 +59,22 @@
       "unknown": "An unexpected error occurred. Check the Home Assistant logs."
     },
     "abort": {
-      "already_configured": "This UniFi controller is already configured."
+      "already_configured": "This UniFi controller is already configured.",
+      "reauth_successful": "Re-authentication was successful. The integration has been reloaded."
+    }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "UniFi Alerts: authentication failed for {name}",
+      "description": "The credentials for **{name}** are no longer valid (e.g. the password or API key was changed). Click **Fix** to re-enter your credentials and restore the integration.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate UniFi Alerts",
+            "description": "Enter new credentials for **{name}** to restore the connection."
+          }
+        }
+      }
     }
   },
   "options": {

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -66,12 +66,11 @@
   "issues": {
     "auth_failed": {
       "title": "UniFi Alerts: authentication failed for {name}",
-      "description": "The credentials for **{name}** are no longer valid (e.g. the password or API key was changed). Click **Fix** to re-enter your credentials and restore the integration.",
       "fix_flow": {
         "step": {
           "confirm": {
             "title": "Re-authenticate UniFi Alerts",
-            "description": "Enter new credentials for **{name}** to restore the connection."
+            "description": "The credentials for **{name}** are no longer valid (e.g. the password or API key was changed). Enter new credentials to restore the connection."
           }
         }
       }

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -584,3 +584,207 @@ async def test_options_flow_rejects_all_disabled() -> None:
     assert result["step_id"] == "init"
     call_kwargs = flow.async_show_form.call_args.kwargs
     assert call_kwargs["errors"] == {"base": "at_least_one_category"}
+
+
+# ---------------------------------------------------------------------------
+# Reauth flow tests
+# ---------------------------------------------------------------------------
+
+
+def _make_reauth_flow(entry_id: str = "entry-test") -> UniFiAlertsConfigFlow:
+    """Create a flow wired up for reauth tests."""
+    flow = UniFiAlertsConfigFlow()
+    flow.context = {"entry_id": entry_id}
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = entry_id
+    mock_entry.title = "UniFi Alerts (https://192.168.1.1)"
+    mock_entry.data = {
+        CONF_CONTROLLER_URL: "https://192.168.1.1",
+        CONF_USERNAME: "admin",
+        CONF_PASSWORD: "oldpassword",
+        CONF_WEBHOOK_SECRET: "secret",
+    }
+
+    hass = MagicMock()
+    hass.config_entries.async_get_entry = MagicMock(return_value=mock_entry)
+    hass.config_entries.async_update_entry = MagicMock()
+    hass.config_entries.async_reload = AsyncMock()
+    flow.hass = hass
+    flow._reauth_entry = mock_entry  # pre-set so reauth_confirm can access it
+    return flow
+
+
+class TestReauthFlow:
+    """Tests for the reauth flow steps."""
+
+    @pytest.mark.asyncio
+    async def test_async_step_reauth_routes_to_reauth_confirm(self) -> None:
+        """async_step_reauth must store the entry and advance to reauth_confirm."""
+        flow = UniFiAlertsConfigFlow()
+        entry_id = "entry-reauth-1"
+        flow.context = {"entry_id": entry_id}
+
+        mock_entry = MagicMock()
+        mock_entry.entry_id = entry_id
+        mock_entry.title = "Test Controller"
+
+        hass = MagicMock()
+        hass.config_entries.async_get_entry = MagicMock(return_value=mock_entry)
+        hass.config_entries.async_reload = AsyncMock()
+        flow.hass = hass
+
+        confirm_result = {"type": "form", "step_id": "reauth_confirm"}
+        flow.async_step_reauth_confirm = AsyncMock(return_value=confirm_result)
+
+        with patch(
+            "custom_components.unifi_alerts.config_flow._create_auth_failed_issue"
+        ):
+            result = await flow.async_step_reauth({})
+
+        assert result == confirm_result
+        assert flow._reauth_entry is mock_entry
+
+    @pytest.mark.asyncio
+    async def test_async_step_reauth_creates_issue(self) -> None:
+        """async_step_reauth must call _create_auth_failed_issue."""
+        flow = UniFiAlertsConfigFlow()
+        entry_id = "entry-issue-test"
+        flow.context = {"entry_id": entry_id}
+
+        mock_entry = MagicMock()
+        mock_entry.entry_id = entry_id
+        mock_entry.title = "Test"
+
+        hass = MagicMock()
+        hass.config_entries.async_get_entry = MagicMock(return_value=mock_entry)
+        hass.config_entries.async_reload = AsyncMock()
+        flow.hass = hass
+        flow.async_step_reauth_confirm = AsyncMock(return_value={"type": "form"})
+
+        with patch(
+            "custom_components.unifi_alerts.config_flow._create_auth_failed_issue"
+        ) as mock_create:
+            await flow.async_step_reauth({})
+
+        mock_create.assert_called_once_with(hass, mock_entry)
+
+    @pytest.mark.asyncio
+    async def test_reauth_confirm_no_input_shows_form(self) -> None:
+        """With no user_input, reauth_confirm must show the credential form."""
+        flow = _make_reauth_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reauth_confirm"})
+
+        result = await flow.async_step_reauth_confirm(user_input=None)
+
+        assert result["step_id"] == "reauth_confirm"
+        flow.async_show_form.assert_called_once()
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["step_id"] == "reauth_confirm"
+        assert not call_kwargs["errors"]
+
+    @pytest.mark.asyncio
+    async def test_reauth_confirm_valid_credentials_updates_entry_and_aborts(self) -> None:
+        """Valid credentials must update entry.data and abort with reauth_successful."""
+        flow = _make_reauth_flow()
+        flow.async_abort = MagicMock(return_value={"type": "abort", "reason": "reauth_successful"})
+
+        new_creds = {CONF_USERNAME: "admin", CONF_PASSWORD: "newpassword"}
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+                return_value=_make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+            patch("custom_components.unifi_alerts.config_flow.ir.async_delete_issue") as mock_del,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value="userpass")
+            instance._is_unifi_os = False
+
+            result = await flow.async_step_reauth_confirm(user_input=new_creds)
+
+        assert result["reason"] == "reauth_successful"
+        flow.hass.config_entries.async_update_entry.assert_called_once()
+        flow.hass.config_entries.async_reload.assert_awaited_once()
+        mock_del.assert_called_once_with(
+            flow.hass, "unifi_alerts", f"auth_failed_{flow._reauth_entry.entry_id}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reauth_confirm_invalid_credentials_shows_error(self) -> None:
+        """Invalid credentials must re-show the form with invalid_auth error."""
+        from custom_components.unifi_alerts.unifi_client import InvalidAuthError
+
+        flow = _make_reauth_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reauth_confirm"})
+
+        new_creds = {CONF_USERNAME: "admin", CONF_PASSWORD: "wrongpassword"}
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+                return_value=_make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(side_effect=InvalidAuthError("bad"))
+
+            result = await flow.async_step_reauth_confirm(user_input=new_creds)
+
+        assert result["step_id"] == "reauth_confirm"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"] == {"base": "invalid_auth"}
+
+    @pytest.mark.asyncio
+    async def test_reauth_confirm_cannot_connect_shows_error(self) -> None:
+        """A connection error during reauth must show cannot_connect error."""
+        from custom_components.unifi_alerts.unifi_client import CannotConnectError
+
+        flow = _make_reauth_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reauth_confirm"})
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+                return_value=_make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(side_effect=CannotConnectError("down"))
+
+            result = await flow.async_step_reauth_confirm(
+                user_input={CONF_USERNAME: "admin", CONF_PASSWORD: "pass"}
+            )
+
+        assert result["step_id"] == "reauth_confirm"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"] == {"base": "cannot_connect"}
+
+    @pytest.mark.asyncio
+    async def test_reauth_confirm_does_not_delete_issue_on_failure(self) -> None:
+        """async_delete_issue must NOT be called when reauth fails."""
+        from custom_components.unifi_alerts.unifi_client import InvalidAuthError
+
+        flow = _make_reauth_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reauth_confirm"})
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+                return_value=_make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+            patch("custom_components.unifi_alerts.config_flow.ir.async_delete_issue") as mock_del,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(side_effect=InvalidAuthError("bad"))
+
+            await flow.async_step_reauth_confirm(
+                user_input={CONF_USERNAME: "admin", CONF_PASSWORD: "wrong"}
+            )
+
+        mock_del.assert_not_called()


### PR DESCRIPTION
## Summary

Closes the v1.1.0 "config entry repair flow" item. When credentials become invalid post-setup (e.g. password rotated on the controller), the integration now triggers HA's standard reauth flow **and** surfaces a clickable repair card in Settings → Repairs so users who dismiss the reauth notification still get a visible fix prompt.

- `__init__.py` — `async_setup_entry` distinguishes `InvalidAuthError` (→ `ConfigEntryAuthFailed`, triggers reauth) from generic connection failures (still `ConfigEntryNotReady` for retry).
- `config_flow.py` — new `async_step_reauth` and `async_step_reauth_confirm` implementing HA's reauth convention; `_create_auth_failed_issue(...)` wrapper around `ir.async_create_issue`; successful reauth updates `entry.data`, reloads the entry, and deletes the repair via `ir.async_delete_issue`.
- `strings.json` + `translations/en.json` (kept identical — CI enforces): `config.step.reauth_confirm`, `config.abort.reauth_successful`, `issues.auth_failed` with `fix_flow.step.confirm`.
- 7 new tests in `TestReauthFlow`; 287 total (was 280).

## Test plan

- [ ] `make check` passes (lint, mypy, HACS preflight, translation drift, 287 tests) — verified locally.
- [ ] Install the integration, then change the controller password externally; confirm a repair card appears in Settings → Repairs and clicking "Fix" opens the credential form.
- [ ] Enter valid new credentials; confirm the entry reloads, entities recover, and the repair card disappears.
- [ ] Enter deliberately wrong credentials; confirm the form shows `invalid_auth` and the repair card persists.

https://claude.ai/code/session_01JbeaeLYzC76GkuD4ZL3U51