### PR TITLE
chore: start v1.4.0-pre1 development cycle

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": ["aiohttp>=3.9.0"],
-  "version": "1.3.0"
+  "version": "1.4.0-pre1"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+## 2026-04-29 — Start v1.4.0-pre1 cycle
+
+Bumped `manifest.json` from `1.3.0` to `1.4.0-pre1` to open the next development cycle. See `docs/TODO.md` and `docs/ROADMAP.md § v1.4.0` for the planned work: UniFi OS only simplification, open-count watermark (PR #44), and the hardening backlog carried over from the v1.2.0 audit.
+
+---
+
 ## 2026-04-29 — Release v1.3.0
 
 Bumped `manifest.json` from `1.3.0-pre5` to `1.3.0` and merged dev to main via PR. Updated ROADMAP.md and TODO.md: v1.3.0 marked complete; "UniFi OS only" and hardening backlog items moved to v1.4.0.


### PR DESCRIPTION
## Summary

- Bumps `manifest.json` from `1.3.0` → `1.4.0-pre1`
- Adds HISTORY.md entry opening the new cycle

Next up in v1.4.0: UniFi OS only simplification, open-count watermark (PR #44), and the hardening backlog from the v1.2.0 audit. See `docs/ROADMAP.md § v1.4.0`.

## Test plan

- [x] `make check` — 348 tests, all passing

https://claude.ai/code/session_01Fx5j3mh1mUvNMswwMzAXTQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fx5j3mh1mUvNMswwMzAXTQ)_