### PR TITLE
chore: bump manifest to 1.4.0-pre2

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": ["aiohttp>=3.9.0"],
-  "version": "1.4.0-pre1"
+  "version": "1.4.0-pre2"
 }


### PR DESCRIPTION
## Summary

Bump `manifest.json` from `1.4.0-pre1` to `1.4.0-pre2` so the next pre-release tag captures the work that landed in clusters A and D.

The existing `v1.4.0-pre1` tag on origin points at commit `719fc49`, which was the tip of `dev` *before* PRs #50 / #51 / #52 merged — it published an empty pre-release that doesn't include any of the webhook-security hardening, repo-hygiene, or release-pipeline migration work. Bumping to `-pre2` lets us cut a fresh tag that captures the current state.

## What's not included

Per `CLAUDE.md § Non-negotiable constraints`: "Pre-release version bumps (`-preN`) do NOT touch `CHANGELOG.md`." The `[Unreleased]` section already accumulates the cluster A and D bullets and stays as-is until the eventual stable `1.4.0` cut. No other files modified.

## Test plan

- [x] `make check` passes locally (371 tests, ruff, mypy, HACS validate, strings/translations parity).
- [ ] CI green on PR.
- [ ] After merge, push the `v1.4.0-pre2` tag — release workflow auto-detects pre-release via `grep -qE -- '-pre[0-9]+$'`, validates the tag matches the manifest, packages the zip, and publishes via `gh release create --generate-notes --prerelease` with categorised notes from PRs #50 / #51 / #52.

https://claude.ai/code/session_01HUaZxCJsWYKweUcMmEtYBa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUaZxCJsWYKweUcMmEtYBa)_