### PR TITLE
chore: bump version to 1.3.0-pre5

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": ["aiohttp>=3.9.0"],
-  "version": "1.3.0-pre4"
+  "version": "1.3.0-pre5"
 }


### PR DESCRIPTION
Bump manifest from `1.3.0-pre4` to `1.3.0-pre5` to cut a pre-release including the `/list/alarm` endpoint fix (#41).

https://claude.ai/code/session_014n5YaCGBfUEVvu1eyssx9K

---
_Generated by [Claude Code](https://claude.ai/code/session_014n5YaCGBfUEVvu1eyssx9K)_