### PR TITLE
fix: add /list/alarm to alarm endpoint probe chain (UniFi Network 9.x+)

### DIFF
--- a/custom_components/unifi_alerts/unifi_client.py
+++ b/custom_components/unifi_alerts/unifi_client.py
@@ -101,10 +101,16 @@ class UniFiClient:
         if not self._authenticated:
             await self.authenticate()
 
-        # Different firmware versions expose different alarm endpoint paths.
-        # Try the bare /alarm path first (more universally supported), then
-        # fall back to /stat/alarm for firmware that only exposes that variant.
+        # Different firmware versions expose the alarm endpoint at different paths.
+        # Try the newest path first so modern firmware succeeds in one call; fall
+        # back to older variants for backwards compatibility. Order matters —
+        # update docs/UNIFI.md § "Alarm API endpoint" if you change this list.
+        #
+        #   /list/alarm  — newest (UniFi Network 9.x+)
+        #   /alarm       — long-standing universal path
+        #   /stat/alarm  — older intermediate variant; some firmware exposes only this
         alarm_paths = [
+            self._network_path(f"/api/s/{site}/list/alarm"),
             self._network_path(f"/api/s/{site}/alarm"),
             self._network_path(f"/api/s/{site}/stat/alarm"),
         ]

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1,5 +1,13 @@
 # History
 
+## 2026-04-29 — Add `/list/alarm` to alarm endpoint probe chain
+
+UniFi Network 9.x changed the alarm endpoint path from `/stat/alarm` to `/list/alarm`. Modern firmware reporting `404` (or `400 api.err.InvalidObject`) on the previously-tried paths meant alarm polling silently fell through to error-out instead of finding the new path.
+
+- **`unifi_client.py` — added `/list/alarm` as the first probe path:** `fetch_alarms()` now walks the chain `[/list/alarm, /alarm, /stat/alarm]` newest-to-oldest. Modern firmware succeeds in one call; legacy firmware still works via fallback. The existing 404 / 400 `api.err.InvalidObject` handling treats any failure as "try the next path" and only surfaces an error to the user after every path is exhausted.
+- **`docs/UNIFI.md` — endpoint history table:** replaced the previous one-line note with an explicit three-row table (`/list/alarm` → newest, `/alarm` → long-standing, `/stat/alarm` → older intermediate). Includes a "if UniFi changes the endpoint again" pointer to the exact code + test files to update, so future maintainers don't have to rediscover the chain.
+- **Tests:** updated `TestFetchAlarms::test_tries_bare_alarm_path_first` → `test_tries_list_alarm_path_first` (asserts `/list/alarm` is the first URL fetched). Added `test_falls_back_through_full_path_chain` (404 on `/list/alarm` and `/alarm`, success on `/stat/alarm` — guards against future regressions where the chain order or contents are changed). Renamed the two existing fallback tests from `..._to_stat_alarm_...` → `..._to_next_path_...` since the chain is now three deep. 348 tests pass.
+
 ## 2026-04-29 — v1.3.0 post-install bug fixes: options flow loop, device registry, blank entities
 
 Three bugs confirmed on a production install of v1.3.0-pre2. All fixed in `claude/fix-config-flow-loop-kvZw7`. Bundled in three v1.2 ROADMAP polish items (touching the same files) to minimise churn.

--- a/docs/UNIFI.md
+++ b/docs/UNIFI.md
@@ -81,10 +81,20 @@ This endpoint **always** requires the `/proxy/network` prefix — it does not ex
 
 ## Alarm API endpoint
 
-**Self-hosted:** `GET /api/s/{site}/alarm`
-**UniFi OS:** `GET /proxy/network/api/s/{site}/alarm`
+**Self-hosted:** `GET /api/s/{site}/<path>`
+**UniFi OS:** `GET /proxy/network/api/s/{site}/<path>`
 
-> **Path variation by firmware:** Some controller firmware versions expose `/api/s/{site}/stat/alarm` instead of the bare `/alarm`. The integration tries `/alarm` first, then `/stat/alarm` as a fallback.
+> **Path variation by firmware — flagged for future maintainers.** UniFi has changed the alarm endpoint path multiple times. The integration probes them in newest-to-oldest order so modern firmware succeeds in one call:
+>
+> | Path | Era | Notes |
+> |---|---|---|
+> | `/list/alarm` | newest (UniFi Network 9.x+) | Tried first. Replaced `/stat/alarm` at some point in the 9.x release line. |
+> | `/alarm` | long-standing | Universal historical path; still present on most firmware. Tried second. |
+> | `/stat/alarm` | older intermediate | Some firmware exposes only this variant. Tried last. |
+>
+> A path that doesn't exist may return either `404` or `400 api.err.InvalidObject` depending on firmware — both are treated as "try the next path". A genuine `400` (e.g. wrong site name) is surfaced to the user only after **all** paths have been tried.
+>
+> **If UniFi changes the endpoint again:** add the new path to the head of `alarm_paths` in `unifi_client.py::fetch_alarms`, update this table, and add a fallback test in `tests/unit/test_unifi_client.py` (see `TestFetchAlarms::test_falls_back_*`).
 
 Default site name is `default`. Multi-site deployments are not currently supported (see `TODO.md`).
 

--- a/tests/unit/test_unifi_client.py
+++ b/tests/unit/test_unifi_client.py
@@ -549,11 +549,12 @@ class TestFetchAlarms:
         )
 
     @pytest.mark.asyncio
-    async def test_tries_bare_alarm_path_first(self):
-        """fetch_alarms must try bare /alarm before the /stat/alarm fallback.
+    async def test_tries_list_alarm_path_first(self):
+        """fetch_alarms must try /list/alarm before any older path.
 
-        /alarm is more universally supported across firmware versions; /stat/alarm
-        is kept as a fallback for firmware that only exposes that variant.
+        /list/alarm is the newest UniFi Network endpoint (9.x+); the older /alarm
+        and /stat/alarm paths are kept as fallbacks so the integration keeps
+        working on older firmware. See docs/UNIFI.md § "Alarm API endpoint".
         """
         client = make_client()
         client._authenticated = True
@@ -576,18 +577,60 @@ class TestFetchAlarms:
 
         assert captured_urls, "Expected at least one GET call"
         first_url = captured_urls[0]
-        assert first_url.endswith("/alarm") and not first_url.endswith("/stat/alarm"), (
-            f"First URL tried must end with bare /alarm; got: {first_url}"
+        assert first_url.endswith("/list/alarm"), (
+            f"First URL tried must end with /list/alarm; got: {first_url}"
         )
-        # Only one call expected — /alarm worked, no fallback needed
+        # Only one call expected — /list/alarm worked, no fallback needed
         assert len(captured_urls) == 1
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_stat_alarm_on_404(self):
-        """fetch_alarms must try /stat/alarm when bare /alarm returns 404.
+    async def test_falls_back_through_full_path_chain(self):
+        """fetch_alarms must walk the full path chain when each preceding path is missing.
 
-        Some controller firmware versions expose /stat/alarm but not bare /alarm.
-        The fallback ensures the integration works across firmware versions.
+        Order is: /list/alarm (newest) → /alarm → /stat/alarm (oldest). A 404 on each
+        of the first two must continue to the next; the third must succeed. This guards
+        against future regressions if someone reorders or drops an entry from
+        ``alarm_paths`` without updating both code and docs.
+        """
+        client = make_client()
+        client._authenticated = True
+        client._is_unifi_os = True
+
+        captured_urls: list[str] = []
+
+        @asynccontextmanager
+        async def _404_404_then_200(*args, **kwargs):
+            captured_urls.append(args[0] if args else "")
+            call_index = len(captured_urls)
+            resp = MagicMock()
+            resp.headers = {}
+            resp.raise_for_status = MagicMock()
+            if call_index < 3:
+                resp.status = 404
+            else:
+                resp.status = 200
+                resp.json = AsyncMock(return_value={"meta": {"rc": "ok"}, "data": []})
+            yield resp
+
+        client._session.get = _404_404_then_200
+        result = await client.fetch_alarms()
+
+        assert len(captured_urls) == 3, (
+            f"Expected exactly three GET calls walking the chain; got {len(captured_urls)}"
+        )
+        assert captured_urls[0].endswith("/list/alarm")
+        assert captured_urls[1].endswith("/alarm") and not captured_urls[1].endswith(
+            "/list/alarm"
+        )
+        assert captured_urls[2].endswith("/stat/alarm")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_next_path_on_404(self):
+        """fetch_alarms must try the next path when the current one returns 404.
+
+        Verifies the basic fallback contract for any single-step transition in the
+        chain. The first path returns 404, the second returns success.
         """
         client = make_client()
         client._authenticated = True
@@ -617,8 +660,8 @@ class TestFetchAlarms:
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_stat_alarm_on_400_invalid_object(self):
-        """fetch_alarms must try /stat/alarm when bare /alarm returns 400 api.err.InvalidObject.
+    async def test_falls_back_to_next_path_on_400_invalid_object(self):
+        """fetch_alarms must try the next path on 400 api.err.InvalidObject.
 
         Some firmware returns 400 + api.err.InvalidObject for endpoint paths that don't
         exist on that firmware version (instead of the more conventional 404).  The


### PR DESCRIPTION
## Summary

UniFi Network 9.x changed the alarm endpoint from `/stat/alarm` to `/list/alarm`. Modern firmware was returning `404` on the paths we tried, breaking alarm polling.

`fetch_alarms()` now walks the path chain newest-to-oldest:

| Path | Era |
|---|---|
| `/list/alarm` | UniFi Network 9.x+ (tried first) |
| `/alarm` | Long-standing universal path |
| `/stat/alarm` | Older intermediate variant |

Modern firmware succeeds in one call; legacy firmware still works via the existing 404 / 400 `api.err.InvalidObject` fallback handling.

## Regression-prevention

- `docs/UNIFI.md` § "Alarm API endpoint" now has an explicit history table with a maintenance pointer telling future maintainers exactly which files to update if UniFi changes the path again
- A code comment in `unifi_client.py` references the docs section so the two stay in sync
- New test `test_falls_back_through_full_path_chain` walks the entire chain on 404s — if anyone reorders or drops an entry from `alarm_paths` without updating both code and docs, the test fails

## Test plan

- [x] `make check` — 348 tests pass (was 347)
- [ ] Verify on a UniFi Network 9.x controller that polling now succeeds in a single call (visible in DEBUG logs as `Fetching alarms from .../list/alarm`)

https://claude.ai/code/session_014n5YaCGBfUEVvu1eyssx9K

---
_Generated by [Claude Code](https://claude.ai/code/session_014n5YaCGBfUEVvu1eyssx9K)_