### PR TITLE
fix: correct pre-release grep regex; bump action-gh-release to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           echo "tag=$TAG" >> $GITHUB_OUTPUT
-          if echo "$TAG" | grep -qE '-pre[0-9]+$'; then
+          if echo "$TAG" | grep -qE -- '-pre[0-9]+$'; then
             echo "prerelease=true" >> $GITHUB_OUTPUT
             echo "Release type: PRE-RELEASE ($TAG)"
           else
@@ -55,7 +55,7 @@ jobs:
           cd ..
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           files: unifi_alerts.zip
           prerelease: ${{ steps.release_type.outputs.prerelease == 'true' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ README.md                         # user-facing install, setup, and contributing
 - **Webhooks are `local_only: True`** — do not remove this without a documented reason.
 - **Webhook bearer token auth is mandatory** — every inbound webhook request must be validated against `CONF_WEBHOOK_SECRET` via `?token=` query param. Never remove this check or accept requests that fail it.
 - **Category state lives only in the coordinator** — entities must not cache state themselves.
+- **Every GitHub Actions `uses:` reference must be pinned to a full 40-character commit SHA** — no branch names (`@main`, `@master`), no tag names (`@v2`, `@v6`), no short SHAs. Add a trailing comment noting the resolved version or branch for human readers (e.g. `# v3.0.0` or `# master tip 2026-04-22`). This applies to every workflow in `.github/workflows/`. When bumping an action, resolve the new SHA via `gh api repos/OWNER/REPO/git/refs/tags/TAG` (or `.../heads/BRANCH` for repos without tags) and replace both the SHA and its comment in the same edit.
 
 ## Coding conventions
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # History
 
+## 2026-04-22 — Fix release workflow: pre-release detection regex + Node 20 deprecation
+
+- **Bug 1 — every release tagged Stable:** [`.github/workflows/release.yml:31`](.github/workflows/release.yml:31) used `grep -qE '-pre[0-9]+$'` to detect pre-release tags. Because the pattern begins with `-`, `grep` parsed it as options (`-p`, `-r`, `-e`) and exited with `grep: invalid option -- 'p'`. The `if` saw the non-zero exit as "no pre-release match" and fell through to the stable branch, so `v1.x.y-preN` tags were being published as stable GitHub releases. Fixed by adding `--` before the pattern (`grep -qE -- '-pre[0-9]+$'`) to terminate `grep`'s option parsing. Verified with both `v1.3.0-pre2` (→ PRE) and `v1.3.0` (→ STABLE) inputs.
+- **Bug 2 — Node 20 deprecation warning on `softprops/action-gh-release`:** bumped [`.github/workflows/release.yml:58`](.github/workflows/release.yml:58) from `v2.6.1` (`153bb8e0…`) to `v3.0.0` (`b4309332981a82ec1c5618f44dd2e27cc8bfbfda`). v3.0.0's only change is moving the action runtime from Node 20 to Node 24, addressing the GitHub-Actions deprecation that forces migration by 2026-06-02. SHA verified via `gh api repos/softprops/action-gh-release/git/refs/tags/v3.0.0`. The inputs we use (`files`, `prerelease`, `name`) are unchanged between v2 and v3, so no other edits required.
+- **No test coverage added:** workflow YAML is exercised only at release-tag push time. End-to-end verification requires cutting a `v1.x.y-preN` tag on `dev` after merge and confirming the published GitHub release is marked "Pre-release".
+- No other third-party actions in the repo are affected — `actions/checkout@v6`, `actions/setup-python@v6`, and the HA/HACS Docker-based actions are exempt or already on Node 24.
+
 ## 2026-04-22 — Fix alarm endpoint: remove invalid limit param, try-both path fallback, surface 400 detail
 
 - **Follow-up bug (same session):** after the API-key coercion fix (PR #31) corrected the UniFi OS path, the integration now correctly hit `/proxy/network/api/s/default/alarm` — but returned a new `ClientResponseError 400`. Root-caused: the `params={"limit": 200}` query parameter is not accepted by the UniFi alarm endpoint and causes `api.err.InvalidObject` (HTTP 400). Additionally, the community wiki and field testing revealed that alarm endpoint paths vary by firmware (`/alarm` works on some, `/stat/alarm` on others).

--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": ["aiohttp>=3.9.0"],
-  "version": "1.3.0-pre1"
+  "version": "1.3.0-pre2"
 }


### PR DESCRIPTION
## Summary

- **Pre-release detection was broken:** `grep -qE '-pre[0-9]+$'` treated the leading `-` in the pattern as grep options, exiting with `grep: invalid option -- 'p'`. The shell `if` interpreted the non-zero exit as "no match" and fell through to the stable branch — so every pushed tag (`v1.x.y-preN` or otherwise) was published as a stable GitHub release. Fixed by adding `--` before the pattern.
- **Node 20 deprecation:** bumped `softprops/action-gh-release` from `v2.6.1` → `v3.0.0` (SHA `b4309332981a82ec1c5618f44dd2e27cc8bfbfda`) to move from Node 20 to Node 24 ahead of the forced migration on 2026-06-02.
- **CLAUDE.md:** added a non-negotiable constraint requiring every `uses:` ref to be pinned to a full 40-char SHA (prevents regression).

## Test plan

- [ ] Regex spot-checked locally: `v1.3.0-pre2 → PRE`, `v1.3.0 → STABLE` ✓
- [ ] YAML parses without error ✓
- [ ] Full end-to-end verification requires pushing a `v1.x.y-preN` tag on `dev` after merge and confirming the GitHub release is marked "Pre-release"

🤖 Generated with [Claude Code](https://claude.com/claude-code)