### PR TITLE
fix: set manifest version to 1.1.0 (squash merge skipped manifest.json)

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": ["aiohttp>=3.9.0"],
-  "version": "1.0.0"
+  "version": "1.1.0"
 }


### PR DESCRIPTION
## Why

The squash merge for PR #22 did not update `manifest.json`. This happened because the common ancestor of `dev` and `main` had version `1.0.0-pre3`, while `main` had already advanced to `1.0.0`. Git could not apply the diff cleanly (expected old value `1.0.0-pre3`, found `1.0.0`) and left the file unchanged.

## Change

Single-line fix: `"version": "1.0.0"` → `"version": "1.1.0"`.

This must merge before the `v1.1.0` tag can be pushed (release.yml validates the tag matches manifest).