### PR TITLE
chore: bump version to 1.3.0-pre3

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": ["aiohttp>=3.9.0"],
-  "version": "1.3.0-pre2"
+  "version": "1.3.0-pre3"
 }


### PR DESCRIPTION
Bumps `manifest.json` version from `1.3.0-pre2` → `1.3.0-pre3` after merging PR #36 (three v1.3.0 post-install bug fixes).

Once CI is green and this merges, push tag `v1.3.0-pre3` to trigger the pre-release.

https://claude.ai/code/session_01VRw9SWaxYbJthD5NmQPvLz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRw9SWaxYbJthD5NmQPvLz)_