### PR TITLE
feat(diagnostics): expose per-category state incl. last_cleared_at

### DIFF
--- a/custom_components/unifi_alerts/diagnostics.py
+++ b/custom_components/unifi_alerts/diagnostics.py
@@ -42,10 +42,22 @@ async def async_get_config_entry_diagnostics(
 
     coordinator_info: dict[str, Any]
     if coordinator is not None:
+        categories: dict[str, dict[str, Any]] = {}
+        for cat, state in coordinator.category_states.items():
+            categories[cat] = {
+                "enabled": state.enabled,
+                "is_alerting": state.is_alerting,
+                "open_count": state.open_count,
+                "alert_count": state.alert_count,
+                "last_cleared_at": (
+                    state.last_cleared_at.isoformat() if state.last_cleared_at is not None else None
+                ),
+            }
         coordinator_info = {
             "any_alerting": coordinator.any_alerting,
             "rollup_alert_count": coordinator.rollup_alert_count,
             "rollup_open_count": coordinator.rollup_open_count,
+            "categories": categories,
         }
     else:
         coordinator_info = {}

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## 2026-04-30 — Expose per-category state (incl. `last_cleared_at`) in diagnostics
 
-Closed the v1.4.0 high-value item *Expose `last_acknowledged_at` in diagnostics*. Previously `diagnostics.py` only emitted the rollup totals (`any_alerting`, `rollup_alert_count`, `rollup_open_count`) plus webhook URLs, which made it impossible for users debugging unexpected `open_count` values to see the per-category acknowledgement watermark.
+Closed the v1.4.0 high-value item *Expose `last_cleared_at` in diagnostics* (the TODO heading used the older name `last_acknowledged_at`, but the actual `CategoryState` attribute and the new diagnostics key are both `last_cleared_at`). Previously `diagnostics.py` only emitted the rollup totals (`any_alerting`, `rollup_alert_count`, `rollup_open_count`) plus webhook URLs, which made it impossible for users debugging unexpected `open_count` values to see the per-category acknowledgement watermark.
 
 ### Changes
 

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1,5 +1,24 @@
 # History
 
+## 2026-04-30 — Expose per-category state (incl. `last_cleared_at`) in diagnostics
+
+Closed the v1.4.0 high-value item *Expose `last_acknowledged_at` in diagnostics*. Previously `diagnostics.py` only emitted the rollup totals (`any_alerting`, `rollup_alert_count`, `rollup_open_count`) plus webhook URLs, which made it impossible for users debugging unexpected `open_count` values to see the per-category acknowledgement watermark.
+
+### Changes
+
+- **`diagnostics.py`** — added a `categories` map under `coordinator` keyed by category name. Each entry now exposes `enabled`, `is_alerting`, `open_count`, `alert_count`, and `last_cleared_at` (ISO-formatted, or `null` when unset). Iterates `coordinator.category_states` (the existing public property on `UniFiAlertsCoordinator`) so no new coordinator API was required. The pre-existing `coordinator is None` short-circuit (used when diagnostics fires during a setup failure) is preserved verbatim — no risk of a `None.category_states` AttributeError.
+- **`tests/unit/test_diagnostics.py`** — `_make_coordinator` helper now accepts an optional `category_states` mapping and defaults to a populated dict of empty `CategoryState` objects so existing tests still see the new `categories` key without modification. Two new tests added (8 total in the file): `test_diagnostics_exposes_per_category_state` (populates one category with non-default values, including a real `datetime` watermark, and asserts the exact dict shape including the ISO-formatted timestamp) and `test_diagnostics_per_category_last_cleared_at_none_when_unset` (asserts `null`/`None` is emitted as `None` rather than crashing or omitting the key).
+
+### Why
+
+Direct response to the TODO item: surfaces the acknowledgement watermark and per-category counters that users need when `open_count` looks wrong. Pure diagnostic-only change — no behaviour, no schema-of-record changes, no new public API — so the failure modes are bounded to the diagnostics download itself.
+
+### Verification
+
+`make check` passes locally: ruff lint+format, mypy, HACS preflight, strings/translations drift, and the full pytest suite (8/8 in `test_diagnostics.py`).
+
+Removed the matching item from `docs/TODO.md § High-value improvements`.
+
 ## 2026-04-29 — Overnight v1.4.0 hardening pass (clusters A and D)
 
 Two PRs targeting the v1.4.0 hardening backlog from `docs/ROADMAP.md`. Both bracketed by full security/architecture/quality audits (BEFORE on clean `dev`, AFTER on the merged audit branch) using three parallel agents per pass.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -20,10 +20,6 @@ Items are grouped by type. Work top-to-bottom within each group unless there's a
 
 ## 🟡 High-value improvements
 
-### Expose `last_acknowledged_at` in diagnostics
-
-The `last_cleared_at` watermark per category is not currently surfaced in the diagnostics platform. Add it to `diagnostics.py` alongside `open_count` and `is_alerting` so users can debug unexpected `open_count` values. Low-effort, diagnostic-only change.
-
 ### Verify update-in-place works without HA reboot
 
 **Problem:** Unknown whether updating the integration (e.g. via HACS or copying files) requires a full Home Assistant restart, or whether reloading the config entry is sufficient. A reboot requirement would be a significant friction point for self-hosted users pushing frequent updates.

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -16,6 +17,7 @@ from custom_components.unifi_alerts.const import (
     DOMAIN,
 )
 from custom_components.unifi_alerts.diagnostics import async_get_config_entry_diagnostics
+from custom_components.unifi_alerts.models import CategoryState
 
 _SAMPLE_WEBHOOK_URLS = {
     cat: f"http://homeassistant.local/api/webhook/unifi_alerts_{cat}" for cat in ALL_CATEGORIES
@@ -44,12 +46,18 @@ def _make_entry(entry_id: str = "test_entry", extra_data: dict | None = None) ->
 
 
 def _make_coordinator(
-    any_alerting: bool = False, rollup_alert_count: int = 0, rollup_open_count: int = 0
+    any_alerting: bool = False,
+    rollup_alert_count: int = 0,
+    rollup_open_count: int = 0,
+    category_states: dict[str, CategoryState] | None = None,
 ) -> MagicMock:
     coordinator = MagicMock()
     coordinator.any_alerting = any_alerting
     coordinator.rollup_alert_count = rollup_alert_count
     coordinator.rollup_open_count = rollup_open_count
+    coordinator.category_states = category_states if category_states is not None else {
+        cat: CategoryState(category=cat) for cat in ALL_CATEGORIES
+    }
     return coordinator
 
 
@@ -120,3 +128,45 @@ async def test_diagnostics_preserves_non_sensitive_config() -> None:
 
     assert result["config_entry"]["controller_url"] == "https://192.168.1.1"
     assert result["config_entry"]["username"] == "**REDACTED**"
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_exposes_per_category_state() -> None:
+    cleared_at = datetime(2026, 4, 30, 12, 0, 0, tzinfo=UTC)
+    cat = ALL_CATEGORIES[0]
+    states = {c: CategoryState(category=c) for c in ALL_CATEGORIES}
+    states[cat] = CategoryState(
+        category=cat,
+        enabled=True,
+        is_alerting=True,
+        alert_count=4,
+        open_count=2,
+        last_cleared_at=cleared_at,
+    )
+    coordinator = _make_coordinator(category_states=states)
+    entry = _make_entry()
+    hass = _make_hass(entry.entry_id, coordinator)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    categories = result["coordinator"]["categories"]
+    assert set(categories.keys()) == set(ALL_CATEGORIES)
+    assert categories[cat] == {
+        "enabled": True,
+        "is_alerting": True,
+        "open_count": 2,
+        "alert_count": 4,
+        "last_cleared_at": cleared_at.isoformat(),
+    }
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_per_category_last_cleared_at_none_when_unset() -> None:
+    coordinator = _make_coordinator()
+    entry = _make_entry()
+    hass = _make_hass(entry.entry_id, coordinator)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    for cat in ALL_CATEGORIES:
+        assert result["coordinator"]["categories"][cat]["last_cleared_at"] is None


### PR DESCRIPTION
Closes the v1.4.0 TODO item _Expose `last_cleared_at` in diagnostics_ (the TODO heading used the older name `last_acknowledged_at`, but the actual `CategoryState` attribute and the new diagnostics key are both `last_cleared_at`).

Previously `diagnostics.py` only emitted rollup totals (`any_alerting`, `rollup_alert_count`, `rollup_open_count`), which made it impossible to debug unexpected `open_count` values without inspecting coordinator internals directly.

## Changes

- **`diagnostics.py`** — adds a `categories` map under `coordinator`, keyed by category name. Each entry exposes `enabled`, `is_alerting`, `open_count`, `alert_count`, and `last_cleared_at` (ISO-formatted string, or `null` when the watermark has never been set). Uses the existing `coordinator.category_states` property — no new public API required. The `coordinator is None` guard (setup-failure path) is preserved, so there is no risk of an `AttributeError` during a partial setup.
- **`tests/unit/test_diagnostics.py`** — `_make_coordinator` now accepts an optional `category_states` mapping; existing tests are unaffected. Two new tests: `test_diagnostics_exposes_per_category_state` (verifies the full dict shape including an ISO-formatted watermark) and `test_diagnostics_per_category_last_cleared_at_none_when_unset` (verifies `None` is emitted rather than omitting the key or crashing).

## Test plan

- [x] `make check` passes: ruff lint+format, mypy, HACS preflight, strings/translations drift, 373 pytest tests (8/8 in `test_diagnostics.py`)
- [ ] Manual: download diagnostics from Settings → Integrations → UniFi Alerts → ⋮ → Download diagnostics and confirm `coordinator.categories` is present with the expected fields

https://claude.ai/code/session_01VkTm9TfsNnDB3mLZJukLsM