### PR TITLE
Add reauth flow, services, and webhook body size limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   validate:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,15 @@ jobs:
     name: Validate with hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: home-assistant/actions/hassfest@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: home-assistant/actions/hassfest@f6f29a7ee3fa0eccadf3620a7b9ee00ab54ec03b  # master
 
   hacs-preflight:
     name: HACS manifest pre-flight (local rules)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
       - name: Run HACS manifest checks
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: hacs-preflight
     steps:
-      - uses: actions/checkout@v6
-      - uses: hacs/action@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: hacs/action@dcb30e72781db3f207d5236b861172774ab0b485  # main
         with:
           category: integration
 
@@ -39,8 +39,8 @@ jobs:
     name: Lint & type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -61,8 +61,8 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
       - name: Install test dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,52 @@
 name: Release
 
+# Triggers on version tags pushed from either branch:
+#   main tags  → stable release:    v1.0.0, v1.1.0, v1.2.0
+#   dev tags   → pre-release:       v1.1.0-pre1, v1.1.0-pre2
+#
+# The workflow validates that the tag version exactly matches the version
+# in manifest.json before packaging to prevent mismatched releases.
+
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'           # stable:      v1.0.0, v1.1.0
+      - 'v[0-9]+.[0-9]+.[0-9]+-pre[0-9]+' # pre-release: v1.0.0-pre1, v1.1.0-pre2
 
 permissions:
   contents: write
 
 jobs:
   release:
-    name: Package and attach release asset
+    name: Package and publish release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Determine release type from tag
+        id: release_type
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          if echo "$TAG" | grep -qE '-pre[0-9]+$'; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "Release type: PRE-RELEASE ($TAG)"
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+            echo "Release type: STABLE ($TAG)"
+          fi
+
+      - name: Validate manifest version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          MANIFEST_VERSION=$(python3 -c "import json; print(json.load(open('custom_components/unifi_alerts/manifest.json'))['version'])")
+          if [ "$TAG_VERSION" != "$MANIFEST_VERSION" ]; then
+            echo "ERROR: tag version ($TAG_VERSION) does not match manifest version ($MANIFEST_VERSION)"
+            echo ""
+            echo "Update manifest.json to version $TAG_VERSION before tagging, or retag with v$MANIFEST_VERSION."
+            exit 1
+          fi
+          echo "OK: tag matches manifest version $MANIFEST_VERSION"
 
       - name: Create release zip
         run: |
@@ -24,5 +58,7 @@ jobs:
         uses: softprops/action-gh-release@v2.6.1
         with:
           files: unifi_alerts.zip
+          prerelease: ${{ steps.release_type.outputs.prerelease == 'true' }}
+          name: ${{ steps.release_type.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     name: Package and publish release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Determine release type from tag
         id: release_type
@@ -55,7 +55,7 @@ jobs:
           cd ..
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@v2.6.1
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2.6.1
         with:
           files: unifi_alerts.zip
           prerelease: ${{ steps.release_type.outputs.prerelease == 'true' }}

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,53 @@
+name: Version Check
+
+# Enforces that manifest.json version is in the correct format for the target branch:
+#   main  → stable semver only:    X.Y.Z          (e.g. 1.0.0, 1.1.0)
+#   dev   → pre-release only:      X.Y.Z-preN     (e.g. 1.1.0-pre1, 1.1.0-pre2)
+#
+# Feature branches are not checked — any version is accepted while work is in progress.
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  version-format:
+    name: Validate version format for branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Extract version from manifest
+        id: version
+        run: |
+          VERSION=$(python3 -c "import json; print(json.load(open('custom_components/unifi_alerts/manifest.json'))['version'])")
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Manifest version: $VERSION"
+
+      - name: Validate version format for main
+        if: github.ref == 'refs/heads/main' || github.base_ref == 'main'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: main branch requires a stable semver version (X.Y.Z), got: $VERSION"
+            echo ""
+            echo "Pre-release suffixes (-preN, -alpha, -beta, etc.) are not allowed on main."
+            echo "Merge dev into main only after bumping the version to a stable semver."
+            exit 1
+          fi
+          echo "OK: $VERSION is a valid stable semver for main"
+
+      - name: Validate version format for dev
+        if: github.ref == 'refs/heads/dev' || github.base_ref == 'dev'
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-pre[0-9]+$'; then
+            echo "ERROR: dev branch requires a pre-release version (X.Y.Z-preN), got: $VERSION"
+            echo ""
+            echo "Only the -preN suffix is accepted on dev (e.g. 1.1.0-pre1)."
+            echo "Bump to a stable version and merge to main when ready to release."
+            exit 1
+          fi
+          echo "OK: $VERSION is a valid pre-release version for dev"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -17,7 +17,7 @@ jobs:
     name: Validate version format for branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - name: Extract version from manifest
         id: version

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,9 @@ tests/
   test_init.py                    # async_setup_entry / async_unload_entry lifecycle, teardown order
   test_entities.py                # all entity property methods: binary_sensor, sensor, event, button
 .github/workflows/
-  ci.yml                          # hassfest + hacs-preflight + HACS action + lint (ruff, mypy, translation drift) + pytest
-  release.yml                     # zips and attaches release asset on GitHub release
+  ci.yml                          # hassfest + hacs-preflight + HACS action + lint (ruff, mypy, translation drift) + pytest; runs on push/PR to main and dev
+  version-check.yml               # enforces version format per branch: main=X.Y.Z stable, dev=X.Y.Z-preN; runs on push/PR to main and dev
+  release.yml                     # triggered by version tags (v1.0.0 for stable, v1.0.0-pre1 for pre-release); validates tag matches manifest; marks GitHub release as pre-release automatically
 .githooks/
   pre-push                        # local gate: HACS preflight → translation drift → ruff → mypy → pytest; install with: git config core.hooksPath .githooks
 scripts/
@@ -86,10 +87,58 @@ README.md                         # user-facing install, setup, and contributing
 - All `const.py` additions go in the appropriate labelled section with a comment.
 - Tests use `MagicMock` / `AsyncMock` for the UniFi client — never make real HTTP calls in tests.
 
+## Branching strategy and versioning
+
+This project uses a two-branch model. All active development happens on `dev`; `main` is stable-only.
+
+### Branches
+
+| Branch | Purpose | Version format | Example |
+|--------|---------|---------------|---------|
+| `main` | Stable releases only. CI enforces no pre-release suffix. | `X.Y.Z` | `1.0.0`, `1.1.0` |
+| `dev` | Active development. CI enforces `-preN` suffix. | `X.Y.Z-preN` | `1.1.0-pre1`, `1.1.0-pre2` |
+| `feature/*` or `claude/*` | Short-lived work. No version format enforced by CI. | Any | — |
+
+### Versioning conventions
+
+- **Minor bumps on main:** releases from `main` increment the minor version (`1.0.0 → 1.1.0 → 1.2.0`). Patch releases (`1.0.1`) are reserved for critical hotfixes.
+- **Pre-release sequence on dev:** each tagged checkpoint on `dev` increments the pre-release counter (`1.1.0-pre1 → 1.1.0-pre2`). The base version (`1.1.0`) matches the *next* planned minor release on `main`.
+- **`manifest.json` is the single source of truth** for the version — the release workflow validates the pushed tag matches it exactly.
+
+### Release workflow
+
+```
+dev  ──┬── (work) ──► tag v1.1.0-pre1  ──► GitHub pre-release  (automated)
+       │
+       ├── (work) ──► tag v1.1.0-pre2  ──► GitHub pre-release  (automated)
+       │
+       └── bump manifest to 1.1.0
+            └─► merge PR to main
+                 └─► tag v1.1.0  ──► GitHub stable release  (automated)
+```
+
+1. **Development:** work on `dev`. Version in manifest stays at `X.Y.Z-preN`.
+2. **Pre-release checkpoint:** bump the `N` in manifest (e.g. `pre1 → pre2`), commit, push, then push the tag `vX.Y.Z-preN`. GitHub Actions creates a pre-release automatically.
+3. **Stable release:** bump manifest from `X.Y.Z-preN` to `X.Y.Z`, open a PR from `dev` to `main`. After merge, tag `vX.Y.Z` on `main`. GitHub Actions creates a stable release.
+4. **Start next cycle:** on `dev`, bump manifest to `X.(Y+1).0-pre1` and continue.
+
+### CI enforcement
+
+- `version-check.yml` blocks pushes and PRs that violate the format for the target branch.
+- `release.yml` fails if the pushed tag does not exactly match `manifest.json`.
+- Never manually create a GitHub release — always push a version tag and let the workflow do it.
+
+### Branch protection (configure once in GitHub Settings → Branches)
+
+Recommended rules:
+- **`main`:** require PR, require status checks (`CI / *`, `Version Check / *`), no direct push, no force-push.
+- **`dev`:** require status checks (`CI / *`, `Version Check / *`), allow direct push (for version bumps), no force-push.
+
 ## Working style
 
 - **Never assume — always ask.** If anything about the task, scope, or approach is unclear, ask before proceeding. Do not guess intent.
-- **Always pull `main` before starting work** — run `git pull origin main` at the start of every session to avoid diverging from origin. Never start implementing changes on a stale branch.
+- **Always pull `dev` before starting work** — run `git pull origin dev` at the start of every session to avoid diverging from origin. Never start implementing changes on a stale branch. Pull `main` only when checking stable state.
+- **Work on `dev`, not `main`** — `main` is only updated via PRs from `dev`. Never commit directly to `main`.
 - **Move into the working directory at the start of every session** — avoids needing path prefixes on every command.
 - Always run `make check` before committing — never commit broken code. `make check` runs lint, typecheck, HACS preflight, translation drift check, and the full test suite in one shot.
 - Always update `HISTORY.md` with a detailed description of what was done, why, and how, including test coverage. This is the primary source of truth for what has been completed and should be reflected in the codebase. Do not rely on memory or Git history alone.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,7 @@ This project uses a two-branch model. All active development happens on `dev`; `
 |--------|---------|---------------|---------|
 | `main` | Stable releases only. CI enforces no pre-release suffix. | `X.Y.Z` | `1.0.0`, `1.1.0` |
 | `dev` | Active development. CI enforces `-preN` suffix. | `X.Y.Z-preN` | `1.1.0-pre1`, `1.1.0-pre2` |
-| `feature/*` or `claude/*` | Short-lived work. No version format enforced by CI. | Any | — |
+| `feature/*` or `claude/*` | Short-lived work. **Must branch off `dev`, not `main`.** No version format enforced by CI. | Any | — |
 
 ### Versioning conventions
 
@@ -139,6 +139,7 @@ Recommended rules:
 - **Never assume — always ask.** If anything about the task, scope, or approach is unclear, ask before proceeding. Do not guess intent.
 - **Always pull `dev` before starting work** — run `git pull origin dev` at the start of every session to avoid diverging from origin. Never start implementing changes on a stale branch. Pull `main` only when checking stable state.
 - **Work on `dev`, not `main`** — `main` is only updated via PRs from `dev`. Never commit directly to `main`.
+- **Feature and claude/* branches must be created from `dev`** — run `git checkout dev && git pull origin dev && git checkout -b <branch>`. Never branch off `main`. PRs from feature branches must target `dev`, not `main`.
 - **Move into the working directory at the start of every session** — avoids needing path prefixes on every command.
 - Always run `make check` before committing — never commit broken code. `make check` runs lint, typecheck, HACS preflight, translation drift check, and the full test suite in one shot.
 - Always update `HISTORY.md` with a detailed description of what was done, why, and how, including test coverage. This is the primary source of truth for what has been completed and should be reflected in the codebase. Do not rely on memory or Git history alone.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,19 @@
 # History
 
+## 2026-04-21 — Extended v1.2 critical-review: full security / architecture / UX audit
+
+- **ROADMAP.md v1.2.0**: expanded from 13 items to 26 items after a comprehensive review from security, senior developer, and user/consumer perspectives.
+- **New critical finding — webhook ID collision on multi-entry:** `webhook_id_for_category()` generates IDs without `entry_id`, so two config entries (multi-controller households) silently overwrite each other's webhook handlers. Promoted to the top of the reliability list with a `(CRITICAL)` tag.
+- **New security findings:** config flow creates bare `aiohttp.ClientSession` bypassing HA's proxy/SSL; credential fragments may leak in `__init__.py` exception messages; no webhook rate limiting/debounce.
+- **Expanded SSL fail-open scope:** identified 4 additional call sites (`_detect_unifi_os`, `_verify_api_key`, `_login_userpass`, `close`) with the same `False` default — all need the same fix.
+- **New reliability findings:** `from_api_alarm` silently drops epoch-millisecond timestamps; `open_count` never updated on webhook path (stale between polls).
+- **New tech debt findings:** config flow accesses private `client._is_unifi_os`; `EventDeviceClass.BUTTON` semantically wrong; clear buttons lack `entity_category`.
+- **New testing findings:** no test for epoch-ms timestamp parsing; no test for dedup/rate limiting; multi-entry test annotated as red-green pair against the webhook ID collision bug.
+- **TODO.md**: matching section updated with all new items, grouped by impact.
+- No code changes — docs only. All 324 tests still pass.
+
+---
+
 ## 2026-04-21 (session 11) — Distinguish re-auth failure from post-re-auth update failure in polling
 
 - **`coordinator.py`**: split the single `except (InvalidAuthError, CannotConnectError)` retry handler into two separate `try/except` blocks — one around `authenticate()` and one around the retried `categorise_alarms()` call.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,48 @@
 # History
 
+## 2026-04-15 (session 9) — Move to two-branch model; add versioning CI enforcement
+
+### Goal
+
+Transition from trunk-driven development to a two-branch model (`main` = stable, `dev` = active pre-release development), add CI that enforces the correct version format on each branch, and update release automation so tags drive publishing rather than manual GitHub UI releases.
+
+### `.github/workflows/version-check.yml` (new)
+
+New workflow triggered on push and PR to `main` and `dev`. Extracts the version from `manifest.json` and:
+- On `main` (or a PR targeting `main`): validates the version matches `^[0-9]+\.[0-9]+\.[0-9]+$` (stable semver, no suffix). Fails with a clear message if a pre-release suffix is present.
+- On `dev` (or a PR targeting `dev`): validates the version matches `^[0-9]+\.[0-9]+\.[0-9]+-pre[0-9]+$`. Fails if the version is stable or uses a non-standard suffix.
+- Feature branches (`claude/*`, `feature/*`) are not checked — any version is accepted.
+
+### `.github/workflows/release.yml` (updated)
+
+Switched trigger from `release: types: [published]` to `push: tags` matching `v*.*.*` (stable) and `v*.*.*-pre*` (pre-release). New behaviour:
+1. Detects whether the tag is a pre-release by checking for a `-pre` suffix.
+2. Validates that the pushed tag version exactly matches the `version` field in `manifest.json`. Fails fast with a descriptive error if they diverge.
+3. Creates the release zip as before.
+4. Calls `softprops/action-gh-release` with `prerelease: true` for pre-release tags and `prerelease: false` for stable tags — the GitHub release type is now automatic, not manual.
+
+### `.github/workflows/ci.yml` (updated)
+
+Added `dev` to `pull_request.branches` so CI runs on PRs targeting `dev` as well as `main`. (Push triggers for `dev` were already present.)
+
+### `manifest.json` (version bump)
+
+Bumped version from `1.0.0-pre3` to `1.0.0`. All v1.0.0 blockers were resolved in sessions 1–8; this marks the first stable release on `main`.
+
+### `dev` branch (created)
+
+Created `dev` branch from the post-merge state of `main`. Bumped `manifest.json` on `dev` to `1.1.0-pre1` to start the next development cycle. All v1.1.0 work (security hardening, reliability, QA) proceeds on `dev` under that version prefix.
+
+### Documentation
+
+- **`CLAUDE.md`**: added "Branching strategy and versioning" section documenting the two-branch model, version conventions, the release workflow diagram, CI enforcement, and recommended branch protection rules. Updated "Working style" to say pull `dev` (not `main`) at the start of each session, and to note that `main` is only updated via PRs.
+- **`ROADMAP.md`**: updated current status blurb; marked v1.0.0 as released; added an "Infrastructure" subsection to v1.1.0 ticking off the branch model and CI versioning work.
+- **`TODO.md`**: no items removed or added (branch setup was not in the backlog; all relevant changes are now live).
+
+### No test changes
+
+No production code was modified. CI workflow changes are validated by the GitHub Actions runner, not by the local pytest suite.
+
 ## 2026-04-11 (session 8) — Fix silent api.err.InvalidObject: persist UniFi OS detection + validate alarm endpoint at setup
 
 ### Root cause

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -40,6 +40,21 @@
 - No source code changes; `make check` passes (only YAML workflow files modified).
 - Removed the `### CI action versions are floating` entry from `TODO.md`; ticked the corresponding item in `ROADMAP.md` v1.1.0 Tech debt.
 
+---
+
+## 2026-04-21 (session 11) — Add clear_category and clear_all services
+
+- Created `custom_components/unifi_alerts/services.py`: defines `SERVICE_CLEAR_CATEGORY` and `SERVICE_CLEAR_ALL` with voluptuous schemas; handlers call `coordinator.cancel_clear(category)`, mutate `state.clear()`, and dispatch `coordinator.async_set_updated_data()` — matching button entity behaviour exactly.
+- Created `custom_components/unifi_alerts/services.yaml`: HA service descriptions with `selector.select` for the `category` field (all 7 slugs listed) and an optional `entry_id` `selector.text` on both services.
+- Wired services into `custom_components/unifi_alerts/__init__.py`: `async_register_services(hass)` called after platform setup (idempotent, safe for multiple entries); `async_unregister_services(hass)` called in `async_unload_entry` only when `hass.data[DOMAIN]` is empty (i.e. last entry is gone).
+- Added `"services"` top-level key to both `custom_components/unifi_alerts/strings.json` and `custom_components/unifi_alerts/translations/en.json` (kept identical — CI drift check verified).
+- Created `tests/unit/test_services.py` with 28 new tests covering: schema validation (valid/invalid category, missing required field, optional entry_id); `clear_category` clears state, cancels clear task, dispatches listeners, skips non-alerting, filters by entry_id; `clear_all` clears all alerting categories with one dispatch per coordinator, skips non-alerting, filters by entry_id; registration idempotency; unregistration only on last-entry unload.
+- All 308 tests pass (280 pre-existing + 28 new); lint, mypy, HACS preflight, and translation drift checks all clean.
+- `TODO.md`: removed `### Service calls` entry under Nice-to-have.
+- `ROADMAP.md`: ticked `[ ] Service calls: ...` to `[x]` under v1.1.0 Tech debt.
+
+---
+
 ## 2026-04-15 (session 10) — v1.1 security: credentials leak + unbounded webhook body
 
 ### Goal

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,16 @@
 # History
 
+## 2026-04-21 (session 11) — Distinguish re-auth failure from post-re-auth update failure in polling
+
+- **`coordinator.py`**: split the single `except (InvalidAuthError, CannotConnectError)` retry handler into two separate `try/except` blocks — one around `authenticate()` and one around the retried `categorise_alarms()` call.
+- Re-auth failures (`InvalidAuthError` or `CannotConnectError` from `authenticate()`) now raise `ConfigEntryAuthFailed` so HA can surface the reauth flow to the user; log message is "Re-authentication failed; credentials may have changed".
+- Post-re-auth poll failures (`CannotConnectError` from the second `categorise_alarms()`) now raise `UpdateFailed` with "Cannot reach UniFi controller after re-authentication" — clearly distinguishable from the first-pass "Cannot reach UniFi controller" message.
+- Added `ConfigEntryAuthFailed` import from `homeassistant.exceptions`.
+- **`tests/unit/test_coordinator.py`**: replaced the old `test_invalid_auth_on_retry_raises_update_failed` test with three new tests in `TestPollingErrorPaths`: re-auth `InvalidAuthError` → `ConfigEntryAuthFailed`; re-auth `CannotConnectError` → `ConfigEntryAuthFailed`; re-auth succeeds but retry fails → `UpdateFailed` containing "after re-authentication".
+- All 282 tests pass; lint, mypy, HACS preflight, and translation drift checks clean.
+
+---
+
 ## 2026-04-21 (session 11) — README: Lovelace card and automation examples
 
 - Added `## Examples` section to `README.md` replacing the minimal one-liner automation stub.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -22,6 +22,15 @@
 
 ---
 
+## 2026-04-21 (session 11) — Add info.md HACS display page
+
+- Created `info.md` at the repository root as the HACS UI display card (56 lines).
+- Covers features, alert categories, requirements, quick setup, and links; kept concise and scannable per HACS conventions.
+- Ticked `[ ] Create info.md` in `ROADMAP.md` v2.0.0 prerequisites.
+- Noted info.md completion in `TODO.md` HACS default repository submission entry.
+
+---
+
 ## 2026-04-15 (session 10) — v1.1 security: credentials leak + unbounded webhook body
 
 ### Goal

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -55,6 +55,17 @@
 
 ---
 
+## 2026-04-21 (session 11) — Config entry repair flow: reauth step + issue_registry
+
+- `__init__.py`: `async_setup_entry` now distinguishes `InvalidAuthError` (raises `ConfigEntryAuthFailed`, triggering HA's standard reauth flow) from generic connection failures (still `ConfigEntryNotReady`).
+- `config_flow.py`: added `async_step_reauth` and `async_step_reauth_confirm` implementing HA's reauth convention. The reauth step also calls `ir.async_create_issue(...)` so a repair card appears in Settings → Repairs, giving users a fixable notification even if the standard reauth prompt is dismissed.
+- On successful reauth the entry is updated, reloaded, and the repair issue is deleted via `ir.async_delete_issue(...)`. Invalid credentials or connection failures redisplay the form with `invalid_auth` / `cannot_connect` errors.
+- `strings.json` + `translations/en.json` (kept identical — CI enforces): added `config.step.reauth_confirm`, `config.abort.reauth_successful`, and `issues.auth_failed` (with `fix_flow.step.confirm`).
+- `tests/unit/test_config_flow.py`: new `TestReauthFlow` class with 7 tests covering reauth routing, issue creation, happy path, invalid_auth, cannot_connect, and "don't delete issue on failure".
+- 287 tests pass (280 → 287).
+
+---
+
 ## 2026-04-15 (session 10) — v1.1 security: credentials leak + unbounded webhook body
 
 ### Goal

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,16 @@
 # History
 
+## 2026-04-21 (session 11) — README: Lovelace card and automation examples
+
+- Added `## Examples` section to `README.md` replacing the minimal one-liner automation stub.
+- Lovelace snippet: `entities` card mixing `binary_sensor.unifi_alerts_any_alert`, five per-category binary sensors, and `sensor.unifi_alerts_total_open_alerts`; only uses entity IDs actually produced by the integration.
+- Automation snippet: `platform: state` trigger on `event.unifi_alerts_security_threat` (correct for HA `EventEntity`); documents all seven event-data attributes (`message`, `category`, `device_name`, `alert_key`, `severity`, `site`, `received_at`) sourced directly from `event.py:_handle_coordinator_update`.
+- Clarified that UniFi Alerts uses HA Event entities (not the hass event bus) — the `event_type` used by `_trigger_event` is `alert_received` and is a per-entity event type, not a bus event.
+- `TODO.md`: removed both nice-to-have items for Lovelace and automation README examples.
+- `ROADMAP.md`: ticked both v1.1.0 UX / Documentation items.
+
+---
+
 ## 2026-04-15 (session 10) — v1.1 security: credentials leak + unbounded webhook body
 
 ### Goal

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -66,6 +66,55 @@
 
 ---
 
+## 2026-04-21 (session 11) — Options flow: edit credentials and controller URL without re-adding integration
+
+### Goal
+
+Close the `Options flow: allow credentials and controller URL to be updated without re-adding integration` v1.1 roadmap item.  Previously the only way to change credentials or the controller URL was to delete the integration and set it up again from scratch — a painful workflow whenever the UniFi admin password rotated or the controller was moved to a new address.
+
+### `config_flow.py` — new `async_step_credentials` step in the options flow
+
+Added a new first step to `UniFiAlertsOptionsFlow` that optionally updates credentials before the existing categories step.  All fields are optional:
+
+- `CONF_CONTROLLER_URL`, `CONF_USERNAME`, `CONF_PASSWORD`, `CONF_API_KEY` — blank values mean "leave unchanged".
+- `CONF_VERIFY_SSL` — always defaulted from the current entry value.
+
+Router step (`async_step_init`) now delegates straight to `async_step_credentials`.  The legacy options-flow logic (category toggles, poll interval, clear timeout, site, webhook URL display) was renamed to `async_step_categories` and is reached either after a successful credentials update or when the credentials step is skipped (all fields blank).
+
+Validation flow for a non-blank submission:
+
+1. Merge the new fields over the existing `entry.data` to produce a test credential dict.
+2. Validate the URL scheme (`http`/`https` only — same check as initial setup).
+3. Construct a temporary `UniFiClient`, call `authenticate()` and `fetch_alarms()`.  Surface `invalid_auth`, `cannot_connect`, or `unknown` as form errors.
+4. If a new URL would collide with another configured entry for this domain, abort with `already_configured`.
+5. On success, call `hass.config_entries.async_update_entry(...)` with the merged `data`, updating `CONF_AUTH_METHOD` and `CONF_IS_UNIFI_OS` from the validated client too.
+
+Only fields the user actually filled in are overwritten — blank fields preserve the existing values.  This means a user can change just the password without having to re-enter the URL or API key.
+
+### `strings.json` / `translations/en.json` — new options-flow strings
+
+Added `options.step.credentials` (title, description, field labels) and the existing `options.error.invalid_auth`, `options.error.cannot_connect`, `options.error.invalid_url_scheme`, `options.error.unknown`, and `options.abort.already_configured`.  Both files remain byte-identical (CI enforces this).
+
+### Tests
+
+Added `TestOptionsFlowCredentials` in `tests/unit/test_config_flow.py` covering:
+
+- All fields blank → credentials step skipped, flows straight to categories.
+- Valid password update → `entry.data[CONF_PASSWORD]` overwritten, auth_method persisted.
+- Valid URL + API key update → both persisted, old username left untouched.
+- Invalid URL scheme → form re-shown with `invalid_url_scheme` error, no `async_update_entry` call.
+- Invalid auth → `invalid_auth` error on form.
+- URL collision with existing entry → abort with `already_configured`.
+- Verify SSL toggle → persisted even when other fields blank (treated as credentials change only if truly blank).
+
+Test count: 280 → 287 (+7).  `make check` passes cleanly.
+
+### Why this matters
+
+This is the last UX paper-cut from v1.0.  Combined with the config-entry repair flow (session 11a) it means credentials can now be rotated or corrected entirely in-place: HA surfaces a repair notification on auth failure, the user clicks through to a re-auth form, or they can proactively open Options → Configure to pre-emptively rotate a password.  No more "delete and re-add the integration" dance.
+
+---
+
 ## 2026-04-15 (session 10) — v1.1 security: credentials leak + unbounded webhook body
 
 ### Goal

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,6 +31,15 @@
 
 ---
 
+## 2026-04-21 (session 11) — Pin CI action versions to commit SHAs
+
+- Pinned all `uses:` lines across `ci.yml`, `release.yml`, and `version-check.yml` to full 40-character commit SHAs.
+- Actions pinned: `actions/checkout@v6`, `actions/setup-python@v6`, `home-assistant/actions/hassfest@master`, `hacs/action@main`, `softprops/action-gh-release@v2.6.1`.
+- Each pinned line includes a trailing `# <tag-or-ref>` comment so the human-readable version remains visible.
+- Eliminates supply-chain risk from floating `@master` / `@main` refs silently picking up breaking upstream changes.
+- No source code changes; `make check` passes (only YAML workflow files modified).
+- Removed the `### CI action versions are floating` entry from `TODO.md`; ticked the corresponding item in `ROADMAP.md` v1.1.0 Tech debt.
+
 ## 2026-04-15 (session 10) — v1.1 security: credentials leak + unbounded webhook body
 
 ### Goal

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,42 @@
 # History
 
+## 2026-04-15 (session 10) — v1.1 security: credentials leak + unbounded webhook body
+
+### Goal
+
+Close the two remaining security items from the v1.1.0 roadmap. Both were non-blocking for v1.0 but important for production quality.
+
+### `unifi_client.py` — credentials leak via exception messages
+
+`fetch_alarms()` and `_login_userpass()` both had `raise CannotConnectError(str(err)) from err`. Some `aiohttp.ClientError` subclasses embed the full request URL in their `__str__()` representation — which can include usernames, passwords, or API keys when the client was constructed with credentials in the URL. Changed both sites to `raise CannotConnectError(type(err).__name__) from err` so only the exception class name appears in HA logs.
+
+### `const.py` — new `WEBHOOK_MAX_BODY_BYTES` constant
+
+Added `WEBHOOK_MAX_BODY_BYTES = 8192` (8 KB) in the defaults section. 8 KB is far larger than any real UniFi alert payload and provides a generous safety margin.
+
+### `webhook_handler.py` — bounded webhook body read
+
+Replaced `payload = await request.json()` (unbounded) with a three-step pattern:
+1. `raw = await request.content.read(WEBHOOK_MAX_BODY_BYTES + 1)` — reads at most 8 193 bytes.
+2. If `len(raw) > WEBHOOK_MAX_BODY_BYTES` → log warning and return HTTP 413, callback not called.
+3. `payload = json.loads(raw.decode())` with `except (json.JSONDecodeError, UnicodeDecodeError, TypeError)` falling back to `{}`.
+
+Added `WEBHOOK_MAX_BODY_BYTES` to the import from `const`.
+
+### Tests
+
+- `test_unifi_client.py`: added `test_client_error_message_is_class_name_not_url` in `TestFetchAlarms` — asserts that a `ClientConnectionError` with a URL-containing message does not propagate the URL into `CannotConnectError.args[0]`; added `test_login_client_error_message_is_class_name_not_url` in `TestLoginUserpass` with the same assertion for the `_login_userpass` path.
+- `test_webhook_handler.py`: updated `make_request()` helper to mock `req.content.read` (returns `json.dumps(body).encode()`) instead of `req.json`; updated `test_malformed_json_uses_empty_dict_fallback` to pass raw invalid bytes via `content.read`; added `test_oversized_body_returns_413` — feeds `WEBHOOK_MAX_BODY_BYTES + 1` bytes and asserts HTTP 413 and no callback invocation. Added `import json` and `WEBHOOK_MAX_BODY_BYTES` to imports.
+
+All 280 tests pass; lint, mypy, HACS preflight, and translation drift checks clean.
+
+### Documentation
+
+- `ROADMAP.md`: ticked both security items `[x]` in the v1.1.0 section.
+- `TODO.md`: removed both resolved items from the Known issues section.
+
+---
+
 ## 2026-04-15 (session 9) — Move to two-branch model; add versioning CI enforcement
 
 ### Goal

--- a/README.md
+++ b/README.md
@@ -119,22 +119,79 @@ Plus rollup entities:
 
 ---
 
-## Automation example
+## Examples
+
+### Lovelace / dashboard card
+
+The snippet below creates an **Entities card** showing network health at a glance: the rollup binary sensor lights up when any category is alerting, followed by per-category binary sensors and the total open-alarm count. Swap in only the categories you have enabled.
+
+```yaml
+type: entities
+title: UniFi Network Health
+entities:
+  # Rollup — any category alerting
+  - entity: binary_sensor.unifi_alerts_any_alert
+    name: Any Alert Active
+
+  # Per-category binary sensors (ON = alert active)
+  - entity: binary_sensor.unifi_alerts_network_device
+    name: Device Offline/Online
+  - entity: binary_sensor.unifi_alerts_network_wan
+    name: WAN Offline/Latency
+  - entity: binary_sensor.unifi_alerts_security_threat
+    name: Threat / IDS
+  - entity: binary_sensor.unifi_alerts_security_firewall
+    name: Firewall Block
+  - entity: binary_sensor.unifi_alerts_power
+    name: Power / PoE
+
+  # Total open-alarm count (polled from controller)
+  - entity: sensor.unifi_alerts_total_open_alerts
+    name: Total Open Alerts
+```
+
+> **Tip:** For a more compact view, replace `type: entities` with `type: glance`. Per-category message sensors (`sensor.unifi_alerts_<category>_last_message`) and open-count sensors (`sensor.unifi_alerts_<category>_open_count`) can be added the same way.
+
+---
+
+### Automation example
+
+UniFi Alerts uses Home Assistant **Event entities** (not the hass event bus). When an alert arrives the entity fires a single event of type `alert_received` and its state updates with the full payload as attributes. Trigger on the event entity using `platform: state`; the payload is available on `trigger.to_state.attributes`.
+
+The event data attributes are:
+
+| Attribute | Description |
+|---|---|
+| `message` | Human-readable alert text from UniFi |
+| `category` | Integration category slug (e.g. `security_threat`) |
+| `device_name` | UniFi device that raised the alert |
+| `alert_key` | Raw UniFi event key (e.g. `EVT_IPS_ThreatDetected`) |
+| `severity` | Severity string from the UniFi payload |
+| `site` | UniFi site name (default: `default`) |
+| `received_at` | ISO-8601 UTC timestamp |
 
 ```yaml
 automation:
   - alias: "Notify on UniFi security threat"
     trigger:
-      - platform: event
-        event_type: unifi_alerts_event
-        event_data:
-          category: security_threat
+      - platform: state
+        entity_id: event.unifi_alerts_security_threat
+    condition:
+      # Only act when the entity actually fired a new event (state changes on each alert)
+      - condition: template
+        value_template: "{{ trigger.to_state.state != 'unavailable' }}"
     action:
-      - service: notify.mobile_app_your_phone
+      - service: persistent_notification.create
         data:
-          title: "⚠️ UniFi Security Alert"
-          message: "{{ trigger.event.data.message }}"
+          title: "UniFi Security Alert"
+          message: >
+            {{ trigger.to_state.attributes.get('message', 'Unknown alert') }}
+            (device: {{ trigger.to_state.attributes.get('device_name', 'unknown') }},
+            key: {{ trigger.to_state.attributes.get('alert_key', '') }})
+          notification_id: "unifi_security_threat"
 ```
+
+> **Tip:** Replace `event.unifi_alerts_security_threat` with any per-category event entity (e.g. `event.unifi_alerts_network_device`, `event.unifi_alerts_power`). Swap `persistent_notification.create` for `notify.mobile_app_your_phone` or any other notify action.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,7 +82,7 @@ Issues that are non-blocking for a first release but important for production qu
 
 ### Tech debt
 
-- [ ] Pin CI action versions to commit SHAs instead of `@master` / `@main` (`ci.yml`)
+- [x] Pin CI action versions to commit SHAs instead of `@master` / `@main` (`ci.yml`)
 - [ ] Config entry repair flow — surface a HA repair notification when auth fails post-setup (`homeassistant.helpers.issue_registry`)
 - [ ] Options flow: allow credentials and controller URL to be updated without re-adding integration
 - [ ] Service calls: `unifi_alerts.clear_category` and `unifi_alerts.clear_all` (`services.py`, `services.yaml`)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,6 +89,69 @@ Issues that are non-blocking for a first release but important for production qu
 
 ---
 
+## v1.2.0 — Critical-review hardening (pre-HACS-default)
+
+A second-opinion pass after the v1.1 PRs landed surfaced a set of items that are not blocking for a stable release but should be closed before submitting to the HACS default catalogue.  These are the "what did we miss?" findings.  Ordered by impact.
+
+### Reliability / correctness
+
+- [ ] **Webhook ID collision on multi-entry (CRITICAL)** — `webhook_id_for_category()` returns `unifi_alerts_{category}` without including `entry_id` (`const.py:183-184`).  Two config entries (multi-controller households) will collide on webhook registration — the second entry silently overwrites the first's handlers.  This is the root cause behind the multi-entry isolation gap noted in the Testing section below.  Fix: include `entry_id` (or a short hash) in the webhook ID, update `WebhookManager` and the config-flow URL display.  Affects `const.py:183-184`, `webhook_handler.py:56`, `config_flow.py:200-205,462-465`.
+- [ ] `UniFiClient.fetch_alarms()` caps results at `limit=200` with no pagination loop — controllers with >200 open alarms silently drop the rest (`unifi_client.py:104`).  Remove the `limit` param so the controller returns the full set.
+- [ ] `fetch_alarms()` passes `ssl=self._config.get(CONF_VERIFY_SSL, False)` — if the key is somehow missing from `_config`, SSL verification silently turns OFF (`unifi_client.py:106`).  Change the fallback to `DEFAULT_VERIFY_SSL` (True) so a missing key fails closed, not open.
+- [ ] **SSL fail-open in 4 additional call sites** — the same `self._config.get(CONF_VERIFY_SSL, False)` pattern with a `False` default exists in `_detect_unifi_os()` (`unifi_client.py:156`), `_verify_api_key()` (`unifi_client.py:202`), `_login_userpass()` (`unifi_client.py:238`), and `close()` (`unifi_client.py:139`).  All must be changed to `DEFAULT_VERIFY_SSL` alongside the `fetch_alarms()` fix above.
+- [ ] `_category_states` is rebuilt from scratch on every config-entry reload — `alert_count` and `last_alert` are discarded whenever the user tweaks an option (`coordinator.py:59-62`).  Persist the last-seen state across reloads (e.g. via `hass.data[DOMAIN][entry.entry_id]["_last_states"]` saved in `async_unload_entry` and restored in `async_setup_entry`).
+- [ ] `WebhookManager.register_all()` registers webhooks inside a loop with no try/finally — if one registration fails partway through, the already-registered ones are not tracked in `self._registered`, so `unregister_all()` cannot clean them up (`webhook_handler.py:47-73`).  Wrap per-iteration with `try: register; self._registered.append(...) except: ...` and/or a finally-driven rollback.
+- [ ] **`datetime.fromisoformat()` called on epoch-millisecond input** (`models.py:52-57`) — the code comment says "UniFi stores timestamps as epoch milliseconds in some fields" but the code calls `datetime.fromisoformat(str(ts))`, which rejects numeric strings and silently falls through to `datetime.now(UTC)`. Every poll-sourced alert therefore has its `received_at` replaced with the poll time, breaking ordering and the "when did this actually fire?" attribute. Add an epoch-ms branch (`datetime.fromtimestamp(int(ts) / 1000, tz=UTC)`) before the ISO fallback; log at WARNING when neither matches.
+- [ ] **`open_count` never updated on webhook path** — `push_alert()` updates `is_alerting` and `alert_count` but `open_count` stays at whatever the last poll returned until the next poll cycle (`coordinator.py:123-143`).  Users automating on the open-count sensor will see stale values between polls.  Consider incrementing `open_count` optimistically in `push_alert()` (and letting the next poll correct it).
+- [ ] **`UniFiClient.close()` silently swallows logout errors** (`unifi_client.py:142-143`) — `except Exception: pass` in the logout path means a failed logout leaves session tokens valid on the controller indefinitely. Log at WARNING with `type(err).__name__` so operators can see the issue without leaking controller response bodies.
+- [ ] **Webhook decode errors silently converted to empty payload** (`webhook_handler.py:105-107`) — `UnicodeDecodeError` and `JSONDecodeError` are both caught and replaced with `{}`, so a misconfigured controller sending non-UTF-8 or truncated JSON produces an alert with `"Unknown alert"` and no key, with nothing in logs. Log at WARNING with the exception class name and first 80 bytes of the raw body (not the full body, for size).
+
+### Security
+
+- [ ] Webhook secret cannot be rotated post-setup — it is generated once in `config_flow.py:84` and stored immutably.  If a user believes the token was leaked, the only recovery is delete-and-re-add.  Add a "Regenerate webhook secret" action to the options flow (reuses the `secrets.token_urlsafe(32)` call, updates `entry.data[CONF_WEBHOOK_SECRET]`, re-registers webhooks, shows new URLs).
+- [ ] **Non-constant-time webhook token comparison** (`webhook_handler.py:89`) — `request.query.get("token") != secret` is vulnerable to a timing side-channel that leaks the secret byte-by-byte. Replace with `hmac.compare_digest(request.query.get("token", ""), secret)`.
+- [ ] **Webhook URLs containing `?token=<secret>` logged at DEBUG** (`__init__.py:92-95`) — users who enable DEBUG logging (commonly requested for troubleshooting) will see tokens in plain text in logs, which they then paste into GitHub issues. Redact `?token=...` from the logged URL, or log only the category→webhook-id mapping.
+- [ ] **Full webhook payload logged at DEBUG** (`webhook_handler.py:109`) — the entire controller payload is echoed to logs. Narrow to `{category, alert_key, severity, device_name}` to avoid accidentally surfacing sensitive fields from future UniFi firmware versions.
+- [ ] **`allow_redirects=True` on unauthenticated probes** (`unifi_client.py:162,178`) — the UniFi-OS detection calls follow redirects without validating the final host matches the configured controller URL. A compromised DNS or on-path attacker could redirect the probe to an attacker-controlled host that returns headers that complete "detection". Set `allow_redirects=False` on probes, or assert `final_url.host == configured_host` before trusting the response.
+- [ ] **Config flow creates bare `aiohttp.ClientSession` instead of HA's `async_get_clientsession`** — `config_flow.py:80,234,343` use `async with aiohttp.ClientSession()` which bypasses HA's proxy configuration, connection pooling, and the `verify_ssl` setting from the form.  Fix: use `async_get_clientsession(self.hass, verify_ssl=user_input.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL))`.
+- [ ] **Credential fragments may leak in `__init__.py` exception messages** — Lines 53-57 pass `err` into `ConfigEntryAuthFailed` and `ConfigEntryNotReady` messages.  If the underlying exception includes URL fragments or auth details, they will appear in HA logs.  The v1.1 fix in `unifi_client.py` logs `type(err).__name__` only; apply the same pattern here (`__init__.py:53-57`).
+- [ ] **No webhook rate limiting / debounce** — a misconfigured UniFi Alarm Manager or noisy category can flood the webhook endpoint, generating a coordinator state update + event entity fire for every POST.  No cooldown exists.  Fix: add a configurable per-category cooldown (e.g. 5s default) in `push_alert()` that skips duplicate `(category, key)` pairs within the window (`coordinator.py:123`).
+
+### Type safety / tech debt
+
+- [ ] `pyproject.toml` has `strict = false` for mypy — `UniFiClient.config` flows as `dict[str, Any]` throughout, hiding type errors.  Migrate `config: dict[str, Any]` to a `TypedDict` or frozen dataclass so `CONF_*` keys are checked, then bump to `strict = true` (or a stricter subset).
+- [ ] Entity naming is ad-hoc — each platform file hard-codes `_attr_name = f"{CATEGORY_LABELS[cat]} Foo"`.  Adopt the `has_entity_name = True` + `_attr_translation_key = "..."` pattern so the strings live in `strings.json` (`binary_sensor.py:60`, `sensor.py:56,109`, `event.py:63`, `button.py`).  Unlocks localisation and cleaner registry IDs.
+- [ ] No sensor `device_class` on the open-count or rollup-count sensors (`sensor.py:96,128`) — add a device_class where one fits (none of HA's built-ins map cleanly to "open alert count"; consider `None` + richer `state_class`).
+- [ ] **Config flow accesses private `client._is_unifi_os`** — `config_flow.py:99,253,372` read a private attribute directly.  If the client internals change, this breaks silently.  Fix: expose `is_unifi_os` as a public `@property` on `UniFiClient` (`unifi_client.py`).
+- [ ] **`EventDeviceClass.BUTTON` is semantically incorrect for alert events** — `event.py:51` uses `BUTTON` as "closest semantic match" but this is misleading in device-class-based automation UIs.  Fix: remove `_attr_device_class` entirely (or set to `None`); no built-in class fits "alert received" (`event.py:51`).
+- [ ] **Clear buttons and diagnostic entities lack `entity_category`** — `UniFiClearCategoryButton` and `UniFiClearAllButton` don't set `_attr_entity_category = EntityCategory.CONFIG` (`button.py:37,63`).  Without this, they appear on the default dashboard and in voice assistant entity lists, which is confusing.  Similarly, message sensors could use `EntityCategory.DIAGNOSTIC`.
+
+### Testing
+
+- [ ] No integration-level test covers two UniFi Alerts config entries active at once — services, webhooks, and coordinator state could leak between them.  Add a multi-entry fixture in `tests/unit/test_init.py` and assert coordinator isolation.  **Note:** the webhook ID collision above (`const.py:183`) means this test will _fail_ until the code is fixed — write the test first as a red-green pair.
+- [ ] No test asserts that a webhook arriving while `_async_update_data()` is mid-await does not produce a regressed `is_alerting` state.  The guard at `coordinator.py:92` (`if alerts and not state.is_alerting`) should prevent it, but there is no test that verifies the interleaving.  Add one in `test_coordinator.py`.
+- [ ] **No test for `from_api_alarm` with numeric (epoch-millisecond) timestamp** — the timestamp parsing code at `models.py:54-57` has an untested edge case where numeric values silently fall back to `now()`.  Add a `test_from_api_alarm_epoch_ms` test (`test_models.py`).
+- [ ] **No test for alert deduplication or rate limiting** — once the webhook debounce is implemented (see Security section), add tests verifying that rapid-fire duplicate alerts within the cooldown window are suppressed.
+
+### Release process / repo hygiene
+
+- [ ] No `CHANGELOG.md` at repo root — the GH release workflow auto-writes release notes but a committed CHANGELOG is what HACS-default reviewers typically look for.  Add `CHANGELOG.md` following Keep-a-Changelog and populate retrospectively from v1.0 onwards.
+- [ ] With GitHub Actions now pinned to SHAs (v1.1), nothing keeps them fresh.  Add Renovate or Dependabot config targeting `github-actions` so pinned SHAs are proposed as PRs on upstream updates.
+- [ ] No `SECURITY.md`, `CODEOWNERS`, or GitHub issue templates.  Adds reviewer signal for HACS-default approval and channels bug reports away from general issues.
+
+### Documentation
+
+- [ ] No supported-firmware matrix in README/info.md — users don't know if their UDM-SE / UCG / UX / CloudKey Gen2 model is expected to work.  Add a small table of tested controller models / firmware versions with any known quirks.
+- [ ] No troubleshooting / FAQ section — common issues (local_only webhooks, self-signed certs, UniFi OS vs legacy, API-key generation paths) are scattered across the README prose.  Consolidate into a Troubleshooting section.
+- [ ] **No uninstall instructions** (README / info.md) — a first-time user who decides to remove the integration has no guidance. Add a one-line "To remove: Settings → Devices & Services → UniFi Alerts → ⋮ → Delete" under Setup.
+- [ ] **`info.md` doesn't warn about the local-network requirement up front** — remote-access (Nabu Casa, reverse-proxy) users install it, configure webhook URLs pointing at their cloud HA, and get silent failure. Add a bold "⚠ Local network only" banner to the first paragraph.
+- [ ] **Setup flow doesn't warn that webhook URLs must be copied before submitting** — URLs are only shown on the final step of the config flow; clicking Submit closes the dialog and users don't realise they missed the copy step. Add a `strings.json` note on the webhook-URLs step: "Copy all URLs into UniFi Network → Settings → Notifications → Alarm Manager **before** clicking Submit."
+- [ ] **No privacy / data retention section in README** — users don't know which UniFi payload fields end up in HA state (message, device_name, site, severity, raw) or how long they persist. Add a short "Data handling" section: what fields are stored, that nothing leaves the local network, and that auto-clear removes `is_alerting`/`last_alert` after the configured timeout.
+- [ ] **Automation example doesn't document the "category disabled → event entity unavailable" edge case** — if a user disables the `security_threat` category via options after wiring up an automation, the event entity becomes unavailable and the automation silently stops firing. Add a one-liner caveat to the README automation section.
+- [ ] **`unique_id` format is undocumented** (README) — power users wiring entities into long-lived automations don't know whether renaming entities in the UI is safe. Document the `{entry_id}_{category}_{sensor_type}` pattern and explicitly note that UI renames preserve `unique_id`, so automations are safe.
+
+---
+
 ## v2.0.0 — HACS default catalogue
 
 Prerequisites for submitting to https://github.com/hacs/default.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,7 +83,7 @@ Issues that are non-blocking for a first release but important for production qu
 ### Tech debt
 
 - [x] Pin CI action versions to commit SHAs instead of `@master` / `@main` (`ci.yml`)
-- [ ] Config entry repair flow — surface a HA repair notification when auth fails post-setup (`homeassistant.helpers.issue_registry`)
+- [x] Config entry repair flow — surface a HA repair notification when auth fails post-setup (`homeassistant.helpers.issue_registry`)
 - [ ] Options flow: allow credentials and controller URL to be updated without re-adding integration
 - [x] Service calls: `unifi_alerts.clear_category` and `unifi_alerts.clear_all` (`services.py`, `services.yaml`)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,7 +85,7 @@ Issues that are non-blocking for a first release but important for production qu
 - [x] Pin CI action versions to commit SHAs instead of `@master` / `@main` (`ci.yml`)
 - [ ] Config entry repair flow — surface a HA repair notification when auth fails post-setup (`homeassistant.helpers.issue_registry`)
 - [ ] Options flow: allow credentials and controller URL to be updated without re-adding integration
-- [ ] Service calls: `unifi_alerts.clear_category` and `unifi_alerts.clear_all` (`services.py`, `services.yaml`)
+- [x] Service calls: `unifi_alerts.clear_category` and `unifi_alerts.clear_all` (`services.py`, `services.yaml`)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,8 +73,8 @@ Issues that are non-blocking for a first release but important for production qu
 
 ### UX / Documentation
 
-- [ ] Lovelace / dashboard YAML example in README
-- [ ] Automation example in README — verify correct `event_type` and `event_data` schema
+- [x] Lovelace / dashboard YAML example in README
+- [x] Automation example in README — verify correct `event_type` and `event_data` schema
 
 ### QA
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,7 +95,7 @@ Prerequisites for submitting to https://github.com/hacs/default.
 
 - [ ] Replace placeholder `brand/icon.png` with a real 256×256 icon
 - [ ] At least 2 tagged releases with passing CI
-- [ ] Create `info.md` (HACS display page)
+- [x] Create `info.md` (HACS display page)
 - [ ] All v1.x issues resolved
 - [ ] Submit PR to `hacs/default`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,11 +2,13 @@
 
 This file maps TODO items to planned releases. Items within each release are ordered by priority — complete them top-to-bottom. Check off each item as it is merged to `main`.
 
-> **Current status:** v1.0.0-pre3 ready to tag. All v1.0.0 blockers resolved. Remaining open items target v1.1.0 (security hardening, reliability). CI is green.
+> **Branching model:** all development happens on `dev` (pre-release versions: `X.Y.Z-preN`). Stable releases are tagged on `main` after a PR merge. See `CLAUDE.md § Branching strategy and versioning` for the full workflow.
+
+> **Current status:** v1.0.0 released. Branch model + CI versioning enforcement in place. Active development continues on `dev` targeting v1.1.0.
 
 ---
 
-## v1.0.0 — First stable release
+## v1.0.0 — First stable release ✓
 
 All blocking bugs, security issues, and UX gaps that will immediately affect new users.
 
@@ -50,7 +52,13 @@ All blocking bugs, security issues, and UX gaps that will immediately affect new
 
 ## v1.1.0 — Security hardening + reliability
 
-Issues that are non-blocking for a first release but important for production quality.
+Issues that are non-blocking for a first release but important for production quality. Development for this release happens on `dev` under version `1.1.0-preN`.
+
+### Infrastructure (completed as part of v1.0.0 → v1.1.0 transition)
+
+- [x] Move to two-branch model (`main` = stable, `dev` = pre-release)
+- [x] Add `version-check.yml` CI: enforce `X.Y.Z` on `main`, `X.Y.Z-preN` on `dev`
+- [x] Update `release.yml` CI: trigger on tags, auto-detect pre-release, validate tag vs manifest
 
 ### Security
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,7 +69,7 @@ Issues that are non-blocking for a first release but important for production qu
 ### Bugs / reliability
 
 - [x] No pagination on `/alarm` endpoint — `limit=200` added (`unifi_client.py:92`)
-- [ ] Polling re-auth is fire-and-forget — misleading log message when re-auth succeeds but second poll fails for a different reason (`coordinator.py`)
+- [x] Polling re-auth is fire-and-forget — misleading log message when re-auth succeeds but second poll fails for a different reason (`coordinator.py`)
 
 ### UX / Documentation
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,8 +63,8 @@ Issues that are non-blocking for a first release but important for production qu
 ### Security
 
 - [x] Unvalidated controller URL allows SSRF — scheme validation added (`config_flow.py`); loopback/link-local rejection remains optional
-- [ ] Unbounded webhook body stored in memory — apply `max_bytes` cap on `request.json()` (`webhook_handler.py:86`)
-- [ ] Credentials leak risk via exception messages in logs — log class name only, not `str(err)` (`unifi_client.py:105,181`)
+- [x] Unbounded webhook body stored in memory — apply `max_bytes` cap on `request.json()` (`webhook_handler.py:86`)
+- [x] Credentials leak risk via exception messages in logs — log class name only, not `str(err)` (`unifi_client.py:105,181`)
 
 ### Bugs / reliability
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,7 +84,7 @@ Issues that are non-blocking for a first release but important for production qu
 
 - [x] Pin CI action versions to commit SHAs instead of `@master` / `@main` (`ci.yml`)
 - [x] Config entry repair flow — surface a HA repair notification when auth fails post-setup (`homeassistant.helpers.issue_registry`)
-- [ ] Options flow: allow credentials and controller URL to be updated without re-adding integration
+- [x] Options flow: allow credentials and controller URL to be updated without re-adding integration
 - [x] Service calls: `unifi_alerts.clear_category` and `unifi_alerts.clear_all` (`services.py`, `services.yaml`)
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -17,10 +17,6 @@ If a restart is required, investigate why (e.g. Python module caching, import-ti
 
 ## 🟢 Nice-to-have
 
-### Config entry repair flow
-If authentication fails after setup (e.g. password changed), HA should surface a repair notification prompting the user to re-enter credentials rather than just showing the entry as unavailable.
-**Reference:** `homeassistant.helpers.issue_registry` and `async_create_issue`.
-
 ### Options flow: allow credentials to be updated without re-adding integration
 Currently the only way to change the controller URL or credentials is to delete and re-add the integration. Add a re-auth step to the options flow. Document the current limitation in the README as a workaround.
 

--- a/TODO.md
+++ b/TODO.md
@@ -41,8 +41,5 @@ After the integration is stable and passes `hassfest`, submit a PR to https://gi
 ### `_device_info` duplication
 The `_device_info()` helper function is duplicated identically across `binary_sensor.py`, `sensor.py`, `event.py`, and `button.py`. Intentional for platform isolation but could be extracted to a shared `entity_base.py` mixin if it becomes a maintenance burden.
 
-### Polling re-auth is fire-and-forget
-In `coordinator._async_update_data`, if re-auth succeeds but the second `categorise_alarms()` call fails for a different reason, the error path is the generic `CannotConnectError` branch which may give a misleading log message.
-
 ### CI action versions are floating (`@master`, `@main`)
 `home-assistant/actions/hassfest@master` and `hacs/action@main` are not pinned to a SHA. A breaking upstream change or supply-chain compromise would silently affect CI. Pin to commit SHAs and update periodically.

--- a/TODO.md
+++ b/TODO.md
@@ -43,5 +43,3 @@ After the integration is stable and passes `hassfest`, submit a PR to https://gi
 ### `_device_info` duplication
 The `_device_info()` helper function is duplicated identically across `binary_sensor.py`, `sensor.py`, `event.py`, and `button.py`. Intentional for platform isolation but could be extracted to a shared `entity_base.py` mixin if it becomes a maintenance burden.
 
-### CI action versions are floating (`@master`, `@main`)
-`home-assistant/actions/hassfest@master` and `hacs/action@main` are not pinned to a SHA. A breaking upstream change or supply-chain compromise would silently affect CI. Pin to commit SHAs and update periodically.

--- a/TODO.md
+++ b/TODO.md
@@ -44,14 +44,6 @@ After the integration is stable and passes `hassfest`, submit a PR to https://gi
 
 ## 🐛 Known issues / technical debt
 
-### Unbounded webhook body stored in memory
-`request.json()` in `webhook_handler.py` reads the full request body without a size cap. A large or malicious payload could spike memory usage.
-**Fix:** Apply a `max_bytes` cap before deserialising. See `webhook_handler.py:86`.
-
-### Credentials leak risk via exception messages in logs
-`unifi_client.py` logs `str(err)` in several exception handlers. Some aiohttp exceptions embed the URL (including credentials) in their string representation.
-**Fix:** Log the exception class name only (`type(err).__name__`). See `unifi_client.py:105,181`.
-
 ### `_device_info` duplication
 The `_device_info()` helper function is duplicated identically across `binary_sensor.py`, `sensor.py`, `event.py`, and `button.py`. Intentional for platform isolation but could be extracted to a shared `entity_base.py` mixin if it becomes a maintenance burden.
 

--- a/TODO.md
+++ b/TODO.md
@@ -24,10 +24,6 @@ If authentication fails after setup (e.g. password changed), HA should surface a
 ### Options flow: allow credentials to be updated without re-adding integration
 Currently the only way to change the controller URL or credentials is to delete and re-add the integration. Add a re-auth step to the options flow. Document the current limitation in the README as a workaround.
 
-### Service calls
-Expose `unifi_alerts.clear_category` and `unifi_alerts.clear_all` as HA services in addition to the button entities. This allows clearing alerts from automations without needing a button press.
-**File to create:** `services.py` (register with `hass.services.async_register`), `services.yaml` (service descriptions).
-
 ### Replace placeholder `brand/icon.png` with a real 256×256 icon
 The current brand asset is a minimal placeholder PNG. Replace with a proper UniFi-themed icon before submitting to the HACS default catalogue.
 

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,76 @@ After the integration is stable and passes `hassfest`, submit a PR to https://gi
 
 ---
 
+## 🔥 v1.2 critical-review findings (pre-HACS-default hardening)
+
+A comprehensive audit after the v1.1 PRs landed surfaced these items. Full detail (with file:line anchors and suggested fixes) is in `ROADMAP.md § v1.2.0`. Grouped by impact:
+
+### Reliability / correctness
+- **🔴 Webhook ID collision on multi-entry (CRITICAL):** `webhook_id_for_category()` returns `unifi_alerts_{category}` without `entry_id` — two config entries silently overwrite each other's webhook handlers (`const.py:183-184`). This is the root cause of the multi-entry isolation gap.
+- **Unbounded alarm list:** `UniFiClient.fetch_alarms()` silently caps at `limit=200`. Remove the `limit` param (`unifi_client.py:104`).
+- **SSL fail-open on missing key:** `ssl=self._config.get(CONF_VERIFY_SSL, False)` — change fallback to `DEFAULT_VERIFY_SSL` so a missing key fails closed (`unifi_client.py:106`).
+- **SSL fail-open in 4 more call sites:** same `False` default in `_detect_unifi_os()` (`:156`), `_verify_api_key()` (`:202`), `_login_userpass()` (`:238`), and `close()` (`:139`).
+- **Category state lost on reload:** `_category_states` is rebuilt from scratch on every options change; persist `alert_count` and `last_alert` across reloads (`coordinator.py:59-62`).
+- **Partial webhook registration leak:** `WebhookManager.register_all()` has no try/finally — a failure mid-loop leaves registered hooks untracked (`webhook_handler.py:47-73`).
+- **Epoch-ms timestamps silently dropped:** `from_api_alarm()` calls `datetime.fromisoformat()` on numeric timestamps, fails, falls back to `now(UTC)` — real alarm time lost (`models.py:52-57`). Add an epoch-ms branch before the ISO fallback; log at WARNING when neither matches.
+- **`open_count` stale on webhook path:** `push_alert()` updates `is_alerting` and `alert_count` but `open_count` stays at whatever the last poll returned (`coordinator.py:123-143`).
+- **`close()` swallows logout errors:** `unifi_client.py:142-143` (`except Exception: pass`). Log at WARNING with class name so operators see stuck sessions.
+- **Webhook decode errors silently dropped:** `webhook_handler.py:105-107` — `UnicodeDecodeError` / `JSONDecodeError` produces an empty payload with no log entry; log at WARNING.
+
+### Security
+- **Webhook secret cannot be rotated:** add a "Regenerate webhook secret" action to the options flow (reuses `secrets.token_urlsafe(32)`, updates `entry.data`, re-registers webhooks) (`config_flow.py:84`).
+- **Timing attack on token comparison:** `webhook_handler.py:89` uses `!=`; switch to `hmac.compare_digest()`.
+- **Debug logs leak webhook tokens:** `__init__.py:92-95` logs full `?token=...` URLs at DEBUG; redact tokens before logging.
+- **Debug logs leak full webhook payloads:** `webhook_handler.py:109`; narrow to known-safe fields only.
+- **`allow_redirects=True` on probes:** `unifi_client.py:162,178` — disable redirects or assert final-URL host matches configured host.
+- **Config flow creates bare `aiohttp.ClientSession`:** bypasses HA's proxy config, connection pool, and SSL settings. Should use `async_get_clientsession(self.hass, verify_ssl=...)` (`config_flow.py:80,234,343`).
+- **Credential fragments in `__init__.py` exception messages:** `err` is passed into `ConfigEntryAuthFailed`/`ConfigEntryNotReady`, may expose URL fragments or auth details in logs (`__init__.py:53-57`).
+- **No webhook rate limiting / debounce:** a noisy category or misconfigured sender can flood the webhook endpoint with no cooldown, generating unbounded state updates and event fires (`coordinator.py:123`).
+
+### Type safety / tech debt
+- **`mypy strict = false`:** migrate `UniFiClient.config: dict[str, Any]` to a TypedDict / frozen dataclass, then bump `pyproject.toml` to `strict = true`.
+- **Ad-hoc entity naming:** adopt `has_entity_name = True` + `_attr_translation_key` pattern across `binary_sensor.py`, `sensor.py`, `event.py`, `button.py` so names live in `strings.json`.
+- **No sensor `device_class`:** consider what fits on the open-count / rollup-count sensors (`sensor.py:96,128`).
+- **Config flow accesses private `client._is_unifi_os`:** expose as a public `@property` on `UniFiClient` (`config_flow.py:99,253,372`).
+- **`EventDeviceClass.BUTTON` wrong for alert events:** remove the device_class or set to `None` (`event.py:51`).
+- **Clear buttons lack `entity_category`:** set `_attr_entity_category = EntityCategory.CONFIG` on `UniFiClearCategoryButton` and `UniFiClearAllButton` (`button.py:37,63`).
+
+### Testing
+- **No multi-entry integration test:** verify two UniFi Alerts entries don't cross-contaminate coordinator/webhook state. Note: the webhook ID collision above means this test will fail until the code is fixed — write it first as a red-green pair.
+- **No interleaving test:** assert that a webhook arriving mid-poll doesn't regress `is_alerting` (guard at `coordinator.py:92` should prevent it, but is untested).
+- **No test for epoch-ms timestamp parsing:** add `test_from_api_alarm_epoch_ms` to `test_models.py`.
+- **No test for dedup/rate limiting:** once the webhook debounce is implemented, add tests verifying cooldown behaviour.
+
+### Release process / repo hygiene
+- **No `CHANGELOG.md`:** add Keep-a-Changelog file, back-fill from v1.0.
+- **Pinned SHAs need a refresh mechanism:** add Renovate or Dependabot config for `github-actions` updates.
+- **Missing repo-hygiene files:** `SECURITY.md`, `CODEOWNERS`, GitHub issue templates.
+
+### Documentation
+- **No supported-firmware matrix:** small table of tested UDM-SE / UCG / UX / CloudKey Gen2 models with any known quirks.
+- **No troubleshooting / FAQ section:** consolidate scattered notes (local_only webhooks, self-signed certs, UniFi OS vs legacy, API-key paths).
+- **No uninstall instructions** in README / info.md.
+- **`info.md` missing upfront local-network warning** — remote-access / Nabu Casa users hit silent failure.
+- **Setup flow doesn't warn "copy URLs before Submit"** — the URLs screen is the final step; users close the dialog without copying.
+- **No privacy / data-retention section** in README explaining which UniFi payload fields are stored in HA state.
+- **Automation README example** doesn't document that disabling a category in options makes its event entity unavailable, breaking dependent automations.
+- **`unique_id` format is undocumented** — users wiring into long-lived automations don't know if UI renames are safe.
+
+### Split `tests/unit/test_config_flow.py` into a package
+**Problem:** `test_config_flow.py` is ~1060 lines with four logically independent test classes (`TestConfigFlowSteps`, `TestOptionsFlowSteps`, `TestOptionsFlowCredentials`, `TestReauthFlow`). The file is hard to load into context in full, and rebase chains that touch multiple classes (as with PR #19 + PR #20) produce interleaved merge conflicts that are tedious to reconstruct.
+**Fix:** Convert to a package:
+```
+tests/unit/config_flow/
+  __init__.py
+  conftest.py           # shared fixtures + _make_options_flow / _make_reauth_flow helpers
+  test_setup.py         # TestConfigFlowSteps (credentials → categories → done)
+  test_options.py       # TestOptionsFlowSteps + TestOptionsFlowCredentials
+  test_reauth.py        # TestReauthFlow
+```
+Move `_make_options_flow`, `_make_reauth_flow`, and any shared `MOCK_*` constants into the new `conftest.py`. Do not split the other test files — they are all under 500 lines and healthy. Target: a `v1.1.0-preN` checkpoint on `dev`.
+
+---
+
 ## 🐛 Known issues / technical debt
 
 ### `_device_info` duplication

--- a/TODO.md
+++ b/TODO.md
@@ -17,9 +17,6 @@ If a restart is required, investigate why (e.g. Python module caching, import-ti
 
 ## 🟢 Nice-to-have
 
-### Options flow: allow credentials to be updated without re-adding integration
-Currently the only way to change the controller URL or credentials is to delete and re-add the integration. Add a re-auth step to the options flow. Document the current limitation in the README as a workaround.
-
 ### Replace placeholder `brand/icon.png` with a real 256×256 icon
 The current brand asset is a minimal placeholder PNG. Replace with a proper UniFi-themed icon before submitting to the HACS default catalogue.
 

--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,8 @@ The current brand asset is a minimal placeholder PNG. Replace with a proper UniF
 
 ### HACS default repository submission
 After the integration is stable and passes `hassfest`, submit a PR to https://github.com/hacs/default to be listed in the default HACS catalogue. Requirements: 2+ releases, passing CI, `hacs.json`, `info.md`, HA brand icon.
+- `info.md` is now present (added session 11).
+- Remaining: 2+ tagged releases, real brand icon (replace placeholder), PR submission to hacs/default.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -24,12 +24,6 @@ If authentication fails after setup (e.g. password changed), HA should surface a
 ### Options flow: allow credentials to be updated without re-adding integration
 Currently the only way to change the controller URL or credentials is to delete and re-add the integration. Add a re-auth step to the options flow. Document the current limitation in the README as a workaround.
 
-### Lovelace card / dashboard example in README
-Add a simple Lovelace YAML snippet showing how to build a network health card using the binary sensors and count sensors. Reduces friction for new users.
-
-### Automation example in README
-Add a simple automation YAML example showing how to trigger on the `unifi_alerts` event entity. Verify the correct `event_type` and `event_data` schema before publishing.
-
 ### Service calls
 Expose `unifi_alerts.clear_category` and `unifi_alerts.clear_all` as HA services in addition to the button entities. This allows clearing alerts from automations without needing a button press.
 **File to create:** `services.py` (register with `hass.services.async_register`), `services.yaml` (service descriptions).

--- a/custom_components/unifi_alerts/__init__.py
+++ b/custom_components/unifi_alerts/__init__.py
@@ -7,7 +7,7 @@ import logging
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
@@ -20,7 +20,7 @@ from .const import (
 )
 from .coordinator import UniFiAlertsCoordinator
 from .services import async_register_services, async_unregister_services
-from .unifi_client import UniFiClient
+from .unifi_client import InvalidAuthError, UniFiClient
 from .webhook_handler import WebhookManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -49,6 +49,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await client.authenticate()
+    except InvalidAuthError as err:
+        _LOGGER.error("Authentication failed for UniFi controller: %s", err)
+        raise ConfigEntryAuthFailed(f"Invalid credentials for UniFi controller: {err}") from err
     except Exception as err:  # noqa: BLE001
         _LOGGER.error("Failed to authenticate to UniFi controller: %s", err)
         raise ConfigEntryNotReady(f"Could not connect to UniFi controller: {err}") from err

--- a/custom_components/unifi_alerts/__init__.py
+++ b/custom_components/unifi_alerts/__init__.py
@@ -19,6 +19,7 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import UniFiAlertsCoordinator
+from .services import async_register_services, async_unregister_services
 from .unifi_client import UniFiClient
 from .webhook_handler import WebhookManager
 
@@ -78,6 +79,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Register domain services (idempotent — safe for multiple entries)
+    async_register_services(hass)
+
     # Re-register webhooks and reload options when the entry is updated
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
@@ -103,6 +107,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         client = entry_data.get("client")
         if client:
             await client.close()
+        # Unregister domain-level services only when the last entry is gone
+        if not hass.data.get(DOMAIN):
+            async_unregister_services(hass)
     return unload_ok
 
 

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -285,6 +285,131 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
         self._config_entry = config_entry
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Router: always start with the credentials step."""
+        return await self.async_step_credentials()
+
+    async def async_step_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Optional step: update controller URL and/or credentials.
+
+        All fields are optional.  If the user leaves every field blank the step
+        is skipped and the flow continues straight to the categories step.  If
+        any credential field is filled in, the new values are validated against
+        the controller before being saved.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            new_url_raw: str = (user_input.get(CONF_CONTROLLER_URL) or "").strip()
+            new_username: str = (user_input.get(CONF_USERNAME) or "").strip()
+            new_password: str = (user_input.get(CONF_PASSWORD) or "").strip()
+            new_api_key: str = (user_input.get(CONF_API_KEY) or "").strip()
+            # verify_ssl always comes through as a bool (voluptuous default)
+            new_verify_ssl: bool = user_input.get(
+                CONF_VERIFY_SSL,
+                self._config_entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+            )
+
+            credentials_changed = bool(new_url_raw or new_username or new_password or new_api_key)
+
+            if not credentials_changed:
+                # Nothing changed — skip straight to categories
+                return await self.async_step_categories()
+
+            # Determine the effective values to test
+            effective_url = (
+                new_url_raw.rstrip("/")
+                if new_url_raw
+                else self._config_entry.data[CONF_CONTROLLER_URL]
+            )
+
+            if URL(effective_url).scheme not in ("http", "https"):
+                errors[CONF_CONTROLLER_URL] = "invalid_url_scheme"
+            else:
+                # Build a merged credential dict for the test client
+                test_data: dict[str, Any] = {
+                    **self._config_entry.data,
+                    CONF_CONTROLLER_URL: effective_url,
+                    CONF_VERIFY_SSL: new_verify_ssl,
+                }
+                if new_username:
+                    test_data[CONF_USERNAME] = new_username
+                if new_password:
+                    test_data[CONF_PASSWORD] = new_password
+                if new_api_key:
+                    test_data[CONF_API_KEY] = new_api_key
+
+                async with aiohttp.ClientSession() as session:
+                    client = UniFiClient(session, effective_url, test_data)
+                    try:
+                        auth_method = await client.authenticate()
+                        await client.fetch_alarms()
+                    except InvalidAuthError:
+                        errors["base"] = "invalid_auth"
+                    except CannotConnectError as err:
+                        _LOGGER.error("Cannot reach controller during options update: %s", err)
+                        errors["base"] = "cannot_connect"
+                    except Exception:  # noqa: BLE001
+                        _LOGGER.exception("Unexpected error during options credentials update")
+                        errors["base"] = "unknown"
+                    else:
+                        # Check whether the new URL would collide with another entry
+                        if effective_url != self._config_entry.data[CONF_CONTROLLER_URL]:
+                            for entry in self.hass.config_entries.async_entries(DOMAIN):
+                                if (
+                                    entry.entry_id != self._config_entry.entry_id
+                                    and entry.data.get(CONF_CONTROLLER_URL) == effective_url
+                                ):
+                                    return self.async_abort(reason="already_configured")
+
+                        # Persist the updated credentials into entry.data
+                        updated_data = {
+                            **self._config_entry.data,
+                            CONF_CONTROLLER_URL: effective_url,
+                            CONF_VERIFY_SSL: new_verify_ssl,
+                            CONF_AUTH_METHOD: auth_method,
+                            CONF_IS_UNIFI_OS: client._is_unifi_os,
+                        }
+                        if new_username:
+                            updated_data[CONF_USERNAME] = new_username
+                        if new_password:
+                            updated_data[CONF_PASSWORD] = new_password
+                        if new_api_key:
+                            updated_data[CONF_API_KEY] = new_api_key
+
+                        self.hass.config_entries.async_update_entry(
+                            self._config_entry, data=updated_data
+                        )
+                        # Proceed to categories; reload will happen after the full options save
+                        return await self.async_step_categories()
+
+        # Build the credentials form — all fields optional with current values as hints
+        _password_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
+        _api_key_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
+        current_url: str = self._config_entry.data.get(CONF_CONTROLLER_URL, "")
+        current_verify_ssl: bool = self._config_entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
+
+        schema = vol.Schema(
+            {
+                vol.Optional(CONF_CONTROLLER_URL): str,
+                vol.Optional(CONF_USERNAME): str,
+                vol.Optional(CONF_PASSWORD): _password_selector,
+                vol.Optional(CONF_API_KEY): _api_key_selector,
+                vol.Optional(CONF_VERIFY_SSL, default=current_verify_ssl): bool,
+            }
+        )
+        return self.async_show_form(
+            step_id="credentials",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={"current_url": current_url},
+        )
+
+    async def async_step_categories(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Update alert categories, poll interval, clear timeout, and site."""
         errors: dict[str, str] = {}
 
         if user_input is not None:

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 from homeassistant.components.webhook import async_generate_url
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.core import callback
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.selector import TextSelector, TextSelectorConfig, TextSelectorType
 from yarl import URL
 
@@ -39,6 +40,19 @@ from .const import (
 from .unifi_client import CannotConnectError, InvalidAuthError, UniFiClient
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _create_auth_failed_issue(hass: Any, entry: Any) -> None:
+    """Create a repair issue in the HA issue registry when credentials fail post-setup."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        f"auth_failed_{entry.entry_id}",
+        is_fixable=True,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="auth_failed",
+        translation_placeholders={"name": entry.title},
+    )
 
 
 class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -192,6 +206,70 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="finish",
             data_schema=vol.Schema(fields),
+        )
+
+    # ── Reauth flow ───────────────────────────────────────────────────────
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
+        """Entry point called by HA when ConfigEntryAuthFailed is raised.
+
+        Creates a repair issue so users see a repair card even if the standard
+        reauth notification is missed.
+        """
+        self._reauth_entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        # Surface a repair card in addition to the standard reauth prompt
+        if self._reauth_entry is not None:
+            _create_auth_failed_issue(self.hass, self._reauth_entry)
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Show credential form and validate new credentials on submit."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None and self._reauth_entry is not None:
+            entry = self._reauth_entry
+            url: str = entry.data.get(CONF_CONTROLLER_URL, "")
+            async with aiohttp.ClientSession() as session:
+                client = UniFiClient(session, url, user_input)
+                try:
+                    auth_method = await client.authenticate()
+                except InvalidAuthError:
+                    errors["base"] = "invalid_auth"
+                except CannotConnectError as err:
+                    _LOGGER.error("Cannot reach controller during reauth: %s", err)
+                    errors["base"] = "cannot_connect"
+                except Exception:  # noqa: BLE001
+                    _LOGGER.exception("Unexpected error during reauth")
+                    errors["base"] = "unknown"
+                else:
+                    # Merge updated credentials into the entry
+                    new_data = {
+                        **entry.data,
+                        **user_input,
+                        CONF_AUTH_METHOD: auth_method,
+                        CONF_IS_UNIFI_OS: client._is_unifi_os,
+                    }
+                    self.hass.config_entries.async_update_entry(entry, data=new_data)
+                    # Clear the repair issue now that auth is restored
+                    ir.async_delete_issue(self.hass, DOMAIN, f"auth_failed_{entry.entry_id}")
+                    await self.hass.config_entries.async_reload(entry.entry_id)
+                    return self.async_abort(reason="reauth_successful")
+
+        _password_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
+        _api_key_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
+        schema = vol.Schema(
+            {
+                vol.Optional(CONF_USERNAME): str,
+                vol.Optional(CONF_PASSWORD): _password_selector,
+                vol.Optional(CONF_API_KEY): _api_key_selector,
+            }
+        )
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=schema,
+            errors=errors,
         )
 
     @staticmethod

--- a/custom_components/unifi_alerts/const.py
+++ b/custom_components/unifi_alerts/const.py
@@ -27,6 +27,7 @@ DEFAULT_POLL_INTERVAL = 60  # seconds
 DEFAULT_CLEAR_TIMEOUT = 30  # minutes
 DEFAULT_VERIFY_SSL = True  # disable in config flow if controller has a self-signed cert
 DEFAULT_SITE = "default"
+WEBHOOK_MAX_BODY_BYTES = 8192  # 8 KB ceiling on inbound webhook bodies
 
 # ──────────────────────────────────────────────
 # Category identifiers

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from typing import Any
 
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -75,9 +76,19 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
             _LOGGER.warning("Auth expired, re-authenticating: %s", err)
             try:
                 await self._client.authenticate()
+            except (InvalidAuthError, CannotConnectError) as reauth_err:
+                _LOGGER.error(
+                    "Re-authentication failed; credentials may have changed: %s", reauth_err
+                )
+                raise ConfigEntryAuthFailed(
+                    f"Re-authentication failed; credentials may have changed: {reauth_err}"
+                ) from reauth_err
+            try:
                 categorised = await self._client.categorise_alarms(self._site)
-            except (InvalidAuthError, CannotConnectError) as retry_err:
-                raise UpdateFailed(f"UniFi auth failed: {retry_err}") from retry_err
+            except CannotConnectError as retry_err:
+                raise UpdateFailed(
+                    f"Cannot reach UniFi controller after re-authentication: {retry_err}"
+                ) from retry_err
         except CannotConnectError as err:
             raise UpdateFailed(f"Cannot reach UniFi controller: {err}") from err
 

--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": ["aiohttp>=3.9.0"],
-  "version": "1.0.0-pre3"
+  "version": "1.0.0"
 }

--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": ["aiohttp>=3.9.0"],
-  "version": "1.0.0"
+  "version": "1.1.0-pre1"
 }

--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": ["aiohttp>=3.9.0"],
-  "version": "1.1.0-pre1"
+  "version": "1.2.0-pre1"
 }

--- a/custom_components/unifi_alerts/services.py
+++ b/custom_components/unifi_alerts/services.py
@@ -1,0 +1,109 @@
+"""Service handlers for unifi_alerts.clear_category and unifi_alerts.clear_all."""
+
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv
+
+from .const import ALL_CATEGORIES, DATA_COORDINATOR, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_CLEAR_CATEGORY = "clear_category"
+SERVICE_CLEAR_ALL = "clear_all"
+
+ATTR_CATEGORY = "category"
+ATTR_ENTRY_ID = "entry_id"
+
+CLEAR_CATEGORY_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_CATEGORY): vol.In(ALL_CATEGORIES),
+        vol.Optional(ATTR_ENTRY_ID): cv.string,
+    }
+)
+
+CLEAR_ALL_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_ENTRY_ID): cv.string,
+    }
+)
+
+
+def _get_coordinators(hass: HomeAssistant, entry_id: str | None):
+    """Yield coordinator(s) from hass.data, optionally filtered by entry_id."""
+    domain_data: dict = hass.data.get(DOMAIN, {})
+    if entry_id is not None:
+        entry_data = domain_data.get(entry_id)
+        if entry_data is None:
+            _LOGGER.warning(
+                "clear service called with unknown entry_id %r — no coordinator found",
+                entry_id,
+            )
+            return
+        yield entry_data[DATA_COORDINATOR]
+    else:
+        for entry_data in domain_data.values():
+            yield entry_data[DATA_COORDINATOR]
+
+
+async def _handle_clear_category(call: ServiceCall) -> None:
+    """Handle the clear_category service call."""
+    hass: HomeAssistant = call.hass
+    category: str = call.data[ATTR_CATEGORY]
+    entry_id: str | None = call.data.get(ATTR_ENTRY_ID)
+
+    for coordinator in _get_coordinators(hass, entry_id):
+        coordinator.cancel_clear(category)
+        state = coordinator.get_category_state(category)
+        if state and state.is_alerting:
+            state.clear()
+            coordinator.async_set_updated_data(coordinator.category_states)
+            _LOGGER.debug("Service clear_category: cleared category %s", category)
+
+
+async def _handle_clear_all(call: ServiceCall) -> None:
+    """Handle the clear_all service call."""
+    hass: HomeAssistant = call.hass
+    entry_id: str | None = call.data.get(ATTR_ENTRY_ID)
+
+    for coordinator in _get_coordinators(hass, entry_id):
+        cleared_any = False
+        for category, state in coordinator.category_states.items():
+            if state.is_alerting:
+                coordinator.cancel_clear(category)
+                state.clear()
+                cleared_any = True
+        if cleared_any:
+            coordinator.async_set_updated_data(coordinator.category_states)
+            _LOGGER.debug("Service clear_all: cleared all alerting categories")
+
+
+def async_register_services(hass: HomeAssistant) -> None:
+    """Register integration services. Idempotent — safe to call multiple times."""
+    if not hass.services.has_service(DOMAIN, SERVICE_CLEAR_CATEGORY):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_CLEAR_CATEGORY,
+            _handle_clear_category,
+            schema=CLEAR_CATEGORY_SCHEMA,
+        )
+
+    if not hass.services.has_service(DOMAIN, SERVICE_CLEAR_ALL):
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_CLEAR_ALL,
+            _handle_clear_all,
+            schema=CLEAR_ALL_SCHEMA,
+        )
+
+
+def async_unregister_services(hass: HomeAssistant) -> None:
+    """Unregister integration services. Only call when the last entry is unloaded."""
+    if hass.services.has_service(DOMAIN, SERVICE_CLEAR_CATEGORY):
+        hass.services.async_remove(DOMAIN, SERVICE_CLEAR_CATEGORY)
+
+    if hass.services.has_service(DOMAIN, SERVICE_CLEAR_ALL):
+        hass.services.async_remove(DOMAIN, SERVICE_CLEAR_ALL)

--- a/custom_components/unifi_alerts/services.yaml
+++ b/custom_components/unifi_alerts/services.yaml
@@ -1,0 +1,50 @@
+clear_category:
+  name: Clear category
+  description: >
+    Manually clear the alert state for a specific category on one or all
+    UniFi Alerts entries. Equivalent to pressing the per-category clear button.
+  fields:
+    category:
+      name: Category
+      description: The alert category to clear.
+      required: true
+      selector:
+        select:
+          options:
+            - value: network_device
+              label: "Network: Device offline/online"
+            - value: network_wan
+              label: "Network: WAN offline/latency"
+            - value: network_client
+              label: "Network: Client connect/disconnect"
+            - value: security_threat
+              label: "Security: Threat / IDS detected"
+            - value: security_honeypot
+              label: "Security: Honeypot triggered"
+            - value: security_firewall
+              label: "Security: Firewall block"
+            - value: power
+              label: "Power: PoE / power loss"
+    entry_id:
+      name: Entry ID
+      description: >
+        Optional. Restrict the clear to a specific config entry (for
+        multi-controller households). Leave blank to clear across all entries.
+      required: false
+      selector:
+        text:
+
+clear_all:
+  name: Clear all
+  description: >
+    Manually clear the alert state for every active category on one or all
+    UniFi Alerts entries. Equivalent to pressing the "Clear All Alerts" button.
+  fields:
+    entry_id:
+      name: Entry ID
+      description: >
+        Optional. Restrict the clear to a specific config entry (for
+        multi-controller households). Leave blank to clear across all entries.
+      required: false
+      selector:
+        text:

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -53,6 +53,32 @@
       "already_configured": "This UniFi controller is already configured."
     }
   },
+  "services": {
+    "clear_category": {
+      "name": "Clear category",
+      "description": "Manually clear the alert state for a specific category on one or all UniFi Alerts entries.",
+      "fields": {
+        "category": {
+          "name": "Category",
+          "description": "The alert category to clear."
+        },
+        "entry_id": {
+          "name": "Entry ID",
+          "description": "Optional config entry ID. Leave blank to clear across all entries."
+        }
+      }
+    },
+    "clear_all": {
+      "name": "Clear all",
+      "description": "Manually clear the alert state for every active category on one or all UniFi Alerts entries.",
+      "fields": {
+        "entry_id": {
+          "name": "Entry ID",
+          "description": "Optional config entry ID. Leave blank to clear across all entries."
+        }
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -104,6 +104,17 @@
   },
   "options": {
     "step": {
+      "credentials": {
+        "title": "Update Controller Credentials",
+        "description": "Optionally update the controller URL or credentials. Leave all fields blank to skip this step and go straight to alert category settings.\n\nCurrent controller: {current_url}",
+        "data": {
+          "controller_url": "New Controller URL (leave blank to keep current)",
+          "username": "New Username (leave blank to keep current)",
+          "password": "New Password (leave blank to keep current)",
+          "api_key": "New API Key (leave blank to keep current)",
+          "verify_ssl": "Verify SSL certificate"
+        }
+      },
       "init": {
         "title": "Update Alert Categories",
         "description": "Update your alert category settings. Webhook URLs for your enabled categories are shown below — copy them into UniFi Alarm Manager as needed.",

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -40,6 +40,15 @@
           "webhook_url_security_firewall": "Security: Firewall block webhook URL",
           "webhook_url_power": "Power: PoE / power loss webhook URL"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate UniFi Alerts",
+        "description": "Your UniFi controller credentials for **{name}** are no longer valid. Enter new credentials to restore the connection.",
+        "data": {
+          "username": "Username (leave blank if using API key)",
+          "password": "Password",
+          "api_key": "API Key (UniFi OS only — leave blank if using username/password)"
+        }
       }
     },
     "error": {
@@ -50,7 +59,21 @@
       "unknown": "An unexpected error occurred. Check the Home Assistant logs."
     },
     "abort": {
-      "already_configured": "This UniFi controller is already configured."
+      "already_configured": "This UniFi controller is already configured.",
+      "reauth_successful": "Re-authentication was successful. The integration has been reloaded."
+    }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "UniFi Alerts: authentication failed for {name}",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate UniFi Alerts",
+            "description": "The credentials for **{name}** are no longer valid (e.g. the password or API key was changed). Enter new credentials to restore the connection."
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -53,6 +53,32 @@
       "already_configured": "This UniFi controller is already configured."
     }
   },
+  "services": {
+    "clear_category": {
+      "name": "Clear category",
+      "description": "Manually clear the alert state for a specific category on one or all UniFi Alerts entries.",
+      "fields": {
+        "category": {
+          "name": "Category",
+          "description": "The alert category to clear."
+        },
+        "entry_id": {
+          "name": "Entry ID",
+          "description": "Optional config entry ID. Leave blank to clear across all entries."
+        }
+      }
+    },
+    "clear_all": {
+      "name": "Clear all",
+      "description": "Manually clear the alert state for every active category on one or all UniFi Alerts entries.",
+      "fields": {
+        "entry_id": {
+          "name": "Entry ID",
+          "description": "Optional config entry ID. Leave blank to clear across all entries."
+        }
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -104,6 +104,17 @@
   },
   "options": {
     "step": {
+      "credentials": {
+        "title": "Update Controller Credentials",
+        "description": "Optionally update the controller URL or credentials. Leave all fields blank to skip this step and go straight to alert category settings.\n\nCurrent controller: {current_url}",
+        "data": {
+          "controller_url": "New Controller URL (leave blank to keep current)",
+          "username": "New Username (leave blank to keep current)",
+          "password": "New Password (leave blank to keep current)",
+          "api_key": "New API Key (leave blank to keep current)",
+          "verify_ssl": "Verify SSL certificate"
+        }
+      },
       "init": {
         "title": "Update Alert Categories",
         "description": "Update your alert category settings. Webhook URLs for your enabled categories are shown below — copy them into UniFi Alarm Manager as needed.",

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -40,6 +40,15 @@
           "webhook_url_security_firewall": "Security: Firewall block webhook URL",
           "webhook_url_power": "Power: PoE / power loss webhook URL"
         }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate UniFi Alerts",
+        "description": "Your UniFi controller credentials for **{name}** are no longer valid. Enter new credentials to restore the connection.",
+        "data": {
+          "username": "Username (leave blank if using API key)",
+          "password": "Password",
+          "api_key": "API Key (UniFi OS only — leave blank if using username/password)"
+        }
       }
     },
     "error": {
@@ -50,7 +59,21 @@
       "unknown": "An unexpected error occurred. Check the Home Assistant logs."
     },
     "abort": {
-      "already_configured": "This UniFi controller is already configured."
+      "already_configured": "This UniFi controller is already configured.",
+      "reauth_successful": "Re-authentication was successful. The integration has been reloaded."
+    }
+  },
+  "issues": {
+    "auth_failed": {
+      "title": "UniFi Alerts: authentication failed for {name}",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Re-authenticate UniFi Alerts",
+            "description": "The credentials for **{name}** are no longer valid (e.g. the password or API key was changed). Enter new credentials to restore the connection."
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/unifi_alerts/unifi_client.py
+++ b/custom_components/unifi_alerts/unifi_client.py
@@ -116,7 +116,7 @@ class UniFiClient:
                     raise CannotConnectError(f"UniFi API error: {msg}")
                 return [a for a in data.get("data", []) if not a.get("archived", False)]
         except aiohttp.ClientError as err:
-            raise CannotConnectError(str(err)) from err
+            raise CannotConnectError(type(err).__name__) from err
 
     async def categorise_alarms(self, site: str = "default") -> dict[str, list[UniFiAlert]]:
         """Fetch alarms and group them by category."""
@@ -264,7 +264,7 @@ class UniFiClient:
             _LOGGER.warning("Authentication failed at all login paths (last: %s)", last_url)
             raise InvalidAuthError("Invalid username or password", login_url=last_url)
         except aiohttp.ClientError as err:
-            raise CannotConnectError(str(err)) from err
+            raise CannotConnectError(type(err).__name__) from err
 
     def _network_path(self, path: str) -> str:
         """Prefix path with /proxy/network on UniFi OS controllers."""

--- a/custom_components/unifi_alerts/webhook_handler.py
+++ b/custom_components/unifi_alerts/webhook_handler.py
@@ -20,6 +20,7 @@ from .const import (
     CONF_ENABLED_CATEGORIES,
     CONF_WEBHOOK_SECRET,
     DOMAIN,
+    WEBHOOK_MAX_BODY_BYTES,
     webhook_id_for_category,
 )
 from .models import UniFiAlert
@@ -93,8 +94,16 @@ class WebhookManager:
                 return Response(status=401)
 
             try:
-                payload = await request.json()
-            except (json.JSONDecodeError, TypeError):
+                raw = await request.content.read(WEBHOOK_MAX_BODY_BYTES + 1)
+                if len(raw) > WEBHOOK_MAX_BODY_BYTES:
+                    _LOGGER.warning(
+                        "Webhook body for category %s exceeds %d bytes, rejecting",
+                        category,
+                        WEBHOOK_MAX_BODY_BYTES,
+                    )
+                    return Response(status=413)
+                payload = json.loads(raw.decode()) if raw else {}
+            except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
                 payload = {}
 
             _LOGGER.debug("Webhook received for category %s: %s", category, payload)

--- a/info.md
+++ b/info.md
@@ -1,0 +1,62 @@
+# UniFi Alerts for Home Assistant
+
+Aggregates **UniFi Network controller alerts** into Home Assistant sensors, binary sensors, event entities, and buttons. Alerts arrive in real time via UniFi Alarm Manager webhooks and are supplemented by periodic REST polling for open-count data and resilience against missed pushes.
+
+---
+
+## Features
+
+- **Real-time webhook push** — UniFi Alarm Manager POSTs alerts to per-category endpoints registered by HA; no polling delay for active alerts
+- **REST polling fallback** — configurable interval keeps open-count sensors accurate even if a webhook is missed
+- **Per-category binary sensors** — ON when an alert is active, auto-clears after a configurable timeout
+- **Per-category message sensors** — last alert text and timestamp as state attributes
+- **Per-category open-count sensors** — live count polled from the controller
+- **Rollup sensors** — a single "any alert active" binary and a total open-count sensor
+- **Event entities** — fire on every inbound alert; use as automation triggers
+- **Clear buttons** — reset any individual category or all categories at once
+- **UI config flow** — full setup and options UI; no YAML required
+- **Auto-detect auth** — tries API key (UniFi OS) then falls back to username/password
+- **Secure defaults** — SSL verification on, webhook bearer-token auth enforced, local-only endpoints
+
+### Alert categories
+
+| Category | Covers |
+|---|---|
+| Network: Device offline/online | APs, switches, gateways disconnecting/reconnecting |
+| Network: WAN offline/latency | WAN failover, internet access events |
+| Network: Client connect/disconnect | Wireless and wired client join/leave |
+| Security: Threat / IDS detected | IPS/IDS threat alerts |
+| Security: Honeypot triggered | Honeypot hit events |
+| Security: Firewall block | GeoIP and blocked traffic events |
+| Power: PoE / power loss | PoE disconnect, power cycle, UPS events |
+
+---
+
+## Requirements
+
+- Home Assistant 2026.1.0 or later
+- UniFi Network controller reachable on the same local network as your HA instance
+- Credentials: API key (UniFi OS consoles) **or** username + password (older controllers)
+
+> **Local network only:** webhook URLs are not reachable over Nabu Casa remote access or from cloud-hosted controllers.
+
+---
+
+## Quick setup
+
+1. Install via HACS: **Integrations → Custom repositories** → add `https://github.com/PHeonix25/unifi_alerts` → **Download** → restart HA.
+2. Go to **Settings → Devices & Services → Add Integration** → search **UniFi Alerts**.
+3. Enter your controller URL and credentials (API key or username/password).
+4. Select the alert categories you want to monitor and configure polling interval and auto-clear timeout.
+5. **Copy the webhook URLs** shown on the final screen into **UniFi Network → Settings → Notifications → Alarm Manager** — one URL per category.
+
+See the [full documentation](https://github.com/PHeonix25/unifi_alerts) for detailed instructions, screenshots, and an automation example.
+
+---
+
+## Links
+
+- [Full documentation / README](https://github.com/PHeonix25/unifi_alerts)
+- [Issue tracker](https://github.com/PHeonix25/unifi_alerts/issues)
+- [Source code](https://github.com/PHeonix25/unifi_alerts)
+- [License (MIT)](https://github.com/PHeonix25/unifi_alerts/blob/main/LICENSE)

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -584,3 +584,207 @@ async def test_options_flow_rejects_all_disabled() -> None:
     assert result["step_id"] == "init"
     call_kwargs = flow.async_show_form.call_args.kwargs
     assert call_kwargs["errors"] == {"base": "at_least_one_category"}
+
+
+# ---------------------------------------------------------------------------
+# Reauth flow tests
+# ---------------------------------------------------------------------------
+
+
+def _make_reauth_flow(entry_id: str = "entry-test") -> UniFiAlertsConfigFlow:
+    """Create a flow wired up for reauth tests."""
+    flow = UniFiAlertsConfigFlow()
+    flow.context = {"entry_id": entry_id}
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = entry_id
+    mock_entry.title = "UniFi Alerts (https://192.168.1.1)"
+    mock_entry.data = {
+        CONF_CONTROLLER_URL: "https://192.168.1.1",
+        CONF_USERNAME: "admin",
+        CONF_PASSWORD: "oldpassword",
+        CONF_WEBHOOK_SECRET: "secret",
+    }
+
+    hass = MagicMock()
+    hass.config_entries.async_get_entry = MagicMock(return_value=mock_entry)
+    hass.config_entries.async_update_entry = MagicMock()
+    hass.config_entries.async_reload = AsyncMock()
+    flow.hass = hass
+    flow._reauth_entry = mock_entry  # pre-set so reauth_confirm can access it
+    return flow
+
+
+class TestReauthFlow:
+    """Tests for the reauth flow steps."""
+
+    @pytest.mark.asyncio
+    async def test_async_step_reauth_routes_to_reauth_confirm(self) -> None:
+        """async_step_reauth must store the entry and advance to reauth_confirm."""
+        flow = UniFiAlertsConfigFlow()
+        entry_id = "entry-reauth-1"
+        flow.context = {"entry_id": entry_id}
+
+        mock_entry = MagicMock()
+        mock_entry.entry_id = entry_id
+        mock_entry.title = "Test Controller"
+
+        hass = MagicMock()
+        hass.config_entries.async_get_entry = MagicMock(return_value=mock_entry)
+        hass.config_entries.async_reload = AsyncMock()
+        flow.hass = hass
+
+        confirm_result = {"type": "form", "step_id": "reauth_confirm"}
+        flow.async_step_reauth_confirm = AsyncMock(return_value=confirm_result)
+
+        with patch(
+            "custom_components.unifi_alerts.config_flow._create_auth_failed_issue"
+        ):
+            result = await flow.async_step_reauth({})
+
+        assert result == confirm_result
+        assert flow._reauth_entry is mock_entry
+
+    @pytest.mark.asyncio
+    async def test_async_step_reauth_creates_issue(self) -> None:
+        """async_step_reauth must call _create_auth_failed_issue."""
+        flow = UniFiAlertsConfigFlow()
+        entry_id = "entry-issue-test"
+        flow.context = {"entry_id": entry_id}
+
+        mock_entry = MagicMock()
+        mock_entry.entry_id = entry_id
+        mock_entry.title = "Test"
+
+        hass = MagicMock()
+        hass.config_entries.async_get_entry = MagicMock(return_value=mock_entry)
+        hass.config_entries.async_reload = AsyncMock()
+        flow.hass = hass
+        flow.async_step_reauth_confirm = AsyncMock(return_value={"type": "form"})
+
+        with patch(
+            "custom_components.unifi_alerts.config_flow._create_auth_failed_issue"
+        ) as mock_create:
+            await flow.async_step_reauth({})
+
+        mock_create.assert_called_once_with(hass, mock_entry)
+
+    @pytest.mark.asyncio
+    async def test_reauth_confirm_no_input_shows_form(self) -> None:
+        """With no user_input, reauth_confirm must show the credential form."""
+        flow = _make_reauth_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reauth_confirm"})
+
+        result = await flow.async_step_reauth_confirm(user_input=None)
+
+        assert result["step_id"] == "reauth_confirm"
+        flow.async_show_form.assert_called_once()
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["step_id"] == "reauth_confirm"
+        assert not call_kwargs["errors"]
+
+    @pytest.mark.asyncio
+    async def test_reauth_confirm_valid_credentials_updates_entry_and_aborts(self) -> None:
+        """Valid credentials must update entry.data and abort with reauth_successful."""
+        flow = _make_reauth_flow()
+        flow.async_abort = MagicMock(return_value={"type": "abort", "reason": "reauth_successful"})
+
+        new_creds = {CONF_USERNAME: "admin", CONF_PASSWORD: "newpassword"}
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+                return_value=_make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+            patch("custom_components.unifi_alerts.config_flow.ir.async_delete_issue") as mock_del,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value="userpass")
+            instance._is_unifi_os = False
+
+            result = await flow.async_step_reauth_confirm(user_input=new_creds)
+
+        assert result["reason"] == "reauth_successful"
+        flow.hass.config_entries.async_update_entry.assert_called_once()
+        flow.hass.config_entries.async_reload.assert_awaited_once()
+        mock_del.assert_called_once_with(
+            flow.hass, "unifi_alerts", f"auth_failed_{flow._reauth_entry.entry_id}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reauth_confirm_invalid_credentials_shows_error(self) -> None:
+        """Invalid credentials must re-show the form with invalid_auth error."""
+        from custom_components.unifi_alerts.unifi_client import InvalidAuthError
+
+        flow = _make_reauth_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reauth_confirm"})
+
+        new_creds = {CONF_USERNAME: "admin", CONF_PASSWORD: "wrongpassword"}
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+                return_value=_make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(side_effect=InvalidAuthError("bad"))
+
+            result = await flow.async_step_reauth_confirm(user_input=new_creds)
+
+        assert result["step_id"] == "reauth_confirm"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"] == {"base": "invalid_auth"}
+
+    @pytest.mark.asyncio
+    async def test_reauth_confirm_cannot_connect_shows_error(self) -> None:
+        """A connection error during reauth must show cannot_connect error."""
+        from custom_components.unifi_alerts.unifi_client import CannotConnectError
+
+        flow = _make_reauth_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reauth_confirm"})
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+                return_value=_make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(side_effect=CannotConnectError("down"))
+
+            result = await flow.async_step_reauth_confirm(
+                user_input={CONF_USERNAME: "admin", CONF_PASSWORD: "pass"}
+            )
+
+        assert result["step_id"] == "reauth_confirm"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"] == {"base": "cannot_connect"}
+
+    @pytest.mark.asyncio
+    async def test_reauth_confirm_does_not_delete_issue_on_failure(self) -> None:
+        """async_delete_issue must NOT be called when reauth fails."""
+        from custom_components.unifi_alerts.unifi_client import InvalidAuthError
+
+        flow = _make_reauth_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reauth_confirm"})
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+                return_value=_make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+            patch("custom_components.unifi_alerts.config_flow.ir.async_delete_issue") as mock_del,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(side_effect=InvalidAuthError("bad"))
+
+            await flow.async_step_reauth_confirm(
+                user_input={CONF_USERNAME: "admin", CONF_PASSWORD: "wrong"}
+            )
+
+        mock_del.assert_not_called()

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -229,7 +229,7 @@ async def test_finish_submit_creates_entry() -> None:
 
 @pytest.mark.asyncio
 async def test_options_init_includes_webhook_urls() -> None:
-    """Options flow init should include webhook URL fields in data_schema."""
+    """Options flow categories step should include webhook URL fields in data_schema."""
     fake_secret = "options-test-secret"
     config_entry = MagicMock()
     config_entry.data = {CONF_ENABLED_CATEGORIES: ALL_CATEGORIES, CONF_WEBHOOK_SECRET: fake_secret}
@@ -244,7 +244,7 @@ async def test_options_init_includes_webhook_urls() -> None:
         "custom_components.unifi_alerts.config_flow.async_generate_url",
         return_value=fake_url,
     ):
-        result = await flow.async_step_init(user_input=None)
+        result = await flow.async_step_categories(user_input=None)
 
     assert result["step_id"] == "init"
     call_kwargs = flow.async_show_form.call_args.kwargs
@@ -291,7 +291,7 @@ async def test_options_init_reads_entry_options_over_data() -> None:
     with patch(
         "custom_components.unifi_alerts.config_flow.async_generate_url", return_value="http://x"
     ):
-        await flow.async_step_init(user_input=None)
+        await flow.async_step_categories(user_input=None)
 
     call_kwargs = flow.async_show_form.call_args.kwargs
     schema = call_kwargs["data_schema"]
@@ -499,7 +499,7 @@ async def test_options_flow_saves_submitted_values() -> None:
     user_input[CONF_CLEAR_TIMEOUT] = 60
     user_input[CONF_SITE] = "secondary"
 
-    result = await flow.async_step_init(user_input)
+    result = await flow.async_step_categories(user_input)
 
     assert result["type"] == "create_entry"
     saved = flow.async_create_entry.call_args.kwargs["data"]
@@ -579,7 +579,7 @@ async def test_options_flow_rejects_all_disabled() -> None:
         "custom_components.unifi_alerts.config_flow.async_generate_url",
         return_value="http://ha.local/webhook/x",
     ):
-        result = await flow.async_step_init(all_off)
+        result = await flow.async_step_categories(all_off)
 
     assert result["step_id"] == "init"
     call_kwargs = flow.async_show_form.call_args.kwargs
@@ -788,3 +788,274 @@ class TestReauthFlow:
             )
 
         mock_del.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Options flow — credentials step
+# ---------------------------------------------------------------------------
+
+
+def _make_options_flow(
+    url: str = "https://192.168.1.1",
+    enabled_categories: list[str] | None = None,
+) -> UniFiAlertsOptionsFlow:
+    """Return an options-flow instance wired with a minimal mock config entry and hass."""
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry-options-creds"
+    config_entry.data = {
+        CONF_CONTROLLER_URL: url,
+        CONF_USERNAME: "admin",
+        CONF_PASSWORD: "secret",
+        CONF_API_KEY: "",
+        CONF_VERIFY_SSL: True,
+        CONF_WEBHOOK_SECRET: "fixed-secret",
+        CONF_ENABLED_CATEGORIES: enabled_categories or ALL_CATEGORIES,
+    }
+    config_entry.options = {}
+
+    flow = UniFiAlertsOptionsFlow(config_entry)
+    hass = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+    hass.config_entries.async_update_entry = MagicMock()
+    hass.config_entries.async_reload = AsyncMock()
+    flow.hass = hass
+    return flow
+
+
+class TestOptionsFlowCredentials:
+    """Tests for the new credentials step in the options flow."""
+
+    @pytest.mark.asyncio
+    async def test_init_routes_to_credentials_step(self) -> None:
+        """Opening the options flow (async_step_init) should show the credentials step first."""
+        flow = _make_options_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "credentials"})
+
+        result = await flow.async_step_init(user_input=None)
+
+        assert result["step_id"] == "credentials"
+        flow.async_show_form.assert_called_once()
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["step_id"] == "credentials"
+
+    @pytest.mark.asyncio
+    async def test_blank_submission_skips_to_categories(self) -> None:
+        """Submitting all-blank credentials skips to the categories step without any auth call."""
+        flow = _make_options_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "init"})
+
+        blank_input = {
+            CONF_CONTROLLER_URL: "",
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with patch(
+            "custom_components.unifi_alerts.config_flow.async_generate_url",
+            return_value="http://ha.local/webhook/x",
+        ):
+            result = await flow.async_step_credentials(blank_input)
+
+        # Should have proceeded to categories (step_id="init" is the categories form)
+        assert result["step_id"] == "init"
+        # No entry update should have occurred
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_valid_new_credentials_updates_entry_data(self) -> None:
+        """Submitting new valid credentials must update entry.data and continue to categories."""
+        flow = _make_options_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "init"})
+
+        new_creds = {
+            CONF_CONTROLLER_URL: "https://10.0.0.1",
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "newpass",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+                return_value=_make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_generate_url",
+                return_value="http://ha.local/webhook/x",
+            ),
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance._is_unifi_os = False
+
+            result = await flow.async_step_credentials(new_creds)
+
+        # entry.data must have been updated
+        flow.hass.config_entries.async_update_entry.assert_called_once()
+        updated_data = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert updated_data[CONF_CONTROLLER_URL] == "https://10.0.0.1"
+        assert updated_data[CONF_PASSWORD] == "newpass"
+
+        # Should have continued to categories
+        assert result["step_id"] == "init"
+
+    @pytest.mark.asyncio
+    async def test_invalid_credentials_shows_error_and_does_not_update(self) -> None:
+        """When the new credentials fail auth, show invalid_auth and do NOT update entry.data."""
+        from custom_components.unifi_alerts.unifi_client import InvalidAuthError
+
+        flow = _make_options_flow()
+        flow.async_show_form = MagicMock(
+            return_value={"type": "form", "step_id": "credentials"}
+        )
+
+        new_creds = {
+            CONF_CONTROLLER_URL: "",
+            CONF_USERNAME: "baduser",
+            CONF_PASSWORD: "wrongpass",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+                return_value=_make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(side_effect=InvalidAuthError("bad creds"))
+
+            result = await flow.async_step_credentials(new_creds)
+
+        assert result["step_id"] == "credentials"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"] == {"base": "invalid_auth"}
+        # entry.data must NOT have been touched
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_url_scheme_shows_error(self) -> None:
+        """A non-http/https URL scheme must show a field-level error without hitting the network."""
+        flow = _make_options_flow()
+        flow.async_show_form = MagicMock(
+            return_value={"type": "form", "step_id": "credentials"}
+        )
+
+        bad_url_input = {
+            CONF_CONTROLLER_URL: "ftp://192.168.1.1",
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with patch(
+            "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+            return_value=_make_session_mock(),
+        ) as mock_session_cls:
+            result = await flow.async_step_credentials(bad_url_input)
+
+        assert result["step_id"] == "credentials"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"].get(CONF_CONTROLLER_URL) == "invalid_url_scheme"
+        # No network call should have been made
+        mock_session_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_url_collision_aborts(self) -> None:
+        """Changing to a URL already used by another entry must abort with already_configured."""
+        flow = _make_options_flow(url="https://192.168.1.1")
+
+        # Simulate an existing OTHER entry with the new URL
+        other_entry = MagicMock()
+        other_entry.entry_id = "other-entry"
+        other_entry.data = {CONF_CONTROLLER_URL: "https://10.0.0.1"}
+        flow.hass.config_entries.async_entries = MagicMock(return_value=[other_entry])
+
+        flow.async_abort = MagicMock(return_value={"type": "abort", "reason": "already_configured"})
+
+        new_creds = {
+            CONF_CONTROLLER_URL: "https://10.0.0.1",
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+                return_value=_make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance._is_unifi_os = False
+
+            result = await flow.async_step_credentials(new_creds)
+
+        assert result["reason"] == "already_configured"
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_after_credential_update_categories_proceeds_normally(self) -> None:
+        """After a successful credentials update, the categories step saves options as usual."""
+        from custom_components.unifi_alerts.const import CONF_CLEAR_TIMEOUT, CONF_POLL_INTERVAL
+
+        flow = _make_options_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "init"})
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+        # First: update credentials
+        new_creds = {
+            CONF_CONTROLLER_URL: "",
+            CONF_USERNAME: "newadmin",
+            CONF_PASSWORD: "",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: False,
+        }
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.aiohttp.ClientSession",
+                return_value=_make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_generate_url",
+                return_value="http://ha.local/webhook/x",
+            ),
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance._is_unifi_os = True
+
+            await flow.async_step_credentials(new_creds)
+
+        # Now: submit the categories step
+        first_cat = ALL_CATEGORIES[0]
+        cat_input = {f"cat_{cat}": (cat == first_cat) for cat in ALL_CATEGORIES}
+        cat_input[CONF_POLL_INTERVAL] = 90
+        cat_input[CONF_CLEAR_TIMEOUT] = 15
+
+        with patch(
+            "custom_components.unifi_alerts.config_flow.async_generate_url",
+            return_value="http://ha.local/webhook/x",
+        ):
+            result = await flow.async_step_categories(cat_input)
+
+        assert result["type"] == "create_entry"
+        saved = flow.async_create_entry.call_args.kwargs["data"]
+        assert saved[CONF_ENABLED_CATEGORIES] == [first_cat]
+        assert saved[CONF_POLL_INTERVAL] == 90
+        assert saved[CONF_CLEAR_TIMEOUT] == 15

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -318,9 +318,9 @@ class TestPollingErrorPaths:
         client.authenticate.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_invalid_auth_on_retry_raises_update_failed(self):
-        """If re-auth also fails, UpdateFailed must be raised."""
-        from homeassistant.helpers.update_coordinator import UpdateFailed
+    async def test_reauth_raises_invalid_auth_raises_config_entry_auth_failed(self):
+        """If re-auth itself raises InvalidAuthError, ConfigEntryAuthFailed must be raised."""
+        from homeassistant.exceptions import ConfigEntryAuthFailed
 
         from custom_components.unifi_alerts.unifi_client import InvalidAuthError
 
@@ -342,8 +342,71 @@ class TestPollingErrorPaths:
             CONF_CLEAR_TIMEOUT: 30,
         }
         coord = UniFiAlertsCoordinator(hass, client, config)
-        with pytest.raises(UpdateFailed):
+        with pytest.raises(ConfigEntryAuthFailed):
             await coord._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_reauth_raises_cannot_connect_raises_config_entry_auth_failed(self):
+        """If re-auth raises CannotConnectError, ConfigEntryAuthFailed must be raised."""
+        from homeassistant.exceptions import ConfigEntryAuthFailed
+
+        from custom_components.unifi_alerts.unifi_client import CannotConnectError, InvalidAuthError
+
+        hass = MagicMock()
+
+        def _create_task(coro, **kwargs):
+            coro.close()
+            return MagicMock()
+
+        hass.async_create_task = _create_task
+        hass.async_create_background_task = _create_task
+        client = MagicMock()
+        client.categorise_alarms = AsyncMock(side_effect=InvalidAuthError("expired"))
+        client.authenticate = AsyncMock(side_effect=CannotConnectError("unreachable during reauth"))
+
+        config = {
+            CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+            CONF_POLL_INTERVAL: 60,
+            CONF_CLEAR_TIMEOUT: 30,
+        }
+        coord = UniFiAlertsCoordinator(hass, client, config)
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coord._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_reauth_succeeds_but_retry_fails_raises_update_failed_with_distinctive_message(
+        self,
+    ):
+        """Re-auth succeeds but retried categorise_alarms fails → UpdateFailed with 'after re-authentication'."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        from custom_components.unifi_alerts.unifi_client import CannotConnectError, InvalidAuthError
+
+        hass = MagicMock()
+
+        def _create_task(coro, **kwargs):
+            coro.close()
+            return MagicMock()
+
+        hass.async_create_task = _create_task
+        hass.async_create_background_task = _create_task
+        client = MagicMock()
+        # First categorise_alarms call fails with auth error; re-auth succeeds; second call fails
+        client.categorise_alarms = AsyncMock(
+            side_effect=[InvalidAuthError("expired"), CannotConnectError("controller 500")]
+        )
+        client.authenticate = AsyncMock()  # re-auth succeeds
+
+        config = {
+            CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+            CONF_POLL_INTERVAL: 60,
+            CONF_CLEAR_TIMEOUT: 30,
+        }
+        coord = UniFiAlertsCoordinator(hass, client, config)
+        with pytest.raises(UpdateFailed) as exc_info:
+            await coord._async_update_data()
+
+        assert "after re-authentication" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_cannot_connect_raises_update_failed(self):

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,0 +1,445 @@
+"""Tests for services.py — clear_category and clear_all service handlers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import voluptuous as vol
+
+from custom_components.unifi_alerts.const import (
+    ALL_CATEGORIES,
+    CATEGORY_NETWORK_WAN,
+    CATEGORY_SECURITY_THREAT,
+    DATA_COORDINATOR,
+    DOMAIN,
+)
+from custom_components.unifi_alerts.models import CategoryState
+from custom_components.unifi_alerts.services import (
+    ATTR_CATEGORY,
+    ATTR_ENTRY_ID,
+    CLEAR_ALL_SCHEMA,
+    CLEAR_CATEGORY_SCHEMA,
+    SERVICE_CLEAR_ALL,
+    SERVICE_CLEAR_CATEGORY,
+    async_register_services,
+    async_unregister_services,
+    _handle_clear_all,
+    _handle_clear_category,
+)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def make_state(category: str, is_alerting: bool = False, enabled: bool = True) -> CategoryState:
+    return CategoryState(category=category, enabled=enabled, is_alerting=is_alerting)
+
+
+def make_coordinator(states: dict[str, CategoryState] | None = None) -> MagicMock:
+    coord = MagicMock()
+    _states = states or {}
+    coord.category_states = _states
+    coord.get_category_state = lambda cat: _states.get(cat)
+    coord.cancel_clear = MagicMock()
+    coord.async_set_updated_data = MagicMock()
+    return coord
+
+
+def make_call(hass: MagicMock, data: dict) -> MagicMock:
+    call = MagicMock()
+    call.hass = hass
+    call.data = data
+    return call
+
+
+def make_hass(entries: dict[str, MagicMock] | None = None) -> MagicMock:
+    """Return a minimal hass mock with hass.data wired up."""
+    hass = MagicMock()
+    hass.data = {DOMAIN: {}}
+    for entry_id, coordinator in (entries or {}).items():
+        hass.data[DOMAIN][entry_id] = {DATA_COORDINATOR: coordinator}
+    return hass
+
+
+# ── schema validation ─────────────────────────────────────────────────────────
+
+
+class TestClearCategorySchema:
+    def test_valid_category_passes(self):
+        result = CLEAR_CATEGORY_SCHEMA({ATTR_CATEGORY: CATEGORY_NETWORK_WAN})
+        assert result[ATTR_CATEGORY] == CATEGORY_NETWORK_WAN
+
+    def test_unknown_category_raises(self):
+        with pytest.raises(vol.Invalid):
+            CLEAR_CATEGORY_SCHEMA({ATTR_CATEGORY: "not_a_real_category"})
+
+    def test_all_known_categories_are_valid(self):
+        for cat in ALL_CATEGORIES:
+            result = CLEAR_CATEGORY_SCHEMA({ATTR_CATEGORY: cat})
+            assert result[ATTR_CATEGORY] == cat
+
+    def test_optional_entry_id_accepted(self):
+        result = CLEAR_CATEGORY_SCHEMA(
+            {ATTR_CATEGORY: CATEGORY_NETWORK_WAN, ATTR_ENTRY_ID: "entry-abc"}
+        )
+        assert result[ATTR_ENTRY_ID] == "entry-abc"
+
+    def test_missing_category_raises(self):
+        with pytest.raises(vol.Invalid):
+            CLEAR_CATEGORY_SCHEMA({})
+
+
+class TestClearAllSchema:
+    def test_empty_call_passes(self):
+        result = CLEAR_ALL_SCHEMA({})
+        assert ATTR_ENTRY_ID not in result
+
+    def test_optional_entry_id_accepted(self):
+        result = CLEAR_ALL_SCHEMA({ATTR_ENTRY_ID: "entry-xyz"})
+        assert result[ATTR_ENTRY_ID] == "entry-xyz"
+
+
+# ── _handle_clear_category ────────────────────────────────────────────────────
+
+
+class TestHandleClearCategory:
+    @pytest.mark.asyncio
+    async def test_clears_alerting_category(self):
+        wan_state = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        coordinator = make_coordinator({CATEGORY_NETWORK_WAN: wan_state})
+        hass = make_hass({"entry-abc": coordinator})
+        call = make_call(hass, {ATTR_CATEGORY: CATEGORY_NETWORK_WAN})
+
+        await _handle_clear_category(call)
+
+        assert wan_state.is_alerting is False
+
+    @pytest.mark.asyncio
+    async def test_cancels_pending_clear_task(self):
+        wan_state = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        coordinator = make_coordinator({CATEGORY_NETWORK_WAN: wan_state})
+        hass = make_hass({"entry-abc": coordinator})
+        call = make_call(hass, {ATTR_CATEGORY: CATEGORY_NETWORK_WAN})
+
+        await _handle_clear_category(call)
+
+        coordinator.cancel_clear.assert_called_once_with(CATEGORY_NETWORK_WAN)
+
+    @pytest.mark.asyncio
+    async def test_calls_async_set_updated_data(self):
+        wan_state = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        coordinator = make_coordinator({CATEGORY_NETWORK_WAN: wan_state})
+        hass = make_hass({"entry-abc": coordinator})
+        call = make_call(hass, {ATTR_CATEGORY: CATEGORY_NETWORK_WAN})
+
+        await _handle_clear_category(call)
+
+        coordinator.async_set_updated_data.assert_called_once_with(coordinator.category_states)
+
+    @pytest.mark.asyncio
+    async def test_non_alerting_category_does_not_notify(self):
+        """If the category is not alerting, no update should be dispatched."""
+        wan_state = make_state(CATEGORY_NETWORK_WAN, is_alerting=False)
+        coordinator = make_coordinator({CATEGORY_NETWORK_WAN: wan_state})
+        hass = make_hass({"entry-abc": coordinator})
+        call = make_call(hass, {ATTR_CATEGORY: CATEGORY_NETWORK_WAN})
+
+        await _handle_clear_category(call)
+
+        coordinator.async_set_updated_data.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_entry_id_filter_targets_only_matching_entry(self):
+        """entry_id kwarg must restrict clearing to only the specified entry."""
+        state_a = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        state_b = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        coord_a = make_coordinator({CATEGORY_NETWORK_WAN: state_a})
+        coord_b = make_coordinator({CATEGORY_NETWORK_WAN: state_b})
+        hass = make_hass({"entry-a": coord_a, "entry-b": coord_b})
+        call = make_call(
+            hass, {ATTR_CATEGORY: CATEGORY_NETWORK_WAN, ATTR_ENTRY_ID: "entry-a"}
+        )
+
+        await _handle_clear_category(call)
+
+        assert state_a.is_alerting is False
+        assert state_b.is_alerting is True  # not touched
+
+    @pytest.mark.asyncio
+    async def test_unknown_entry_id_logs_warning_and_does_nothing(self):
+        wan_state = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        coordinator = make_coordinator({CATEGORY_NETWORK_WAN: wan_state})
+        hass = make_hass({"entry-abc": coordinator})
+        call = make_call(
+            hass, {ATTR_CATEGORY: CATEGORY_NETWORK_WAN, ATTR_ENTRY_ID: "no-such-entry"}
+        )
+
+        with patch("custom_components.unifi_alerts.services._LOGGER") as mock_log:
+            await _handle_clear_category(call)
+
+        mock_log.warning.assert_called_once()
+        assert wan_state.is_alerting is True  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_affects_all_entries_when_entry_id_omitted(self):
+        """Without entry_id, every coordinator's state should be cleared."""
+        state_a = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        state_b = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        coord_a = make_coordinator({CATEGORY_NETWORK_WAN: state_a})
+        coord_b = make_coordinator({CATEGORY_NETWORK_WAN: state_b})
+        hass = make_hass({"entry-a": coord_a, "entry-b": coord_b})
+        call = make_call(hass, {ATTR_CATEGORY: CATEGORY_NETWORK_WAN})
+
+        await _handle_clear_category(call)
+
+        assert state_a.is_alerting is False
+        assert state_b.is_alerting is False
+
+
+# ── _handle_clear_all ─────────────────────────────────────────────────────────
+
+
+class TestHandleClearAll:
+    @pytest.mark.asyncio
+    async def test_clears_all_alerting_categories(self):
+        wan_state = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        threat_state = make_state(CATEGORY_SECURITY_THREAT, is_alerting=True)
+        coordinator = make_coordinator(
+            {CATEGORY_NETWORK_WAN: wan_state, CATEGORY_SECURITY_THREAT: threat_state}
+        )
+        hass = make_hass({"entry-abc": coordinator})
+        call = make_call(hass, {})
+
+        await _handle_clear_all(call)
+
+        assert wan_state.is_alerting is False
+        assert threat_state.is_alerting is False
+
+    @pytest.mark.asyncio
+    async def test_skips_non_alerting_categories(self):
+        wan_state = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        quiet_state = make_state(CATEGORY_SECURITY_THREAT, is_alerting=False)
+        coordinator = make_coordinator(
+            {CATEGORY_NETWORK_WAN: wan_state, CATEGORY_SECURITY_THREAT: quiet_state}
+        )
+        hass = make_hass({"entry-abc": coordinator})
+        call = make_call(hass, {})
+
+        await _handle_clear_all(call)
+
+        # Only WAN was alerting — cancel_clear should be called once for it
+        coordinator.cancel_clear.assert_called_once_with(CATEGORY_NETWORK_WAN)
+
+    @pytest.mark.asyncio
+    async def test_calls_async_set_updated_data_once_per_coordinator(self):
+        """Even with multiple alerting categories, only one listener dispatch per coordinator."""
+        wan_state = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        threat_state = make_state(CATEGORY_SECURITY_THREAT, is_alerting=True)
+        coordinator = make_coordinator(
+            {CATEGORY_NETWORK_WAN: wan_state, CATEGORY_SECURITY_THREAT: threat_state}
+        )
+        hass = make_hass({"entry-abc": coordinator})
+        call = make_call(hass, {})
+
+        await _handle_clear_all(call)
+
+        coordinator.async_set_updated_data.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_dispatch_when_nothing_alerting(self):
+        quiet_state = make_state(CATEGORY_NETWORK_WAN, is_alerting=False)
+        coordinator = make_coordinator({CATEGORY_NETWORK_WAN: quiet_state})
+        hass = make_hass({"entry-abc": coordinator})
+        call = make_call(hass, {})
+
+        await _handle_clear_all(call)
+
+        coordinator.async_set_updated_data.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_entry_id_filter_targets_only_matching_entry(self):
+        state_a = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        state_b = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        coord_a = make_coordinator({CATEGORY_NETWORK_WAN: state_a})
+        coord_b = make_coordinator({CATEGORY_NETWORK_WAN: state_b})
+        hass = make_hass({"entry-a": coord_a, "entry-b": coord_b})
+        call = make_call(hass, {ATTR_ENTRY_ID: "entry-a"})
+
+        await _handle_clear_all(call)
+
+        assert state_a.is_alerting is False
+        assert state_b.is_alerting is True  # not touched
+
+    @pytest.mark.asyncio
+    async def test_affects_all_entries_when_entry_id_omitted(self):
+        state_a = make_state(CATEGORY_NETWORK_WAN, is_alerting=True)
+        state_b = make_state(CATEGORY_SECURITY_THREAT, is_alerting=True)
+        coord_a = make_coordinator({CATEGORY_NETWORK_WAN: state_a})
+        coord_b = make_coordinator({CATEGORY_SECURITY_THREAT: state_b})
+        hass = make_hass({"entry-a": coord_a, "entry-b": coord_b})
+        call = make_call(hass, {})
+
+        await _handle_clear_all(call)
+
+        assert state_a.is_alerting is False
+        assert state_b.is_alerting is False
+
+
+# ── async_register_services / async_unregister_services ──────────────────────
+
+
+class TestServiceRegistration:
+    def _make_hass_with_services(self, has_category: bool = False, has_all: bool = False):
+        hass = MagicMock()
+        hass.services = MagicMock()
+        hass.services.has_service = MagicMock(
+            side_effect=lambda domain, name: (
+                (name == SERVICE_CLEAR_CATEGORY and has_category)
+                or (name == SERVICE_CLEAR_ALL and has_all)
+            )
+        )
+        hass.services.async_register = MagicMock()
+        hass.services.async_remove = MagicMock()
+        return hass
+
+    def test_registers_both_services_on_first_call(self):
+        hass = self._make_hass_with_services()
+        async_register_services(hass)
+        assert hass.services.async_register.call_count == 2
+
+    def test_idempotent_when_services_already_registered(self):
+        hass = self._make_hass_with_services(has_category=True, has_all=True)
+        async_register_services(hass)
+        hass.services.async_register.assert_not_called()
+
+    def test_registers_only_missing_service(self):
+        # category already registered, clear_all missing
+        hass = self._make_hass_with_services(has_category=True, has_all=False)
+        async_register_services(hass)
+        # Only clear_all should be registered
+        assert hass.services.async_register.call_count == 1
+        registered_name = hass.services.async_register.call_args[0][1]
+        assert registered_name == SERVICE_CLEAR_ALL
+
+    def test_unregister_removes_both_services(self):
+        hass = self._make_hass_with_services(has_category=True, has_all=True)
+        async_unregister_services(hass)
+        assert hass.services.async_remove.call_count == 2
+
+    def test_unregister_is_safe_when_services_not_registered(self):
+        hass = self._make_hass_with_services(has_category=False, has_all=False)
+        async_unregister_services(hass)  # must not raise
+        hass.services.async_remove.assert_not_called()
+
+
+# ── integration with __init__.py wiring ───────────────────────────────────────
+
+
+class TestServicesWiredFromInit:
+    """Verify that __init__.async_setup_entry calls register_services and
+    async_unload_entry calls unregister_services only when last entry is gone."""
+
+    def _make_setup_patches(self):
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = MagicMock(return_value=None)
+        mock_coordinator.async_config_entry_first_refresh.__await__ = lambda self: iter([None])
+        from unittest.mock import AsyncMock
+
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.async_shutdown = AsyncMock()
+        mock_coordinator.push_alert = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.authenticate = AsyncMock()
+        mock_client.close = AsyncMock()
+
+        mock_wm = MagicMock()
+        mock_wm.register_all = MagicMock(return_value={})
+        mock_wm.unregister_all = MagicMock()
+        return mock_client, mock_coordinator, mock_wm
+
+    @pytest.mark.asyncio
+    async def test_register_services_called_on_setup(self):
+        from conftest import make_entry, make_hass
+
+        from custom_components.unifi_alerts import async_setup_entry
+
+        hass = make_hass()
+        entry = make_entry()
+        mock_client, mock_coord, mock_wm = self._make_setup_patches()
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.async_get_clientsession",
+                return_value=MagicMock(),
+            ),
+            patch("custom_components.unifi_alerts.UniFiClient", return_value=mock_client),
+            patch(
+                "custom_components.unifi_alerts.UniFiAlertsCoordinator",
+                return_value=mock_coord,
+            ),
+            patch("custom_components.unifi_alerts.WebhookManager", return_value=mock_wm),
+            patch(
+                "custom_components.unifi_alerts.async_register_services"
+            ) as mock_register,
+        ):
+            await async_setup_entry(hass, entry)
+
+        mock_register.assert_called_once_with(hass)
+
+    @pytest.mark.asyncio
+    async def test_unregister_services_called_when_last_entry_unloads(self):
+        from conftest import make_entry, make_hass
+
+        from custom_components.unifi_alerts import async_unload_entry
+        from custom_components.unifi_alerts.const import DATA_COORDINATOR, DATA_UNREGISTER_WEBHOOKS, DATA_WEBHOOK_IDS
+
+        hass = make_hass()
+        entry = make_entry()
+        mock_client, mock_coord, mock_wm = self._make_setup_patches()
+
+        # Populate as if setup completed
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+            DATA_COORDINATOR: mock_coord,
+            DATA_WEBHOOK_IDS: {},
+            DATA_UNREGISTER_WEBHOOKS: mock_wm.unregister_all,
+            "client": mock_client,
+        }
+
+        with patch(
+            "custom_components.unifi_alerts.async_unregister_services"
+        ) as mock_unregister:
+            await async_unload_entry(hass, entry)
+
+        mock_unregister.assert_called_once_with(hass)
+
+    @pytest.mark.asyncio
+    async def test_unregister_services_not_called_when_entries_remain(self):
+        from conftest import make_entry, make_hass
+
+        from custom_components.unifi_alerts import async_unload_entry
+        from custom_components.unifi_alerts.const import DATA_COORDINATOR, DATA_UNREGISTER_WEBHOOKS, DATA_WEBHOOK_IDS
+
+        hass = make_hass()
+        entry1 = make_entry(entry_id="entry-1")
+        entry2 = make_entry(entry_id="entry-2")
+        mock_client, mock_coord, mock_wm = self._make_setup_patches()
+
+        # Two entries registered
+        hass.data.setdefault(DOMAIN, {})
+        for eid in (entry1.entry_id, entry2.entry_id):
+            hass.data[DOMAIN][eid] = {
+                DATA_COORDINATOR: mock_coord,
+                DATA_WEBHOOK_IDS: {},
+                DATA_UNREGISTER_WEBHOOKS: mock_wm.unregister_all,
+                "client": mock_client,
+            }
+
+        with patch(
+            "custom_components.unifi_alerts.async_unregister_services"
+        ) as mock_unregister:
+            # Unload only entry1 — entry2 still remains
+            await async_unload_entry(hass, entry1)
+
+        mock_unregister.assert_not_called()

--- a/tests/unit/test_unifi_client.py
+++ b/tests/unit/test_unifi_client.py
@@ -277,6 +277,29 @@ class TestLoginUserpass:
             await client._login_userpass()
 
     @pytest.mark.asyncio
+    async def test_login_client_error_message_is_class_name_not_url(self):
+        """CannotConnectError from _login_userpass must use class name, not str(err).
+
+        Same credential-leak prevention as fetch_alarms: aiohttp errors can embed
+        the login URL (which may contain the password) in their string representation.
+        """
+        import aiohttp
+
+        client = make_client()
+        client._is_unifi_os = False
+
+        @asynccontextmanager
+        async def _raise(*args, **kwargs):
+            raise aiohttp.ClientConnectionError("https://admin:hunter2@192.168.1.1/api/login")
+            yield
+
+        client._session.post = _raise
+        with pytest.raises(CannotConnectError) as exc_info:
+            await client._login_userpass()
+        assert "hunter2" not in str(exc_info.value)
+        assert exc_info.value.args[0] == "ClientConnectionError"
+
+    @pytest.mark.asyncio
     async def test_http_401_raises_invalid_auth(self):
         """HTTP 401 should still raise InvalidAuthError (bad credentials)."""
         client = make_client()
@@ -459,6 +482,30 @@ class TestFetchAlarms:
         client._session.get = _raise
         with pytest.raises(CannotConnectError):
             await client.fetch_alarms()
+
+    @pytest.mark.asyncio
+    async def test_client_error_message_is_class_name_not_url(self):
+        """CannotConnectError message must be the exception class name, not str(err).
+
+        aiohttp exceptions can embed the controller URL (including credentials) in
+        their string representation.  Using type(err).__name__ prevents credential
+        leaks via HA log output.
+        """
+        import aiohttp
+
+        client = make_client()
+        client._authenticated = True
+
+        @asynccontextmanager
+        async def _raise(*args, **kwargs):
+            raise aiohttp.ClientConnectionError("https://admin:secret@192.168.1.1/api")
+            yield
+
+        client._session.get = _raise
+        with pytest.raises(CannotConnectError) as exc_info:
+            await client.fetch_alarms()
+        assert "secret" not in str(exc_info.value)
+        assert exc_info.value.args[0] == "ClientConnectionError"
 
     @pytest.mark.asyncio
     async def test_sends_limit_param(self):

--- a/tests/unit/test_webhook_handler.py
+++ b/tests/unit/test_webhook_handler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -12,6 +13,7 @@ from custom_components.unifi_alerts.const import (
     CATEGORY_SECURITY_THREAT,
     CONF_ENABLED_CATEGORIES,
     CONF_WEBHOOK_SECRET,
+    WEBHOOK_MAX_BODY_BYTES,
 )
 from custom_components.unifi_alerts.webhook_handler import WebhookManager
 
@@ -32,13 +34,9 @@ def make_manager(enabled=None, secret="test-secret-123", hass=None):
 def make_request(token: str | None = "test-secret-123", json_body: dict | None = None):
     """Build a minimal mock aiohttp.web.Request."""
     req = MagicMock()
-    # query is a dict-like object
     req.query = {"token": token} if token is not None else {}
-    # json() is async
-    if json_body is None:
-        req.json = AsyncMock(return_value={"key": "EVT_GW_WANTransition", "message": "WAN down"})
-    else:
-        req.json = AsyncMock(return_value=json_body)
+    body_dict = json_body if json_body is not None else {"key": "EVT_GW_WANTransition", "message": "WAN down"}
+    req.content.read = AsyncMock(return_value=json.dumps(body_dict).encode())
     return req
 
 
@@ -226,17 +224,27 @@ class TestMakeHandler:
     @pytest.mark.asyncio
     async def test_malformed_json_uses_empty_dict_fallback(self):
         """If the body can't be parsed as JSON, push_callback is still called with empty payload."""
-        import json
-
         manager, push_cb = make_manager(secret="tok")
         handler = manager._make_handler(CATEGORY_NETWORK_WAN, "tok")
         req = make_request(token="tok")
-        req.json = AsyncMock(side_effect=json.JSONDecodeError("nope", "", 0))
+        req.content.read = AsyncMock(return_value=b"not valid json {{")
         await handler(manager._hass, "wh-id", req)
         push_cb.assert_called_once()
         # Alert should have fallback message
         call_category, call_alert = push_cb.call_args[0]
         assert call_alert.message == "Unknown alert"
+
+    @pytest.mark.asyncio
+    async def test_oversized_body_returns_413(self):
+        """A webhook body larger than WEBHOOK_MAX_BODY_BYTES must be rejected with HTTP 413."""
+        manager, push_cb = make_manager(secret="tok")
+        handler = manager._make_handler(CATEGORY_NETWORK_WAN, "tok")
+        req = make_request(token="tok")
+        req.content.read = AsyncMock(return_value=b"x" * (WEBHOOK_MAX_BODY_BYTES + 1))
+        response = await handler(manager._hass, "wh-id", req)
+        assert response is not None
+        assert response.status == 413
+        push_cb.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_alert_fields_populated_from_payload(self):


### PR DESCRIPTION
## Summary

This PR implements three major features to improve reliability, user experience, and security:

1. **Re-authentication flow** — when credentials expire post-setup, HA now surfaces a repair card and reauth prompt instead of silently failing
2. **Service handlers** — expose `clear_category` and `clear_all` as HA services for automation integration
3. **Webhook body size limit** — cap inbound webhook payloads at 8 KB to prevent unbounded memory growth

## Key Changes

### Config Flow & Re-authentication
- Added `async_step_reauth()` and `async_step_reauth_confirm()` to handle credential updates without deleting/re-adding the integration
- New helper `_create_auth_failed_issue()` creates a repair issue in HA's issue registry when auth fails, surfacing a repair card to users
- Re-auth form accepts username, password, and API key; validates credentials before updating entry data
- On successful re-auth, the repair issue is deleted and the entry is reloaded
- Updated `strings.json` and `translations/en.json` with reauth form labels and error messages

### Services
- Created `services.py` with `clear_category` and `clear_all` service handlers
- Defined `CLEAR_CATEGORY_SCHEMA` (required category, optional entry_id) and `CLEAR_ALL_SCHEMA` (optional entry_id)
- Services can target a single entry or all entries; clear buttons now have service equivalents for automation use
- Created `services.yaml` with service descriptions and category selector options
- Added `async_register_services()` and `async_unregister_services()` lifecycle hooks in `__init__.py`

### Webhook Security
- Added `WEBHOOK_MAX_BODY_BYTES = 8192` constant to `const.py`
- Updated `webhook_handler.py` to enforce size limit on `request.json()` call, preventing unbounded memory allocation from malicious or malformed payloads

### Coordinator Error Handling
- Split single `except (InvalidAuthError, CannotConnectError)` block in `_async_update_data()` into two separate handlers
- Re-auth failures now raise `ConfigEntryAuthFailed` (triggers HA's reauth flow) with message "Re-authentication failed; credentials may have changed"
- Post-re-auth poll failures raise `UpdateFailed` with "Cannot reach UniFi controller after re-authentication" — clearly distinguishable from first-pass failures

### Testing
- Added comprehensive test suite in `tests/unit/test_services.py` (445 lines) covering schema validation, service handlers, entry filtering, and error cases
- Updated `tests/unit/test_config_flow.py` to test reauth flow steps, credential validation, issue creation/deletion, and error handling
- Renamed `async_step_init()` calls to `async_step_categories()` in options flow tests for clarity
- Updated `tests/unit/test_coordinator.py` to distinguish re-auth failures from post-re-auth poll failures
- Added credential-leak prevention test in `test_unifi_client.py` to verify error messages use class names, not string representations

### CI/CD & Documentation
- Added `version-check.yml` workflow to enforce version format per branch (main: `X.Y.Z`, dev: `X.Y.Z-preN`)
- Updated `release.yml` to trigger on version tags and validate tag matches manifest version
- Updated `ci.yml` to run on both `main` and `dev` branches
- Created `info.md` for HACS display card
- Updated `README.md` with Lovelace card and automation examples
- Updated `ROADMAP.md` and `TODO.md` to reflect completed items and new findings from security audit
- Updated `CLAUDE.md` with branching strategy and CI workflow documentation

### Version
- Bumped manifest version from `1.0.0-pre3` to `1.2.0-pre1` to reflect scope of changes

## Notable Implementation Details

- Re-auth flow integrates with HA's native repair system (`issue_registry`) for better UX
- Services use optional `entry_id` parameter to support both single-entry and multi-entry

https://claude.ai/code/session_01WYVaQ9ArNVdv8QdSnEjMXy