### PR TITLE
chore(release): bump version to 1.4.0-pre3

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": ["aiohttp>=3.9.0"],
-  "version": "1.4.0-pre2"
+  "version": "1.4.0-pre3"
 }


### PR DESCRIPTION
Bumps manifest version from `1.4.0-pre2` → `1.4.0-pre3`.

Bundles the changes merged since pre2:
- PR #58 — SSL fail-open fix (5 call sites) + `_get_coordinators` guard
- PR #59 — Drop legacy self-hosted paths, add `async_migrate_entry` (UniFi OS only)

Once merged, run:
```bash
git checkout dev && git pull origin dev
git tag v1.4.0-pre3 && git push origin v1.4.0-pre3
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qix4Z23oCSjQvrFeC9fWLN)_