### PR TITLE
fix: resolve three v1.3.0 post-install bugs (options flow loop, missing device, blank entities)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,26 @@
 # History
 
+## 2026-04-29 — v1.3.0 post-install bug fixes: options flow loop, device registry, blank entities
+
+Three bugs confirmed on a production install of v1.3.0-pre2. All fixed in `claude/fix-config-flow-loop-kvZw7`. Bundled in three v1.2 ROADMAP polish items (touching the same files) to minimise churn.
+
+- **Bug 1 — Options flow loops between pages 1 and 2:** `UniFiAlertsOptionsFlow.async_step_categories` rendered its form with `step_id="init"`. Every submit routed back to `async_step_init`, which unconditionally called `async_step_credentials()`, landing the user on page 1 again — an infinite loop that never saved any changes. Root cause: the categories form used the wrong `step_id` value.
+  - **Fix:** restructured `UniFiAlertsOptionsFlow` to exactly mirror the initial setup's 3-step flow — credentials (page 1, blank = skip) → categories (page 2, settings only) → finish (page 3, webhook URL display + final submit). Added `self._pending_options` to carry data from categories to finish. The `async_step_finish` in the options flow is a new method that calls `self.async_create_entry(title="", data=self._pending_options)`.
+  - **Files:** `custom_components/unifi_alerts/config_flow.py:281-500`, `strings.json`, `translations/en.json`
+  - **Tests:** rewrote `test_options_init_includes_webhook_urls` → `test_options_finish_includes_webhook_urls`; renamed `test_options_init_reads_entry_options_over_data` → `test_options_categories_reads_entry_options_over_data`; updated `test_options_flow_saves_submitted_values`, `test_options_flow_rejects_all_disabled`, and `test_blank_submission_skips_to_categories` / `test_valid_new_credentials_updates_entry_data` / `test_after_credential_update_categories_proceeds_normally` in `TestOptionsFlowCredentials`; added `test_options_categories_submit_routes_to_finish`, `test_options_finish_submit_creates_entry`, `test_options_flow_full_cycle`.
+
+- **Bug 2 — No device/service parent visible on integration page:** All four platform files (`binary_sensor`, `sensor`, `event`, `button`) already set `_attr_device_info` with correct shared `identifiers` and `DeviceEntryType.SERVICE`. However, HA's "Services" section does not always render the card prominently when the device is created lazily (on first entity registration) and when `configuration_url` is absent.
+  - **Fix:** added proactive device registration via `dr.async_get(hass).async_get_or_create(...)` in `async_setup_entry` — runs before platform forwarding, guaranteeing the device exists immediately. Added `configuration_url=entry.data.get(CONF_CONTROLLER_URL)` to all four `_device_info()` helpers and to the proactive call, so the Services card links directly to the UniFi controller web UI.
+  - **Files:** `custom_components/unifi_alerts/__init__.py`, `binary_sensor.py`, `sensor.py`, `event.py`, `button.py` (all touched for `CONF_CONTROLLER_URL` import + `configuration_url` field)
+  - **Tests:** added `TestDeviceRegistration.test_setup_creates_service_device` and `test_setup_device_has_configuration_url` in `test_init.py`; added `TestDeviceInfo` class (5 tests) in `test_entities.py`.
+
+- **Bug 3 — Blank entities / can't get detail:** `UniFiCategoryMessageSensor.native_value` returned `None` on a fresh install (no alert ever received), which HA rendered as a blank "unknown" state with no useful detail view. Three v1.2 ROADMAP polish items were bundled in since they touched the same files:
+  - **Fix (message sensor default):** `native_value` now returns `"No alerts yet"` when `state.last_alert is None`. Entity is always clickable and self-explanatory. Return type annotation changed to `str` (was `str | None`). (`sensor.py:60-64`)
+  - **Fix (message sensor category):** added `_attr_entity_category = EntityCategory.DIAGNOSTIC` to `UniFiCategoryMessageSensor` — keeps informational message sensors off the default dashboard. (`sensor.py`)
+  - **Fix (button categories):** added `_attr_entity_category = EntityCategory.CONFIG` to both `UniFiClearCategoryButton` and `UniFiClearAllButton` — removes them from voice assistant entity lists and default dashboards. (`button.py`)
+  - **Fix (event device class):** removed `_attr_device_class = EventDeviceClass.BUTTON` from `UniFiAlertEventEntity`. The comment admitted it was "closest semantic match" but it misleads device-class-based automation UIs. `device_class` is now unset. (`event.py`)
+  - **Tests:** added `TestEntityCategories` class (6 tests: DIAGNOSTIC on message sensor, CONFIG on both clear buttons, no device_class on event entity, "No alerts yet" default, message returned when alert present) in `test_entities.py`.
+
 ## 2026-04-22 — Fix release workflow: pre-release detection regex + Node 20 deprecation
 
 - **Bug 1 — every release tagged Stable:** [`.github/workflows/release.yml:31`](.github/workflows/release.yml:31) used `grep -qE '-pre[0-9]+$'` to detect pre-release tags. Because the pattern begins with `-`, `grep` parsed it as options (`-p`, `-r`, `-e`) and exited with `grep: invalid option -- 'p'`. The `if` saw the non-zero exit as "no pre-release match" and fell through to the stable branch, so `v1.x.y-preN` tags were being published as stable GitHub releases. Fixed by adding `--` before the pattern (`grep -qE -- '-pre[0-9]+$'`) to terminate `grep`'s option parsing. Verified with both `v1.3.0-pre2` (→ PRE) and `v1.3.0` (→ STABLE) inputs.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ automation:
 
 > **Tip:** Replace `event.unifi_alerts_security_threat` with any per-category event entity (e.g. `event.unifi_alerts_network_device`, `event.unifi_alerts_power`). Swap `persistent_notification.create` for `notify.mobile_app_your_phone` or any other notify action.
 
+#### Automation caveats
+
+- **Event entities show `unknown` until the first alert fires.** `EventEntity` has no persistent state — it only carries the data from the most recent event. On a fresh install or after an HA restart, all event entities start in `unknown` state. This is normal and expected; your automations will trigger correctly once the first alert arrives.
+- **Disabling a category makes its event entity `unavailable`.** If you disable a category in **Settings → Devices & Services → UniFi Alerts → Configure**, the corresponding event entity becomes unavailable and any automation that triggers on it will silently stop firing. Re-enable the category or update the automation accordingly.
+
 ---
 
 ## Contributing

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -123,8 +123,8 @@ A second-opinion pass after the v1.1 PRs landed surfaced a set of items that are
 - [ ] Entity naming is ad-hoc — each platform file hard-codes `_attr_name = f"{CATEGORY_LABELS[cat]} Foo"`.  Adopt the `has_entity_name = True` + `_attr_translation_key = "..."` pattern so the strings live in `strings.json` (`binary_sensor.py:60`, `sensor.py:56,109`, `event.py:63`, `button.py`).  Unlocks localisation and cleaner registry IDs.
 - [ ] No sensor `device_class` on the open-count or rollup-count sensors (`sensor.py:96,128`) — add a device_class where one fits (none of HA's built-ins map cleanly to "open alert count"; consider `None` + richer `state_class`).
 - [ ] **Config flow accesses private `client._is_unifi_os`** — `config_flow.py:99,253,372` read a private attribute directly.  If the client internals change, this breaks silently.  Fix: expose `is_unifi_os` as a public `@property` on `UniFiClient` (`unifi_client.py`).
-- [ ] **`EventDeviceClass.BUTTON` is semantically incorrect for alert events** — `event.py:51` uses `BUTTON` as "closest semantic match" but this is misleading in device-class-based automation UIs.  Fix: remove `_attr_device_class` entirely (or set to `None`); no built-in class fits "alert received" (`event.py:51`).
-- [ ] **Clear buttons and diagnostic entities lack `entity_category`** — `UniFiClearCategoryButton` and `UniFiClearAllButton` don't set `_attr_entity_category = EntityCategory.CONFIG` (`button.py:37,63`).  Without this, they appear on the default dashboard and in voice assistant entity lists, which is confusing.  Similarly, message sensors could use `EntityCategory.DIAGNOSTIC`.
+- [x] **`EventDeviceClass.BUTTON` is semantically incorrect for alert events** — resolved in v1.3.0 post-install fix PR.
+- [x] **Clear buttons and diagnostic entities lack `entity_category`** — resolved in v1.3.0 post-install fix PR.
 
 ### Testing
 
@@ -149,6 +149,16 @@ A second-opinion pass after the v1.1 PRs landed surfaced a set of items that are
 - [ ] **No privacy / data retention section in README** — users don't know which UniFi payload fields end up in HA state (message, device_name, site, severity, raw) or how long they persist. Add a short "Data handling" section: what fields are stored, that nothing leaves the local network, and that auto-clear removes `is_alerting`/`last_alert` after the configured timeout.
 - [ ] **Automation example doesn't document the "category disabled → event entity unavailable" edge case** — if a user disables the `security_threat` category via options after wiring up an automation, the event entity becomes unavailable and the automation silently stops firing. Add a one-liner caveat to the README automation section.
 - [ ] **`unique_id` format is undocumented** (README) — power users wiring entities into long-lived automations don't know whether renaming entities in the UI is safe. Document the `{entry_id}_{category}_{sensor_type}` pattern and explicitly note that UI renames preserve `unique_id`, so automations are safe.
+
+---
+
+## v1.3.0 — Post-install bug fixes
+
+Three bugs confirmed in production on v1.3.0-pre2. Resolved in `claude/fix-config-flow-loop-kvZw7`.
+
+- [x] **Options flow loop** — `UniFiAlertsOptionsFlow` restructured to mirror 3-step initial-setup (credentials → categories → webhook URLs). (`config_flow.py`, `strings.json`, `translations/en.json`)
+- [x] **No device/service parent** — proactive device registration via `dr.async_get_or_create` in `async_setup_entry`; `configuration_url` added to all `_device_info()` helpers. (`__init__.py`, all platform files)
+- [x] **Blank / unclickable entities** — message sensor defaults to `"No alerts yet"` instead of `None`; `EntityCategory.DIAGNOSTIC` on message sensors; `EntityCategory.CONFIG` on clear buttons; removed wrong `EventDeviceClass.BUTTON` from event entities. (`sensor.py`, `button.py`, `event.py`)
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,16 @@
 
 Prioritised backlog. Items are grouped by type. Work top-to-bottom within each group unless there's a dependency noted.
 
+## 🔵 v1.3.0 — Post-install bug fixes
+
+Three bugs confirmed in production after v1.3.0-pre2 install on `https://unifi.home.hermens.com.au`. All resolved in `claude/fix-config-flow-loop-kvZw7` (merged to dev):
+
+- [x] **Options flow loops between pages 1 and 2** — `async_step_categories` used `step_id="init"` causing every submit to re-route to `async_step_init` → credentials. Fixed by restructuring `UniFiAlertsOptionsFlow` to mirror the 3-step initial-setup flow: credentials → categories → finish (webhook URLs). (`config_flow.py:281-470`, `strings.json`, `translations/en.json`)
+- [x] **No device/service parent visible** — entities had correct `DeviceInfo` but no proactive registration in `async_setup_entry`. Added `dr.async_get_or_create(...)` call before platform forwarding, and added `configuration_url` to all four `_device_info()` helpers so the Services card is clickable to the controller URL. (`__init__.py`, `binary_sensor.py`, `sensor.py`, `event.py`, `button.py`)
+- [x] **Blank entities / can't click** — `UniFiCategoryMessageSensor.native_value` returned `None` before first alert. Changed to return `"No alerts yet"`. Also bundled v1.2 polish: `EntityCategory.DIAGNOSTIC` on message sensors, `EntityCategory.CONFIG` on clear buttons, removed wrong `EventDeviceClass.BUTTON` from event entities. (`sensor.py`, `button.py`, `event.py`)
+
+---
+
 ## 🔵 v1.3.0 — UniFi OS only
 
 **Decision (2026-04-22):** officially support only UniFi OS controllers. Classic self-hosted controllers (Network Application on bare Linux/Windows) are excluded. See `ROADMAP.md § v1.3.0` for full rationale.
@@ -72,8 +82,8 @@ A comprehensive audit after the v1.1 PRs landed surfaced these items. Full detai
 - **Ad-hoc entity naming:** adopt `has_entity_name = True` + `_attr_translation_key` pattern across `binary_sensor.py`, `sensor.py`, `event.py`, `button.py` so names live in `strings.json`.
 - **No sensor `device_class`:** consider what fits on the open-count / rollup-count sensors (`sensor.py:96,128`).
 - **Config flow accesses private `client._is_unifi_os`:** expose as a public `@property` on `UniFiClient` (`config_flow.py:99,253,372`).
-- **`EventDeviceClass.BUTTON` wrong for alert events:** remove the device_class or set to `None` (`event.py:51`).
-- **Clear buttons lack `entity_category`:** set `_attr_entity_category = EntityCategory.CONFIG` on `UniFiClearCategoryButton` and `UniFiClearAllButton` (`button.py:37,63`).
+- ~~**`EventDeviceClass.BUTTON` wrong for alert events**~~ — resolved in v1.3.0 post-install fix PR.
+- ~~**Clear buttons lack `entity_category`**~~ — resolved in v1.3.0 post-install fix PR.
 
 ### Testing
 - **No multi-entry integration test:** verify two UniFi Alerts entries don't cross-contaminate coordinator/webhook state. Note: the webhook ID collision above means this test will fail until the code is fixed — write it first as a red-green pair.

--- a/custom_components/unifi_alerts/__init__.py
+++ b/custom_components/unifi_alerts/__init__.py
@@ -8,9 +8,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import DeviceEntryType
 
 from .const import (
+    CONF_CONTROLLER_URL,
     CONF_VERIFY_SSL,
     DATA_COORDINATOR,
     DATA_UNREGISTER_WEBHOOKS,
@@ -55,6 +58,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except Exception as err:  # noqa: BLE001
         _LOGGER.error("Failed to authenticate to UniFi controller: %s", err)
         raise ConfigEntryNotReady(f"Could not connect to UniFi controller: {err}") from err
+
+    # Proactively register the hub device so it appears in HA's Services section
+    # immediately after setup — before any entity is registered.
+    dev_reg = dr.async_get(hass)
+    dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id)},
+        name="UniFi Alerts",
+        manufacturer="Ubiquiti",
+        model="UniFi Network Controller",
+        entry_type=DeviceEntryType.SERVICE,
+        configuration_url=entry.data.get(CONF_CONTROLLER_URL),
+    )
 
     coordinator = UniFiAlertsCoordinator(hass, client, dict(entry.data) | dict(entry.options))
 

--- a/custom_components/unifi_alerts/binary_sensor.py
+++ b/custom_components/unifi_alerts/binary_sensor.py
@@ -18,6 +18,7 @@ from .const import (
     CATEGORY_ICONS,
     CATEGORY_ICONS_OK,
     CATEGORY_LABELS,
+    CONF_CONTROLLER_URL,
     DATA_COORDINATOR,
     DOMAIN,
 )
@@ -142,4 +143,5 @@ def _device_info(entry: ConfigEntry) -> DeviceInfo:
         manufacturer="Ubiquiti",
         model="UniFi Network Controller",
         entry_type=DeviceEntryType.SERVICE,
+        configuration_url=entry.data.get(CONF_CONTROLLER_URL),
     )

--- a/custom_components/unifi_alerts/button.py
+++ b/custom_components/unifi_alerts/button.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
@@ -12,6 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import (
     ALL_CATEGORIES,
     CATEGORY_LABELS,
+    CONF_CONTROLLER_URL,
     DATA_COORDINATOR,
     DOMAIN,
 )
@@ -39,6 +41,7 @@ class UniFiClearCategoryButton(ButtonEntity):
 
     _attr_has_entity_name = True
     _attr_icon = "mdi:bell-off"
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
         self,
@@ -66,6 +69,7 @@ class UniFiClearAllButton(ButtonEntity):
     _attr_has_entity_name = True
     _attr_name = "Clear All Alerts"
     _attr_icon = "mdi:shield-off"
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
         self,
@@ -91,4 +95,5 @@ def _device_info(entry: ConfigEntry) -> DeviceInfo:
         manufacturer="Ubiquiti",
         model="UniFi Network Controller",
         entry_type=DeviceEntryType.SERVICE,
+        configuration_url=entry.data.get(CONF_CONTROLLER_URL),
     )

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -283,6 +283,7 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         self._config_entry = config_entry
+        self._pending_options: dict[str, Any] = {}
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Router: always start with the credentials step."""
@@ -417,19 +418,13 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
             if not enabled:
                 errors["base"] = "at_least_one_category"
             else:
-                return self.async_create_entry(
-                    title="",
-                    data={
-                        CONF_ENABLED_CATEGORIES: enabled,
-                        CONF_POLL_INTERVAL: user_input.get(
-                            CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL
-                        ),
-                        CONF_CLEAR_TIMEOUT: user_input.get(
-                            CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT
-                        ),
-                        CONF_SITE: user_input.get(CONF_SITE, DEFAULT_SITE),
-                    },
-                )
+                self._pending_options = {
+                    CONF_ENABLED_CATEGORIES: enabled,
+                    CONF_POLL_INTERVAL: user_input.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL),
+                    CONF_CLEAR_TIMEOUT: user_input.get(CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT),
+                    CONF_SITE: user_input.get(CONF_SITE, DEFAULT_SITE),
+                }
+                return await self.async_step_finish()
 
         current_enabled: list[str] = self._config_entry.options.get(
             CONF_ENABLED_CATEGORIES,
@@ -459,12 +454,28 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
         )
         fields[vol.Optional(CONF_SITE, default=current_site)] = str
 
-        secret: str = self._config_entry.data.get(CONF_WEBHOOK_SECRET, "")
-        for cat in ALL_CATEGORIES:
-            url = f"{async_generate_url(self.hass, webhook_id_for_category(cat))}?token={secret}"
-            fields[vol.Optional(f"webhook_url_{cat}", default=url)] = str
         return self.async_show_form(
-            step_id="init",
+            step_id="categories",
             data_schema=vol.Schema(fields),
             errors=errors,
+            description_placeholders={cat: CATEGORY_LABELS[cat] for cat in ALL_CATEGORIES},
+        )
+
+    async def async_step_finish(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Display webhook URLs, then save options on submit."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=self._pending_options)
+
+        enabled: list[str] = self._pending_options.get(CONF_ENABLED_CATEGORIES, ALL_CATEGORIES)
+        secret: str = self._config_entry.data.get(CONF_WEBHOOK_SECRET, "")
+        fields: dict = {}
+        for cat in ALL_CATEGORIES:
+            if cat in enabled:
+                url = (
+                    f"{async_generate_url(self.hass, webhook_id_for_category(cat))}?token={secret}"
+                )
+                fields[vol.Optional(f"webhook_url_{cat}", default=url)] = str
+        return self.async_show_form(
+            step_id="finish",
+            data_schema=vol.Schema(fields),
         )

--- a/custom_components/unifi_alerts/event.py
+++ b/custom_components/unifi_alerts/event.py
@@ -6,7 +6,7 @@ for automations that should trigger on *each* alert rather than a state change.
 
 from __future__ import annotations
 
-from homeassistant.components.event import EventDeviceClass, EventEntity
+from homeassistant.components.event import EventEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntryType
@@ -18,6 +18,7 @@ from .const import (
     ALL_CATEGORIES,
     CATEGORY_ICONS,
     CATEGORY_LABELS,
+    CONF_CONTROLLER_URL,
     DATA_COORDINATOR,
     DOMAIN,
 )
@@ -48,7 +49,6 @@ class UniFiAlertEventEntity(CoordinatorEntity[UniFiAlertsCoordinator], EventEnti
     """
 
     _attr_has_entity_name = True
-    _attr_device_class = EventDeviceClass.BUTTON  # closest semantic match
     _attr_event_types = ["alert_received"]
 
     def __init__(
@@ -110,4 +110,5 @@ def _device_info(entry: ConfigEntry) -> DeviceInfo:
         manufacturer="Ubiquiti",
         model="UniFi Network Controller",
         entry_type=DeviceEntryType.SERVICE,
+        configuration_url=entry.data.get(CONF_CONTROLLER_URL),
     )

--- a/custom_components/unifi_alerts/sensor.py
+++ b/custom_components/unifi_alerts/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
@@ -15,6 +16,7 @@ from .const import (
     CATEGORY_ICONS,
     CATEGORY_ICONS_OK,
     CATEGORY_LABELS,
+    CONF_CONTROLLER_URL,
     DATA_COORDINATOR,
     DOMAIN,
 )
@@ -43,6 +45,7 @@ class UniFiCategoryMessageSensor(CoordinatorEntity[UniFiAlertsCoordinator], Sens
     """Sensor whose state is the last alert message for a category."""
 
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,
@@ -57,10 +60,10 @@ class UniFiCategoryMessageSensor(CoordinatorEntity[UniFiAlertsCoordinator], Sens
         self._attr_device_info = _device_info(entry)
 
     @property
-    def native_value(self) -> str | None:
+    def native_value(self) -> str:
         state: CategoryState | None = self.coordinator.get_category_state(self._category)
         if not state or not state.last_alert:
-            return None
+            return "No alerts yet"
         return state.last_alert.message
 
     @property
@@ -160,4 +163,5 @@ def _device_info(entry: ConfigEntry) -> DeviceInfo:
         manufacturer="Ubiquiti",
         model="UniFi Network Controller",
         entry_type=DeviceEntryType.SERVICE,
+        configuration_url=entry.data.get(CONF_CONTROLLER_URL),
     )

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -115,9 +115,9 @@
           "verify_ssl": "Verify SSL certificate"
         }
       },
-      "init": {
+      "categories": {
         "title": "Update Alert Categories",
-        "description": "Update your alert category settings. Webhook URLs for your enabled categories are shown below — copy them into UniFi Alarm Manager as needed.",
+        "description": "Update which alert types to monitor and adjust polling settings. Webhook URLs will be shown in the next step.",
         "data": {
           "cat_network_device": "Network: Device offline/online",
           "cat_network_wan": "Network: WAN offline/latency",
@@ -128,7 +128,13 @@
           "cat_power": "Power: PoE / power loss",
           "poll_interval": "Polling interval (seconds)",
           "clear_timeout": "Auto-clear timeout (minutes)",
-          "site": "UniFi site name",
+          "site": "UniFi site name"
+        }
+      },
+      "finish": {
+        "title": "Webhook URLs",
+        "description": "Copy each webhook URL into UniFi Alarm Manager, then click **Submit** to save the changes.",
+        "data": {
           "webhook_url_network_device": "Network: Device offline/online webhook URL",
           "webhook_url_network_wan": "Network: WAN offline/latency webhook URL",
           "webhook_url_network_client": "Network: Client connect/disconnect webhook URL",

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -115,9 +115,9 @@
           "verify_ssl": "Verify SSL certificate"
         }
       },
-      "init": {
+      "categories": {
         "title": "Update Alert Categories",
-        "description": "Update your alert category settings. Webhook URLs for your enabled categories are shown below — copy them into UniFi Alarm Manager as needed.",
+        "description": "Update which alert types to monitor and adjust polling settings. Webhook URLs will be shown in the next step.",
         "data": {
           "cat_network_device": "Network: Device offline/online",
           "cat_network_wan": "Network: WAN offline/latency",
@@ -128,7 +128,13 @@
           "cat_power": "Power: PoE / power loss",
           "poll_interval": "Polling interval (seconds)",
           "clear_timeout": "Auto-clear timeout (minutes)",
-          "site": "UniFi site name",
+          "site": "UniFi site name"
+        }
+      },
+      "finish": {
+        "title": "Webhook URLs",
+        "description": "Copy each webhook URL into UniFi Alarm Manager, then click **Submit** to save the changes.",
+        "data": {
           "webhook_url_network_device": "Network: Device offline/online webhook URL",
           "webhook_url_network_wan": "Network: WAN offline/latency webhook URL",
           "webhook_url_network_client": "Network: Client connect/disconnect webhook URL",

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -228,8 +228,8 @@ async def test_finish_submit_creates_entry() -> None:
 
 
 @pytest.mark.asyncio
-async def test_options_init_includes_webhook_urls() -> None:
-    """Options flow categories step should include webhook URL fields in data_schema."""
+async def test_options_finish_includes_webhook_urls() -> None:
+    """Options flow finish step should include webhook URL fields with the stored secret."""
     fake_secret = "options-test-secret"
     config_entry = MagicMock()
     config_entry.data = {CONF_ENABLED_CATEGORIES: ALL_CATEGORIES, CONF_WEBHOOK_SECRET: fake_secret}
@@ -237,28 +237,127 @@ async def test_options_init_includes_webhook_urls() -> None:
 
     flow = UniFiAlertsOptionsFlow(config_entry)
     flow.hass = MagicMock()
-    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "init"})
+    flow._pending_options = {CONF_ENABLED_CATEGORIES: ALL_CATEGORIES}
+    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "finish"})
 
     fake_url = "http://homeassistant.local:8123/api/webhook/unifi_alerts_network_device"
     with patch(
         "custom_components.unifi_alerts.config_flow.async_generate_url",
         return_value=fake_url,
     ):
-        result = await flow.async_step_categories(user_input=None)
+        result = await flow.async_step_finish(user_input=None)
 
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "finish"
     call_kwargs = flow.async_show_form.call_args.kwargs
     schema = call_kwargs["data_schema"]
-    # Webhook URLs must be present as field defaults in the schema (filter to strings only
-    # because the options schema also contains booleans for category toggles).
     str_defaults = [v for v in (k.default() for k in schema.schema) if isinstance(v, str)]
     assert any(f"?token={fake_secret}" in v for v in str_defaults)
     assert any(fake_url in v for v in str_defaults)
 
 
 @pytest.mark.asyncio
-async def test_options_init_reads_entry_options_over_data() -> None:
-    """Options flow must prefer entry.options over entry.data for saved settings."""
+async def test_options_categories_submit_routes_to_finish() -> None:
+    """Submitting valid categories should call async_step_finish (not create_entry directly)."""
+    config_entry = MagicMock()
+    config_entry.data = {CONF_ENABLED_CATEGORIES: ALL_CATEGORIES, CONF_WEBHOOK_SECRET: "s"}
+    config_entry.options = {}
+
+    flow = UniFiAlertsOptionsFlow(config_entry)
+    flow.hass = MagicMock()
+    finish_result = {"type": "form", "step_id": "finish"}
+    flow.async_step_finish = AsyncMock(return_value=finish_result)
+
+    cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+    result = await flow.async_step_categories(cat_input)
+
+    flow.async_step_finish.assert_called_once()
+    assert result["step_id"] == "finish"
+
+
+@pytest.mark.asyncio
+async def test_options_finish_submit_creates_entry() -> None:
+    """Submitting the finish step (empty user_input) must call async_create_entry with pending options."""
+    from custom_components.unifi_alerts.const import CONF_CLEAR_TIMEOUT, CONF_POLL_INTERVAL, CONF_SITE
+
+    config_entry = MagicMock()
+    config_entry.data = {CONF_ENABLED_CATEGORIES: ALL_CATEGORIES, CONF_WEBHOOK_SECRET: "s"}
+    config_entry.options = {}
+
+    flow = UniFiAlertsOptionsFlow(config_entry)
+    flow.hass = MagicMock()
+    flow._pending_options = {
+        CONF_ENABLED_CATEGORIES: [ALL_CATEGORIES[0]],
+        CONF_POLL_INTERVAL: 300,
+        CONF_CLEAR_TIMEOUT: 60,
+        CONF_SITE: "default",
+    }
+    flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+    result = await flow.async_step_finish(user_input={})
+
+    flow.async_create_entry.assert_called_once()
+    call_kwargs = flow.async_create_entry.call_args.kwargs
+    assert call_kwargs["title"] == ""
+    assert call_kwargs["data"] is flow._pending_options
+    assert result["type"] == "create_entry"
+
+
+@pytest.mark.asyncio
+async def test_options_flow_full_cycle() -> None:
+    """Full options flow: blank credentials → categories → finish → create_entry."""
+    from custom_components.unifi_alerts.const import CONF_CLEAR_TIMEOUT, CONF_POLL_INTERVAL, CONF_SITE
+
+    config_entry = MagicMock()
+    config_entry.data = {
+        CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+        CONF_WEBHOOK_SECRET: "full-cycle-secret",
+        CONF_POLL_INTERVAL: 60,
+        CONF_CLEAR_TIMEOUT: 5,
+    }
+    config_entry.options = {}
+
+    flow = UniFiAlertsOptionsFlow(config_entry)
+    hass = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+    hass.config_entries.async_update_entry = MagicMock()
+    flow.hass = hass
+    flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+    # Step 1: blank credentials → skip to categories
+    blank_creds = {CONF_CONTROLLER_URL: "", CONF_USERNAME: "", CONF_PASSWORD: "", CONF_API_KEY: "", CONF_VERIFY_SSL: True}
+    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
+    await flow.async_step_credentials(blank_creds)
+
+    # Step 2: submit categories
+    first_cat = ALL_CATEGORIES[0]
+    cat_input = {f"cat_{cat}": (cat == first_cat) for cat in ALL_CATEGORIES}
+    cat_input[CONF_POLL_INTERVAL] = 120
+    cat_input[CONF_CLEAR_TIMEOUT] = 10
+    cat_input[CONF_SITE] = "default"
+
+    with patch(
+        "custom_components.unifi_alerts.config_flow.async_generate_url",
+        return_value="http://ha.local/webhook/x",
+    ):
+        await flow.async_step_categories(cat_input)
+
+    # Step 3: submit finish → create_entry
+    with patch(
+        "custom_components.unifi_alerts.config_flow.async_generate_url",
+        return_value="http://ha.local/webhook/x",
+    ):
+        result = await flow.async_step_finish(user_input={})
+
+    assert result["type"] == "create_entry"
+    saved = flow.async_create_entry.call_args.kwargs["data"]
+    assert saved[CONF_ENABLED_CATEGORIES] == [first_cat]
+    assert saved[CONF_POLL_INTERVAL] == 120
+    assert saved[CONF_CLEAR_TIMEOUT] == 10
+
+
+@pytest.mark.asyncio
+async def test_options_categories_reads_entry_options_over_data() -> None:
+    """Options flow categories step must prefer entry.options over entry.data for saved settings."""
     from custom_components.unifi_alerts.const import (
         CONF_CLEAR_TIMEOUT,
         CONF_POLL_INTERVAL,
@@ -286,14 +385,12 @@ async def test_options_init_reads_entry_options_over_data() -> None:
 
     flow = UniFiAlertsOptionsFlow(config_entry)
     flow.hass = MagicMock()
-    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "init"})
+    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
 
-    with patch(
-        "custom_components.unifi_alerts.config_flow.async_generate_url", return_value="http://x"
-    ):
-        await flow.async_step_categories(user_input=None)
+    await flow.async_step_categories(user_input=None)
 
     call_kwargs = flow.async_show_form.call_args.kwargs
+    assert call_kwargs["step_id"] == "categories"
     schema = call_kwargs["data_schema"]
     # The schema's defaults must reflect the options values, not the data values
     schema_defaults = {str(k): k.default() for k in schema.schema}
@@ -472,7 +569,7 @@ async def test_categories_step_accepts_boundary_clear_timeouts(clear_timeout: in
 
 @pytest.mark.asyncio
 async def test_options_flow_saves_submitted_values() -> None:
-    """Submitting the options flow must persist the selected categories and intervals."""
+    """Submitting the options flow (categories → finish) must persist the selected categories and intervals."""
     from custom_components.unifi_alerts.const import (
         CONF_CLEAR_TIMEOUT,
         CONF_POLL_INTERVAL,
@@ -499,7 +596,19 @@ async def test_options_flow_saves_submitted_values() -> None:
     user_input[CONF_CLEAR_TIMEOUT] = 60
     user_input[CONF_SITE] = "secondary"
 
-    result = await flow.async_step_categories(user_input)
+    # Submit categories (stores in _pending_options, routes to finish)
+    with patch(
+        "custom_components.unifi_alerts.config_flow.async_generate_url",
+        return_value="http://ha.local/webhook/x",
+    ):
+        await flow.async_step_categories(user_input)
+
+    # Submit finish → creates entry
+    with patch(
+        "custom_components.unifi_alerts.config_flow.async_generate_url",
+        return_value="http://ha.local/webhook/x",
+    ):
+        result = await flow.async_step_finish(user_input={})
 
     assert result["type"] == "create_entry"
     saved = flow.async_create_entry.call_args.kwargs["data"]
@@ -572,16 +681,12 @@ async def test_options_flow_rejects_all_disabled() -> None:
 
     flow = UniFiAlertsOptionsFlow(config_entry)
     flow.hass = MagicMock()
-    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "init"})
+    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
 
     all_off = {f"cat_{cat}": False for cat in ALL_CATEGORIES}
-    with patch(
-        "custom_components.unifi_alerts.config_flow.async_generate_url",
-        return_value="http://ha.local/webhook/x",
-    ):
-        result = await flow.async_step_categories(all_off)
+    result = await flow.async_step_categories(all_off)
 
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "categories"
     call_kwargs = flow.async_show_form.call_args.kwargs
     assert call_kwargs["errors"] == {"base": "at_least_one_category"}
 
@@ -842,7 +947,7 @@ class TestOptionsFlowCredentials:
     async def test_blank_submission_skips_to_categories(self) -> None:
         """Submitting all-blank credentials skips to the categories step without any auth call."""
         flow = _make_options_flow()
-        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "init"})
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
 
         blank_input = {
             CONF_CONTROLLER_URL: "",
@@ -852,14 +957,10 @@ class TestOptionsFlowCredentials:
             CONF_VERIFY_SSL: True,
         }
 
-        with patch(
-            "custom_components.unifi_alerts.config_flow.async_generate_url",
-            return_value="http://ha.local/webhook/x",
-        ):
-            result = await flow.async_step_credentials(blank_input)
+        result = await flow.async_step_credentials(blank_input)
 
-        # Should have proceeded to categories (step_id="init" is the categories form)
-        assert result["step_id"] == "init"
+        # Should have proceeded to categories
+        assert result["step_id"] == "categories"
         # No entry update should have occurred
         flow.hass.config_entries.async_update_entry.assert_not_called()
 
@@ -867,7 +968,7 @@ class TestOptionsFlowCredentials:
     async def test_valid_new_credentials_updates_entry_data(self) -> None:
         """Submitting new valid credentials must update entry.data and continue to categories."""
         flow = _make_options_flow()
-        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "init"})
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
 
         new_creds = {
             CONF_CONTROLLER_URL: "https://10.0.0.1",
@@ -883,10 +984,6 @@ class TestOptionsFlowCredentials:
                 return_value=_make_session_mock(),
             ),
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
-            patch(
-                "custom_components.unifi_alerts.config_flow.async_generate_url",
-                return_value="http://ha.local/webhook/x",
-            ),
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value="userpass")
@@ -902,7 +999,7 @@ class TestOptionsFlowCredentials:
         assert updated_data[CONF_PASSWORD] == "newpass"
 
         # Should have continued to categories
-        assert result["step_id"] == "init"
+        assert result["step_id"] == "categories"
 
     @pytest.mark.asyncio
     async def test_invalid_credentials_shows_error_and_does_not_update(self) -> None:
@@ -1008,11 +1105,11 @@ class TestOptionsFlowCredentials:
 
     @pytest.mark.asyncio
     async def test_after_credential_update_categories_proceeds_normally(self) -> None:
-        """After a successful credentials update, the categories step saves options as usual."""
+        """After a successful credentials update, categories → finish → create_entry works end-to-end."""
         from custom_components.unifi_alerts.const import CONF_CLEAR_TIMEOUT, CONF_POLL_INTERVAL
 
         flow = _make_options_flow()
-        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "init"})
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
         flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
 
         # First: update credentials
@@ -1030,10 +1127,6 @@ class TestOptionsFlowCredentials:
                 return_value=_make_session_mock(),
             ),
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
-            patch(
-                "custom_components.unifi_alerts.config_flow.async_generate_url",
-                return_value="http://ha.local/webhook/x",
-            ),
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value="userpass")
@@ -1042,7 +1135,7 @@ class TestOptionsFlowCredentials:
 
             await flow.async_step_credentials(new_creds)
 
-        # Now: submit the categories step
+        # Now: submit the categories step (stores in _pending_options, routes to finish)
         first_cat = ALL_CATEGORIES[0]
         cat_input = {f"cat_{cat}": (cat == first_cat) for cat in ALL_CATEGORIES}
         cat_input[CONF_POLL_INTERVAL] = 90
@@ -1052,7 +1145,14 @@ class TestOptionsFlowCredentials:
             "custom_components.unifi_alerts.config_flow.async_generate_url",
             return_value="http://ha.local/webhook/x",
         ):
-            result = await flow.async_step_categories(cat_input)
+            await flow.async_step_categories(cat_input)
+
+        # Submit finish → create_entry
+        with patch(
+            "custom_components.unifi_alerts.config_flow.async_generate_url",
+            return_value="http://ha.local/webhook/x",
+        ):
+            result = await flow.async_step_finish(user_input={})
 
         assert result["type"] == "create_entry"
         saved = flow.async_create_entry.call_args.kwargs["data"]

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -234,14 +234,14 @@ class TestUniFiCategoryMessageSensor:
         entity = self._make(state)
         assert entity.native_value == "WAN went down"
 
-    def test_native_value_none_when_no_alert(self):
+    def test_native_value_default_when_no_alert(self):
         state = make_state()
         entity = self._make(state)
-        assert entity.native_value is None
+        assert entity.native_value == "No alerts yet"
 
-    def test_native_value_none_when_state_missing(self):
+    def test_native_value_default_when_state_missing(self):
         entity = self._make(None)
-        assert entity.native_value is None
+        assert entity.native_value == "No alerts yet"
 
     def test_available_true_when_enabled(self):
         state = make_state(enabled=True)
@@ -523,3 +523,105 @@ class TestUniFiClearAllButton:
         entity = self._make(states)
         await entity.async_press()
         entity._coordinator.async_set_updated_data.assert_called_once()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Device info — configuration_url + proactive registration cross-checks
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestDeviceInfo:
+    """_device_info() helpers in all four platforms must include configuration_url."""
+
+    def test_binary_sensor_device_info_has_configuration_url(self):
+        from custom_components.unifi_alerts.binary_sensor import _device_info
+
+        entry = make_entry()
+        info = _device_info(entry)
+        assert info["configuration_url"] == entry.data["controller_url"]
+
+    def test_sensor_device_info_has_configuration_url(self):
+        from custom_components.unifi_alerts.sensor import _device_info
+
+        entry = make_entry()
+        info = _device_info(entry)
+        assert info["configuration_url"] == entry.data["controller_url"]
+
+    def test_event_device_info_has_configuration_url(self):
+        from custom_components.unifi_alerts.event import _device_info
+
+        entry = make_entry()
+        info = _device_info(entry)
+        assert info["configuration_url"] == entry.data["controller_url"]
+
+    def test_button_device_info_has_configuration_url(self):
+        from custom_components.unifi_alerts.button import _device_info
+
+        entry = make_entry()
+        info = _device_info(entry)
+        assert info["configuration_url"] == entry.data["controller_url"]
+
+    def test_all_platforms_share_identical_identifiers(self):
+        from custom_components.unifi_alerts.binary_sensor import _device_info as bs_info
+        from custom_components.unifi_alerts.button import _device_info as btn_info
+        from custom_components.unifi_alerts.event import _device_info as ev_info
+        from custom_components.unifi_alerts.sensor import _device_info as s_info
+
+        entry = make_entry()
+        assert bs_info(entry)["identifiers"] == s_info(entry)["identifiers"]
+        assert bs_info(entry)["identifiers"] == ev_info(entry)["identifiers"]
+        assert bs_info(entry)["identifiers"] == btn_info(entry)["identifiers"]
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Entity categories + message sensor default
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestEntityCategories:
+    """Verify entity_category assignments for the polish items bundled into v1.3."""
+
+    def test_message_sensor_is_diagnostic(self):
+        from homeassistant.const import EntityCategory
+
+        from custom_components.unifi_alerts.sensor import UniFiCategoryMessageSensor
+
+        # CachedProperties metaclass stores _attr_* backing values as __attr_* in __dict__
+        assert UniFiCategoryMessageSensor.__dict__.get("__attr_entity_category") == EntityCategory.DIAGNOSTIC
+
+    def test_clear_category_button_is_config(self):
+        from homeassistant.const import EntityCategory
+
+        from custom_components.unifi_alerts.button import UniFiClearCategoryButton
+
+        assert UniFiClearCategoryButton.__dict__.get("__attr_entity_category") == EntityCategory.CONFIG
+
+    def test_clear_all_button_is_config(self):
+        from homeassistant.const import EntityCategory
+
+        from custom_components.unifi_alerts.button import UniFiClearAllButton
+
+        assert UniFiClearAllButton.__dict__.get("__attr_entity_category") == EntityCategory.CONFIG
+
+    def test_event_entity_has_no_device_class(self):
+        from custom_components.unifi_alerts.event import UniFiAlertEventEntity
+
+        # __attr_device_class is the CachedProperties backing key; absent means no override
+        assert "__attr_device_class" not in UniFiAlertEventEntity.__dict__
+
+    def test_message_sensor_returns_no_alerts_yet_when_empty(self):
+        from custom_components.unifi_alerts.sensor import UniFiCategoryMessageSensor
+
+        coord = make_coordinator({CATEGORY_NETWORK_WAN: make_state()})
+        entry = make_entry()
+        entity = UniFiCategoryMessageSensor(coord, entry, CATEGORY_NETWORK_WAN)
+        assert entity.native_value == "No alerts yet"
+
+    def test_message_sensor_returns_message_when_alert_present(self):
+        from custom_components.unifi_alerts.sensor import UniFiCategoryMessageSensor
+
+        alert = make_alert(message="WAN went down")
+        coord = make_coordinator({CATEGORY_NETWORK_WAN: make_state(last_alert=alert)})
+        entry = make_entry()
+        entity = UniFiCategoryMessageSensor(coord, entry, CATEGORY_NETWORK_WAN)
+        assert entity.native_value == "WAN went down"

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -10,6 +10,7 @@ from conftest import make_entry, make_hass
 from custom_components.unifi_alerts.const import (
     ALL_CATEGORIES,
     CONF_CLEAR_TIMEOUT,
+    CONF_CONTROLLER_URL,
     CONF_ENABLED_CATEGORIES,
     CONF_POLL_INTERVAL,
     CONF_VERIFY_SSL,
@@ -68,6 +69,7 @@ class TestAsyncSetupEntry:
                 return_value=mock_coordinator,
             ),
             patch("custom_components.unifi_alerts.WebhookManager", return_value=mock_wm),
+            patch("custom_components.unifi_alerts.dr.async_get", return_value=MagicMock()),
         ):
             result = await async_setup_entry(hass, entry)
 
@@ -91,6 +93,7 @@ class TestAsyncSetupEntry:
                 return_value=mock_coordinator,
             ),
             patch("custom_components.unifi_alerts.WebhookManager", return_value=mock_wm),
+            patch("custom_components.unifi_alerts.dr.async_get", return_value=MagicMock()),
         ):
             await async_setup_entry(hass, entry)
 
@@ -121,6 +124,7 @@ class TestAsyncSetupEntry:
                 return_value=mock_coordinator,
             ),
             patch("custom_components.unifi_alerts.WebhookManager", return_value=mock_wm),
+            patch("custom_components.unifi_alerts.dr.async_get", return_value=MagicMock()),
             pytest.raises(ConfigEntryNotReady),
         ):
             await async_setup_entry(hass, entry)
@@ -147,6 +151,7 @@ class TestAsyncSetupEntry:
                 return_value=mock_coordinator,
             ),
             patch("custom_components.unifi_alerts.WebhookManager", return_value=mock_wm),
+            patch("custom_components.unifi_alerts.dr.async_get", return_value=MagicMock()),
             pytest.raises(ConfigEntryNotReady),
         ):
             await async_setup_entry(hass, entry)
@@ -181,6 +186,7 @@ class TestAsyncSetupEntry:
                 return_value=mock_coordinator,
             ),
             patch("custom_components.unifi_alerts.WebhookManager", return_value=mock_wm),
+            patch("custom_components.unifi_alerts.dr.async_get", return_value=MagicMock()),
         ):
             await async_setup_entry(hass, entry)
 
@@ -206,6 +212,7 @@ class TestAsyncSetupEntry:
                 return_value=mock_coordinator,
             ),
             patch("custom_components.unifi_alerts.WebhookManager", return_value=mock_wm),
+            patch("custom_components.unifi_alerts.dr.async_get", return_value=MagicMock()),
         ):
             await async_setup_entry(hass, entry)
 
@@ -230,6 +237,7 @@ class TestAsyncSetupEntry:
                 return_value=mock_coordinator,
             ),
             patch("custom_components.unifi_alerts.WebhookManager", return_value=mock_wm),
+            patch("custom_components.unifi_alerts.dr.async_get", return_value=MagicMock()),
         ):
             await async_setup_entry(hass, entry)
 
@@ -334,6 +342,76 @@ class TestAsyncUnloadEntry:
         await async_unload_entry(hass, entry)
 
         assert call_order == ["shutdown", "unregister", "close"]
+
+
+# ── device registry ───────────────────────────────────────────────────────────
+
+
+class TestDeviceRegistration:
+    """async_setup_entry must proactively register the hub device."""
+
+    @pytest.mark.asyncio
+    async def test_setup_creates_service_device(self):
+        """async_setup_entry must call async_get_or_create with SERVICE entry type."""
+        from homeassistant.helpers.device_registry import DeviceEntryType
+
+        from custom_components.unifi_alerts import async_setup_entry
+
+        hass = make_hass()
+        entry = make_entry()
+        mock_client, mock_coordinator, mock_wm = _patch_all()
+
+        mock_dev_reg = MagicMock()
+        mock_dev_reg.async_get_or_create = MagicMock()
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.async_get_clientsession", return_value=MagicMock()
+            ),
+            patch("custom_components.unifi_alerts.UniFiClient", return_value=mock_client),
+            patch(
+                "custom_components.unifi_alerts.UniFiAlertsCoordinator",
+                return_value=mock_coordinator,
+            ),
+            patch("custom_components.unifi_alerts.WebhookManager", return_value=mock_wm),
+            patch("custom_components.unifi_alerts.dr.async_get", return_value=mock_dev_reg),
+        ):
+            await async_setup_entry(hass, entry)
+
+        mock_dev_reg.async_get_or_create.assert_called_once()
+        call_kwargs = mock_dev_reg.async_get_or_create.call_args.kwargs
+        assert call_kwargs["config_entry_id"] == entry.entry_id
+        assert call_kwargs["entry_type"] == DeviceEntryType.SERVICE
+        assert (DOMAIN, entry.entry_id) in call_kwargs["identifiers"]
+
+    @pytest.mark.asyncio
+    async def test_setup_device_has_configuration_url(self):
+        """The registered device must carry the controller URL as configuration_url."""
+        from custom_components.unifi_alerts import async_setup_entry
+
+        hass = make_hass()
+        entry = make_entry()
+        mock_client, mock_coordinator, mock_wm = _patch_all()
+
+        mock_dev_reg = MagicMock()
+        mock_dev_reg.async_get_or_create = MagicMock()
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.async_get_clientsession", return_value=MagicMock()
+            ),
+            patch("custom_components.unifi_alerts.UniFiClient", return_value=mock_client),
+            patch(
+                "custom_components.unifi_alerts.UniFiAlertsCoordinator",
+                return_value=mock_coordinator,
+            ),
+            patch("custom_components.unifi_alerts.WebhookManager", return_value=mock_wm),
+            patch("custom_components.unifi_alerts.dr.async_get", return_value=mock_dev_reg),
+        ):
+            await async_setup_entry(hass, entry)
+
+        call_kwargs = mock_dev_reg.async_get_or_create.call_args.kwargs
+        assert call_kwargs["configuration_url"] == entry.data[CONF_CONTROLLER_URL]
 
 
 # ── _async_update_listener ────────────────────────────────────────────────────

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -380,6 +380,7 @@ class TestServicesWiredFromInit:
                 return_value=mock_coord,
             ),
             patch("custom_components.unifi_alerts.WebhookManager", return_value=mock_wm),
+            patch("custom_components.unifi_alerts.dr.async_get", return_value=MagicMock()),
             patch(
                 "custom_components.unifi_alerts.async_register_services"
             ) as mock_register,


### PR DESCRIPTION
## Summary

Three production-confirmed bugs from the v1.3.0-pre2 install, all resolved in this PR:

- **Options flow loops between pages 1 and 2** — `async_step_categories` used `step_id="init"`, causing every submit to re-route to `async_step_init` → credentials. Rewrote `UniFiAlertsOptionsFlow` as a 3-step flow mirroring initial setup: credentials → categories → finish (webhook URLs).
- **No device/service parent visible** — entities had correct `DeviceInfo` but no proactive registration in `async_setup_entry`. Added `dr.async_get_or_create(...)` before platform forwarding, and added `configuration_url` to all four `_device_info()` helpers so the Services card is clickable.
- **Blank entities / can't click** — `UniFiCategoryMessageSensor.native_value` returned `None` before first alert. Changed to return `"No alerts yet"`. Also bundled v1.2 polish: `EntityCategory.DIAGNOSTIC` on message sensors, `EntityCategory.CONFIG` on clear buttons, removed wrong `EventDeviceClass.BUTTON` from event entities.

## Files changed

| File | Change |
|---|---|
| `config_flow.py` | Rewrite `UniFiAlertsOptionsFlow` to 3-step flow |
| `strings.json` / `translations/en.json` | Replace options step definitions (credentials, categories, finish) |
| `__init__.py` | Proactive device registration via `dr.async_get_or_create` |
| `binary_sensor.py`, `sensor.py`, `event.py`, `button.py` | Add `configuration_url` to `_device_info()`; entity category + device_class fixes |
| `test_config_flow.py` | Rework options-flow tests for 3-step flow (5 new, several updated) |
| `test_init.py` | Add `TestDeviceRegistration` (2 new tests); patch `dr.async_get` in existing setup tests |
| `test_entities.py` | New `TestDeviceInfo` (5 tests) + `TestEntityCategories` (6 tests) |
| `test_services.py` | Patch `dr.async_get` in setup-calling test |
| `README.md` | Add automation caveats subsection |
| `HISTORY.md`, `TODO.md`, `ROADMAP.md` | Bookkeeping |

## Test plan

- [x] `make check` clean — 346 tests pass, 0 fail (ruff, mypy, HACS validation, translation drift, pytest)
- [ ] Manual: Settings → Integrations → UniFi Alerts → Configure — confirm 3 pages (credentials → categories → webhook URLs → saved)
- [ ] Manual: Settings → Devices & Services → UniFi Alerts — confirm "Services" row appears and is clickable to controller URL
- [ ] Manual: Fresh install, no webhooks fired — message sensors show "No alerts yet", count sensors show 0

https://claude.ai/code/session_01VRw9SWaxYbJthD5NmQPvLz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRw9SWaxYbJthD5NmQPvLz)_