### PR TITLE
fix: remove duplicate steps in release.yml; pin checkout SHA in version-check.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,31 +48,6 @@ jobs:
           fi
           echo "OK: tag matches manifest version $MANIFEST_VERSION"
 
-      - name: Determine release type from tag
-        id: release_type
-        run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          if echo "$TAG" | grep -qE '-pre[0-9]+$'; then
-            echo "prerelease=true" >> $GITHUB_OUTPUT
-            echo "Release type: PRE-RELEASE ($TAG)"
-          else
-            echo "prerelease=false" >> $GITHUB_OUTPUT
-            echo "Release type: STABLE ($TAG)"
-          fi
-
-      - name: Validate manifest version matches tag
-        run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-          MANIFEST_VERSION=$(python3 -c "import json; print(json.load(open('custom_components/unifi_alerts/manifest.json'))['version'])")
-          if [ "$TAG_VERSION" != "$MANIFEST_VERSION" ]; then
-            echo "ERROR: tag version ($TAG_VERSION) does not match manifest version ($MANIFEST_VERSION)"
-            echo ""
-            echo "Update manifest.json to version $TAG_VERSION before tagging, or retag with v$MANIFEST_VERSION."
-            exit 1
-          fi
-          echo "OK: tag matches manifest version $MANIFEST_VERSION"
-
       - name: Create release zip
         run: |
           cd custom_components

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -17,7 +17,7 @@ jobs:
     name: Validate version format for branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Extract version from manifest
         id: version


### PR DESCRIPTION
## What broke and why

### `release.yml` — duplicate `id: release_type`
The "Determine release type from tag" and "Validate manifest version matches tag" steps appeared **twice** in the same job (lines 26–49 and 51–74). GitHub Actions rejects duplicate step IDs within a scope, producing:
> `The identifier 'release_type' may not be used more than once within the same scope.`

This prevented **every tag push** from triggering a release. The duplicate was introduced during the conflict-resolution merge for PR #22 — both the dev and main versions of the file were concatenated rather than one being chosen.

### `version-check.yml` — unpinned `actions/checkout@v6`
The SHA-pinning work from v1.1 (`a74e574`) was lost when the same merge-conflict resolution accidentally took the `main` side of the `version-check.yml` add/add conflict. The correct SHA-pinned ref (`de0fac2e...`) from dev was discarded.

### Why CI didn't catch this
`ci.yml` only runs `ruff`, `mypy`, `hassfest`, and `pytest` — none validate GitHub Actions YAML syntax. `release.yml` only fires on tag pushes, so it never ran on any PR. A tool like [`actionlint`](https://github.com/rhysd/actionlint) in the lint job would have caught the duplicate ID immediately. This is tracked in TODO.md as a future improvement.

## Changes
- `release.yml`: removed the 24-line duplicate block (steps at lines 51–74)
- `version-check.yml`: replaced `actions/checkout@v6` with the SHA-pinned `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6`