### PR TITLE
Reverse alarm endpoint fallback order and handle 400 InvalidObject

### DIFF
--- a/custom_components/unifi_alerts/unifi_client.py
+++ b/custom_components/unifi_alerts/unifi_client.py
@@ -102,17 +102,17 @@ class UniFiClient:
             await self.authenticate()
 
         # Different firmware versions expose different alarm endpoint paths.
-        # We try the documented /stat/alarm path first, then fall back to the
-        # bare /alarm path for older firmware that may not expose /stat/alarm.
+        # Try the bare /alarm path first (more universally supported), then
+        # fall back to /stat/alarm for firmware that only exposes that variant.
         alarm_paths = [
-            self._network_path(f"/api/s/{site}/stat/alarm"),
             self._network_path(f"/api/s/{site}/alarm"),
+            self._network_path(f"/api/s/{site}/stat/alarm"),
         ]
         for path in alarm_paths:
             result = await self._try_fetch_alarms(path, site)
             if result is not None:
                 return result
-            # None means 404 — try the next path
+            # None means path not found (404 or api.err.InvalidObject) — try next
         raise CannotConnectError(
             f"Could not find the alarm endpoint for site '{site}'. Tried: {', '.join(alarm_paths)}"
         )
@@ -135,15 +135,24 @@ class UniFiClient:
                     _LOGGER.debug("Alarm path %s returned 404 — trying next path", path)
                     return None
                 if resp.status == 400:
-                    # UniFi returns JSON even on 400 — try to surface the msg field.
-                    detail = ""
+                    # UniFi returns JSON even on 400 — parse the msg field.
+                    # Some firmware returns 400 + api.err.InvalidObject for paths that
+                    # don't exist on that firmware version (instead of 404), so treat
+                    # that error code as "path not found" and let the caller try the
+                    # next path. Any other 400 is a genuine error worth surfacing.
+                    unifi_msg = ""
                     try:
                         body = await resp.json(content_type=None)
                         unifi_msg = body.get("meta", {}).get("msg", "")
-                        if unifi_msg:
-                            detail = f" ({unifi_msg})"
                     except Exception:  # noqa: BLE001
                         pass
+                    if unifi_msg == "api.err.InvalidObject":
+                        _LOGGER.debug(
+                            "Alarm path %s returned 400 api.err.InvalidObject — trying next path",
+                            path,
+                        )
+                        return None
+                    detail = f" ({unifi_msg})" if unifi_msg else ""
                     raise CannotConnectError(
                         f"Alarm endpoint rejected the request (HTTP 400{detail}). "
                         f"Check that the site name '{site}' exists on the controller."

--- a/tests/unit/test_unifi_client.py
+++ b/tests/unit/test_unifi_client.py
@@ -549,12 +549,11 @@ class TestFetchAlarms:
         )
 
     @pytest.mark.asyncio
-    async def test_tries_stat_alarm_path_first(self):
-        """fetch_alarms must try /stat/alarm before the bare /alarm fallback.
+    async def test_tries_bare_alarm_path_first(self):
+        """fetch_alarms must try bare /alarm before the /stat/alarm fallback.
 
-        /stat/alarm is the documented UniFi Network API path and works on
-        modern firmware.  The bare /alarm is kept as a fallback for older firmware
-        that may not expose /stat/alarm.
+        /alarm is more universally supported across firmware versions; /stat/alarm
+        is kept as a fallback for firmware that only exposes that variant.
         """
         client = make_client()
         client._authenticated = True
@@ -577,15 +576,15 @@ class TestFetchAlarms:
 
         assert captured_urls, "Expected at least one GET call"
         first_url = captured_urls[0]
-        assert first_url.endswith("/stat/alarm"), (
-            f"First URL tried must end with /stat/alarm; got: {first_url}"
+        assert first_url.endswith("/alarm") and not first_url.endswith("/stat/alarm"), (
+            f"First URL tried must end with bare /alarm; got: {first_url}"
         )
-        # Only one call expected — /stat/alarm worked, no fallback needed
+        # Only one call expected — /alarm worked, no fallback needed
         assert len(captured_urls) == 1
 
     @pytest.mark.asyncio
     async def test_falls_back_to_stat_alarm_on_404(self):
-        """fetch_alarms must try /stat/alarm when /alarm returns 404.
+        """fetch_alarms must try /stat/alarm when bare /alarm returns 404.
 
         Some controller firmware versions expose /stat/alarm but not bare /alarm.
         The fallback ensures the integration works across firmware versions.
@@ -618,6 +617,43 @@ class TestFetchAlarms:
         assert result == []
 
     @pytest.mark.asyncio
+    async def test_falls_back_to_stat_alarm_on_400_invalid_object(self):
+        """fetch_alarms must try /stat/alarm when bare /alarm returns 400 api.err.InvalidObject.
+
+        Some firmware returns 400 + api.err.InvalidObject for endpoint paths that don't
+        exist on that firmware version (instead of the more conventional 404).  The
+        integration must treat this the same as 404 and try the next path.
+        """
+        client = make_client()
+        client._authenticated = True
+        client._is_unifi_os = True
+
+        call_count = [0]
+        invalid_body = {"meta": {"rc": "error", "msg": "api.err.InvalidObject"}, "data": []}
+
+        @asynccontextmanager
+        async def _invalid_object_then_200(*args, **kwargs):
+            call_count[0] += 1
+            resp = MagicMock()
+            if call_count[0] == 1:
+                resp.status = 400
+                resp.headers = {}
+                resp.raise_for_status = MagicMock()
+                resp.json = AsyncMock(return_value=invalid_body)
+            else:
+                resp.status = 200
+                resp.headers = {}
+                resp.raise_for_status = MagicMock()
+                resp.json = AsyncMock(return_value={"meta": {"rc": "ok"}, "data": []})
+            yield resp
+
+        client._session.get = _invalid_object_then_200
+        result = await client.fetch_alarms()
+
+        assert call_count[0] == 2, "Expected exactly two GET calls (primary + fallback)"
+        assert result == []
+
+    @pytest.mark.asyncio
     async def test_all_paths_404_raises_cannot_connect(self):
         """When all alarm paths return 404, raise CannotConnectError with the tried paths."""
         client = make_client()
@@ -631,16 +667,29 @@ class TestFetchAlarms:
 
     @pytest.mark.asyncio
     async def test_http_400_raises_cannot_connect_with_site_hint(self):
-        """HTTP 400 from the alarm endpoint must raise CannotConnectError with actionable hint.
+        """HTTP 400 (non-InvalidObject) from the alarm endpoint raises CannotConnectError.
 
-        A 400 typically means the site name is wrong or the firmware rejects the request.
-        The error message must name the site so the user knows what to check.
+        A 400 with any error other than api.err.InvalidObject means a genuine rejection
+        (e.g. wrong site name).  The error message must name the site so the user knows
+        what to check.  api.err.InvalidObject is treated as "path not found" (see separate
+        test) and causes a fallback rather than an immediate error.
         """
         client = make_client()
         client._authenticated = True
         client._is_unifi_os = True
-        ctx = _make_response(400)
-        client._session.get = ctx
+        # Return 400 with a non-InvalidObject body so neither path is treated as "not found"
+        bad_body = {"meta": {"rc": "error", "msg": "api.err.Invalid"}, "data": []}
+
+        @asynccontextmanager
+        async def _400_bad(*args, **kwargs):
+            resp = MagicMock()
+            resp.status = 400
+            resp.headers = {}
+            resp.raise_for_status = MagicMock()
+            resp.json = AsyncMock(return_value=bad_body)
+            yield resp
+
+        client._session.get = _400_bad
 
         with pytest.raises(CannotConnectError) as exc_info:
             await client.fetch_alarms()


### PR DESCRIPTION
## Summary
This PR reverses the order of alarm endpoint path fallbacks and adds special handling for HTTP 400 responses with `api.err.InvalidObject` error codes.

## Key Changes
- **Reversed endpoint fallback order**: Changed from trying `/stat/alarm` first to trying bare `/alarm` first, as it's more universally supported across firmware versions
- **Added `api.err.InvalidObject` handling**: Treat HTTP 400 responses with `api.err.InvalidObject` error code as "path not found" and trigger fallback to the next path, since some firmware versions return this instead of 404 for non-existent endpoints
- **Updated error handling logic**: Distinguish between genuine HTTP 400 errors (which should raise `CannotConnectError`) and "path not found" scenarios (which should trigger fallback)
- **Updated documentation**: Revised docstrings and comments to reflect the new endpoint priority and error handling behavior

## Implementation Details
- The `fetch_alarms` method now tries paths in order: `/alarm` → `/stat/alarm`
- The `_try_fetch_alarms` method now returns `None` for both 404 and 400 with `api.err.InvalidObject`, signaling to try the next path
- Other HTTP 400 errors (with different error messages) still raise `CannotConnectError` with the site name hint
- Added comprehensive test coverage for the new 400 `api.err.InvalidObject` fallback behavior

https://claude.ai/code/session_014n5YaCGBfUEVvu1eyssx9K