### PR TITLE
fix(config-flow): stage options credentials and persist verify_ssl atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Options-flow credential changes are now staged and persisted atomically only when the user submits the finish step. Previously, `async_step_credentials` called `async_update_entry` eagerly, so closing the dialog at the categories step left a new password (or rotated webhook secret) persisted against the user's intent. The `verify_ssl` toggle now also persists when flipped on its own; previously it was filtered out of the change-detection check and silently ignored.
 - `make check` now passes on Windows. A new top-level `tests/conftest.py` applies two Windows-only workarounds: it forces `SelectorEventLoop` for `aiodns` (both via `set_event_loop_policy(WindowsSelectorEventLoopPolicy())` and by rebinding `WindowsProactorEventLoopPolicy._loop_factory` so HA's per-test `HassEventLoopPolicy` produces Selector loops via inheritance), and it neutralises `pytest_socket.disable_socket` so asyncio's `socket.socketpair()` self-pipe survives. HA core's earlier `socket_allow_hosts(["127.0.0.1"])` filter still applies, so external network egress remains blocked. No-op on Linux/macOS.
 - Polling no longer re-asserts `is_alerting` for alarms older than the acknowledgement watermark. Previously the binary sensor flipped back to Problem with a stale message after a Clear, while Open Count stayed at 0.
 - `_auto_clear` now persists the advanced watermark to storage. An HA restart immediately after a timer-triggered clear no longer resets `open_count` to the lifetime total.

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -296,6 +296,10 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
     def __init__(self, config_entry: ConfigEntry) -> None:
         self._config_entry = config_entry
         self._pending_options: dict[str, Any] = {}
+        # Staged updates to `entry.data` (credentials, verify_ssl, rotated webhook
+        # secret). Held until the user submits the finish step, then persisted
+        # atomically so abandoning the flow mid-way leaves nothing behind.
+        self._pending_data: dict[str, Any] = {}
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Router: always start with the credentials step."""
@@ -319,28 +323,34 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
             new_password: str = (user_input.get(CONF_PASSWORD) or "").strip()
             new_api_key: str = (user_input.get(CONF_API_KEY) or "").strip()
             regenerate_secret: bool = bool(user_input.get(CONF_REGENERATE_WEBHOOK_SECRET, False))
-            # verify_ssl always comes through as a bool (voluptuous default)
-            new_verify_ssl: bool = user_input.get(
-                CONF_VERIFY_SSL,
-                self._config_entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+            current_verify_ssl: bool = self._config_entry.data.get(
+                CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL
             )
+            # verify_ssl always comes through as a bool (voluptuous default)
+            new_verify_ssl: bool = user_input.get(CONF_VERIFY_SSL, current_verify_ssl)
+            verify_ssl_changed = new_verify_ssl != current_verify_ssl
 
             credentials_changed = bool(new_url_raw or new_username or new_password or new_api_key)
 
-            if not credentials_changed and not regenerate_secret:
+            if not credentials_changed and not regenerate_secret and not verify_ssl_changed:
                 # Nothing changed — skip straight to categories
                 return await self.async_step_categories()
 
-            if regenerate_secret and not credentials_changed:
-                # Secret rotation only — no credentials to validate. Persist
-                # the new secret immediately and continue to categories so the
-                # finish step shows the updated webhook URLs.
-                updated_data = {
-                    **self._config_entry.data,
-                    CONF_WEBHOOK_SECRET: secrets.token_urlsafe(32),
-                }
-                self.hass.config_entries.async_update_entry(self._config_entry, data=updated_data)
-                _LOGGER.info("Webhook secret regenerated for %s", self._config_entry.entry_id)
+            if not credentials_changed:
+                # Verify-SSL flip and/or secret rotation only — no credentials to
+                # validate against the controller. Stage the change; the finish
+                # step will persist atomically when the user submits.
+                pending = dict(self._config_entry.data)
+                if verify_ssl_changed:
+                    pending[CONF_VERIFY_SSL] = new_verify_ssl
+                if regenerate_secret:
+                    # WHY: Rotation replaces the `?token=...` bearer but reuses
+                    # the webhook ID suffix. An attacker with the old token
+                    # still hits a live endpoint; the token check rejects them.
+                    # URL-path revocation requires deleting and re-adding the
+                    # entry. See SECURITY.md § "Webhook secret rotation".
+                    pending[CONF_WEBHOOK_SECRET] = secrets.token_urlsafe(32)
+                self._pending_data = pending
                 return await self.async_step_categories()
 
             # Determine the effective values to test
@@ -389,42 +399,31 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
                             ):
                                 return self.async_abort(reason="already_configured")
 
-                    # Persist the updated credentials into entry.data
-                    updated_data = {
+                    # Stage the updated entry.data — actual persistence happens
+                    # in the finish step, so abandoning the flow leaves nothing
+                    # behind. async_update_entry is intentionally NOT called here.
+                    pending = {
                         **self._config_entry.data,
                         CONF_CONTROLLER_URL: effective_url,
                         CONF_VERIFY_SSL: new_verify_ssl,
                         CONF_AUTH_METHOD: auth_method,
                     }
                     if new_username:
-                        updated_data[CONF_USERNAME] = new_username
+                        pending[CONF_USERNAME] = new_username
                     if new_password:
-                        updated_data[CONF_PASSWORD] = new_password
+                        pending[CONF_PASSWORD] = new_password
                     if new_api_key:
-                        updated_data[CONF_API_KEY] = new_api_key
+                        pending[CONF_API_KEY] = new_api_key
                     if regenerate_secret:
-                        # WHY: Rotation replaces the `?token=...` bearer but reuses the
-                        # webhook ID suffix (URL path). An attacker with the old token still
-                        # hits a live endpoint; the token check rejects them. URL-path
-                        # revocation requires deleting and re-adding the entry. See
-                        # SECURITY.md § "Webhook secret rotation".
-                        updated_data[CONF_WEBHOOK_SECRET] = secrets.token_urlsafe(32)
-                        _LOGGER.info(
-                            "Webhook secret regenerated for %s",
-                            self._config_entry.entry_id,
-                        )
-
-                    self.hass.config_entries.async_update_entry(
-                        self._config_entry, data=updated_data
-                    )
-                    # Proceed to categories; reload will happen after the full options save
+                        pending[CONF_WEBHOOK_SECRET] = secrets.token_urlsafe(32)
+                    self._pending_data = pending
                     return await self.async_step_categories()
 
         # Build the credentials form — all fields optional with current values as hints
         _password_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
         _api_key_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
         current_url: str = self._config_entry.data.get(CONF_CONTROLLER_URL, "")
-        current_verify_ssl: bool = self._config_entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
+        current_verify_ssl = self._config_entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
 
         schema = vol.Schema(
             {
@@ -500,10 +499,22 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
     async def async_step_finish(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Display webhook URLs, then save options on submit."""
         if user_input is not None:
+            # Persist any staged entry.data updates atomically before writing
+            # the options entry. If the user abandoned the flow before reaching
+            # this step, _pending_data is empty and entry.data is untouched.
+            if self._pending_data:
+                self.hass.config_entries.async_update_entry(
+                    self._config_entry, data=self._pending_data
+                )
             return self.async_create_entry(title="", data=self._pending_options)
 
         enabled: list[str] = self._pending_options.get(CONF_ENABLED_CATEGORIES, ALL_CATEGORIES)
-        secret: str = self._config_entry.data.get(CONF_WEBHOOK_SECRET, "")
+        # Display URLs using the staged secret (if rotation is queued) so the
+        # finish step shows what the entry WILL contain after submission.
+        secret: str = self._pending_data.get(
+            CONF_WEBHOOK_SECRET,
+            self._config_entry.data.get(CONF_WEBHOOK_SECRET, ""),
+        )
         suffix: str = self._config_entry.data.get(CONF_WEBHOOK_ID_SUFFIX, "")
         fields: dict = {}
         for cat in ALL_CATEGORIES:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,8 +14,8 @@ Closes the remaining auth/credential exposure paths, makes the options flow tran
 
 ### Options-flow atomicity
 
-- [ ] **Stage credential changes** (`config_flow.py`): `async_step_credentials` calls `async_update_entry()` eagerly. Abandoning the flow after credentials but before finish leaves the change persisted. Stage into `self._pending_data`, persist atomically in `async_step_finish`.
-- [ ] **`verify_ssl` toggle alone must persist**: `credentials_changed` ignores the SSL flag. Roll into the staging refactor above.
+- [x] **Stage credential changes** (`config_flow.py`): `async_step_credentials` no longer calls `async_update_entry()` eagerly; new credentials, rotated webhook secrets, and `verify_ssl` flips are staged in `self._pending_data` and persisted atomically by `async_step_finish`.
+- [x] **`verify_ssl` toggle alone now persists**: change detection no longer filters out the SSL flag, so flipping the checkbox without any credential change is staged and committed.
 
 ### Reliability (pulled forward from v1.6.0; field-confirmed)
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -19,11 +19,6 @@ Outstanding work only. Items are removed when they ship; completion lives in `do
 - **`_category_states` rebuilt on reload** (`coordinator.py`): `alert_count` and `last_alert` are discarded on every options change. Persist them alongside watermarks in the existing `Store`.
 - **Silent JSON-parse failure during 400-error inspection** (`unifi_client.py`): `except Exception: pass` swallows malformed UniFi error bodies, hiding the `api.err.InvalidObject` fallback. Log at DEBUG with the exception class name.
 
-## Security
-
-- **Options-flow credential changes persist before the user submits the flow** (`config_flow.py`): `async_step_credentials` calls `async_update_entry()` eagerly. Abandoning the flow after credentials but before finish leaves the change persisted. Stage into `self._pending_data` and persist atomically in `async_step_finish`.
-- **`verify_ssl` toggle alone does not persist** (`config_flow.py`): `credentials_changed` ignores the SSL flag. Flipping the checkbox without other changes is a no-op. Best landed alongside the staging refactor above.
-
 ## Type safety / tech debt
 
 - **`mypy strict = false`**: migrate `UniFiClient.config: dict[str, Any]` to a `TypedDict` or frozen dataclass, then bump `pyproject.toml` to `strict = true`.

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -987,8 +987,12 @@ class TestOptionsFlowCredentials:
         flow.hass.config_entries.async_update_entry.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_valid_new_credentials_updates_entry_data(self) -> None:
-        """Submitting new valid credentials must update entry.data and continue to categories."""
+    async def test_valid_new_credentials_stages_entry_data(self) -> None:
+        """Submitting new valid credentials must STAGE entry.data and continue to categories.
+
+        Persistence is deferred to async_step_finish so abandoning the flow
+        between credentials and finish leaves the original entry untouched.
+        """
         flow = _make_options_flow()
         flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
 
@@ -1014,11 +1018,12 @@ class TestOptionsFlowCredentials:
 
             result = await flow.async_step_credentials(new_creds)
 
-        # entry.data must have been updated
-        flow.hass.config_entries.async_update_entry.assert_called_once()
-        updated_data = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
-        assert updated_data[CONF_CONTROLLER_URL] == "https://10.0.0.1"
-        assert updated_data[CONF_PASSWORD] == "newpass"
+        # entry.data must NOT have been persisted yet
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+
+        # The pending values must be staged, ready for async_step_finish to commit
+        assert flow._pending_data[CONF_CONTROLLER_URL] == "https://10.0.0.1"
+        assert flow._pending_data[CONF_PASSWORD] == "newpass"
 
         # Should have continued to categories
         assert result["step_id"] == "categories"
@@ -1056,8 +1061,9 @@ class TestOptionsFlowCredentials:
         assert result["step_id"] == "credentials"
         call_kwargs = flow.async_show_form.call_args.kwargs
         assert call_kwargs["errors"] == {"base": "invalid_auth"}
-        # entry.data must NOT have been touched
+        # entry.data must NOT have been touched and nothing should be staged
         flow.hass.config_entries.async_update_entry.assert_not_called()
+        assert flow._pending_data == {}
 
     @pytest.mark.asyncio
     async def test_invalid_url_scheme_shows_error(self) -> None:
@@ -1124,6 +1130,7 @@ class TestOptionsFlowCredentials:
 
         assert result["reason"] == "already_configured"
         flow.hass.config_entries.async_update_entry.assert_not_called()
+        assert flow._pending_data == {}
 
     @pytest.mark.asyncio
     async def test_after_credential_update_categories_proceeds_normally(self) -> None:
@@ -1157,6 +1164,11 @@ class TestOptionsFlowCredentials:
 
             await flow.async_step_credentials(new_creds)
 
+        # The credentials step must NOT persist eagerly — the staged data is
+        # only committed once async_step_finish runs.
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+        assert flow._pending_data[CONF_USERNAME] == "newadmin"
+
         # Now: submit the categories step (stores in _pending_options, routes to finish)
         first_cat = ALL_CATEGORIES[0]
         cat_input = {f"cat_{cat}": (cat == first_cat) for cat in ALL_CATEGORIES}
@@ -1169,7 +1181,7 @@ class TestOptionsFlowCredentials:
         ):
             await flow.async_step_categories(cat_input)
 
-        # Submit finish → create_entry
+        # Submit finish → create_entry. entry.data is now persisted atomically.
         with patch(
             "custom_components.unifi_alerts.config_flow.async_generate_url",
             return_value="http://ha.local/webhook/x",
@@ -1177,10 +1189,136 @@ class TestOptionsFlowCredentials:
             result = await flow.async_step_finish(user_input={})
 
         assert result["type"] == "create_entry"
+        flow.hass.config_entries.async_update_entry.assert_called_once()
+        committed = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert committed[CONF_USERNAME] == "newadmin"
         saved = flow.async_create_entry.call_args.kwargs["data"]
         assert saved[CONF_ENABLED_CATEGORIES] == [first_cat]
         assert saved[CONF_POLL_INTERVAL] == 90
         assert saved[CONF_CLEAR_TIMEOUT] == 15
+
+    @pytest.mark.asyncio
+    async def test_abandoning_flow_after_credentials_does_not_persist(self) -> None:
+        """Submitting valid credentials and then abandoning the flow before
+        finish must leave entry.data untouched.
+
+        Regression guard for the v1.5 atomicity fix: prior to v1.5,
+        async_step_credentials called async_update_entry eagerly so closing
+        the dialog at the categories step left the new password persisted.
+        """
+        flow = _make_options_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
+
+        new_creds = {
+            CONF_CONTROLLER_URL: "https://10.0.0.1",
+            CONF_USERNAME: "newadmin",
+            CONF_PASSWORD: "newpass",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=_make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance._is_unifi_os = False
+            await flow.async_step_credentials(new_creds)
+
+        # User abandoned the dialog: no further steps invoked.
+        # entry.data must NOT have been written. The staged dict holds the
+        # change that *would* have been committed if the user had finished.
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+        assert flow._pending_data[CONF_PASSWORD] == "newpass"
+
+    @pytest.mark.asyncio
+    async def test_verify_ssl_only_toggle_stages_and_skips_auth(self) -> None:
+        """Flipping verify_ssl with no other changes must stage the new value
+        and skip the auth call — credentials_changed is False here.
+
+        Regression guard: prior to v1.5 the verify_ssl flag was filtered out
+        of the change-detection check, so toggling it alone was a silent no-op.
+        """
+        flow = _make_options_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
+        # Fixture default is verify_ssl=True; flip to False
+        ssl_only = {
+            CONF_CONTROLLER_URL: "",
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: False,
+        }
+
+        with patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls:
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock()
+            await flow.async_step_credentials(ssl_only)
+            instance.authenticate.assert_not_called()
+
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+        assert flow._pending_data[CONF_VERIFY_SSL] is False
+        # Other entry-data keys must be carried over unchanged
+        assert flow._pending_data[CONF_USERNAME] == "admin"
+        assert flow._pending_data[CONF_WEBHOOK_SECRET] == "fixed-secret"
+
+    @pytest.mark.asyncio
+    async def test_verify_ssl_only_toggle_persists_on_finish(self) -> None:
+        """End-to-end: a verify_ssl flip submitted through to finish must call
+        async_update_entry with the new value."""
+        from custom_components.unifi_alerts.const import CONF_CLEAR_TIMEOUT, CONF_POLL_INTERVAL
+
+        flow = _make_options_flow()
+        flow.async_show_form = MagicMock(
+            side_effect=lambda **kwargs: {"type": "form", "step_id": kwargs["step_id"]}
+        )
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+        await flow.async_step_credentials({
+            CONF_CONTROLLER_URL: "",
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: False,
+        })
+
+        cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+        cat_input[CONF_POLL_INTERVAL] = 60
+        cat_input[CONF_CLEAR_TIMEOUT] = 5
+        with patch(
+            "custom_components.unifi_alerts.config_flow.async_generate_url",
+            return_value="http://ha.local/webhook/x",
+        ):
+            await flow.async_step_categories(cat_input)
+            await flow.async_step_finish(user_input={})
+
+        flow.hass.config_entries.async_update_entry.assert_called_once()
+        committed = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert committed[CONF_VERIFY_SSL] is False
+
+    @pytest.mark.asyncio
+    async def test_verify_ssl_unchanged_no_op_skips_persist(self) -> None:
+        """Submitting credentials with verify_ssl matching the stored value and
+        no other fields must skip persistence entirely (no staged data)."""
+        flow = _make_options_flow()  # entry has verify_ssl=True
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
+
+        same_input = {
+            CONF_CONTROLLER_URL: "",
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: True,
+        }
+
+        await flow.async_step_credentials(same_input)
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+        assert flow._pending_data == {}
 
 
 # ---------------------------------------------------------------------------
@@ -1199,8 +1337,10 @@ class TestWebhookSecretRotation:
     """
 
     @pytest.mark.asyncio
-    async def test_rotate_only_persists_new_secret_and_skips_auth(self) -> None:
-        """Ticking only the regenerate checkbox must NOT call authenticate()."""
+    async def test_rotate_only_stages_new_secret_and_skips_auth(self) -> None:
+        """Ticking only the regenerate checkbox must NOT call authenticate()
+        and must NOT persist eagerly — the new secret is staged for the
+        finish step to commit atomically."""
         from custom_components.unifi_alerts.const import CONF_REGENERATE_WEBHOOK_SECRET
 
         flow = _make_options_flow()
@@ -1221,16 +1361,16 @@ class TestWebhookSecretRotation:
             await flow.async_step_credentials(rotate_only)
             instance.authenticate.assert_not_called()
 
-        flow.hass.config_entries.async_update_entry.assert_called_once()
-        updated = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        # No persistence at this stage; the secret is staged.
+        flow.hass.config_entries.async_update_entry.assert_not_called()
         # New secret must differ from the fixture-installed one
-        assert updated[CONF_WEBHOOK_SECRET] != "fixed-secret"
+        assert flow._pending_data[CONF_WEBHOOK_SECRET] != "fixed-secret"
         # And it must be a non-empty token (token_urlsafe(32) is at least 40 chars)
-        assert len(updated[CONF_WEBHOOK_SECRET]) >= 40
+        assert len(flow._pending_data[CONF_WEBHOOK_SECRET]) >= 40
 
     @pytest.mark.asyncio
-    async def test_rotate_with_credential_change_updates_both(self) -> None:
-        """Ticking regenerate alongside new creds rotates the secret AND updates creds."""
+    async def test_rotate_with_credential_change_stages_both(self) -> None:
+        """Ticking regenerate alongside new creds stages the rotated secret AND new creds."""
         from custom_components.unifi_alerts.const import CONF_REGENERATE_WEBHOOK_SECRET
 
         flow = _make_options_flow()
@@ -1258,10 +1398,10 @@ class TestWebhookSecretRotation:
             instance._is_unifi_os = False
             await flow.async_step_credentials(new_input)
 
-        flow.hass.config_entries.async_update_entry.assert_called_once()
-        updated = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
-        assert updated[CONF_PASSWORD] == "newpass"
-        assert updated[CONF_WEBHOOK_SECRET] != "fixed-secret"
+        # No eager persistence; staged for finish.
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+        assert flow._pending_data[CONF_PASSWORD] == "newpass"
+        assert flow._pending_data[CONF_WEBHOOK_SECRET] != "fixed-secret"
 
     @pytest.mark.asyncio
     async def test_unticked_does_not_rotate(self) -> None:
@@ -1281,23 +1421,21 @@ class TestWebhookSecretRotation:
         }
 
         await flow.async_step_credentials(no_rotate)
-        # No update at all because nothing changed
+        # No update or staging at all because nothing changed
         flow.hass.config_entries.async_update_entry.assert_not_called()
+        assert flow._pending_data == {}
 
     @pytest.mark.asyncio
     async def test_finish_step_displays_new_url_after_rotation(self) -> None:
-        """After secret rotation, the finish step must show URLs with the NEW token.
+        """After secret rotation is staged, the finish step must show URLs with
+        the NEW token even though entry.data has not been written yet.
 
-        Regression guard: HA's ``async_update_entry`` mutates ``entry.data``
-        synchronously via ``object.__setattr__(entry, "data", ...)``. Our flow
-        relies on that — between calling ``async_update_entry`` and reading
-        ``self._config_entry.data[CONF_WEBHOOK_SECRET]`` in the finish step,
-        no awaits intervene that could swap data. If HA ever changed those
-        semantics (or if a regression introduced an extra await between the
-        update and the read), users would see the OLD token displayed in the
-        finish step despite the new one being persisted — a confusing UX
-        bug. This test simulates the real HA behaviour and asserts the URL
-        contains the freshly-rotated secret.
+        Under the staged-persistence model the finish step renders from
+        ``self._pending_data`` until the user submits, so the displayed URLs
+        match what the entry WILL contain after submit. If a regression made
+        the finish step read straight from ``self._config_entry.data`` again,
+        the user would see the OLD token alongside a regenerate confirmation:
+        a confusing UX bug.
         """
         from custom_components.unifi_alerts.const import (
             CONF_REGENERATE_WEBHOOK_SECRET,
@@ -1306,12 +1444,6 @@ class TestWebhookSecretRotation:
 
         flow = _make_options_flow()
 
-        # Simulate HA's real async_update_entry: mutate entry.data in-place
-        def _fake_update(entry, *, data=None, **kwargs):
-            if data is not None:
-                entry.data = data
-
-        flow.hass.config_entries.async_update_entry = MagicMock(side_effect=_fake_update)
         # Make data a real dict (not MagicMock) so .get() / mutation work cleanly
         flow._config_entry.data = {
             **flow._config_entry.data,
@@ -1331,10 +1463,12 @@ class TestWebhookSecretRotation:
             CONF_REGENERATE_WEBHOOK_SECRET: True,
         })
 
-        # Capture the new secret that was just persisted
-        new_secret = flow._config_entry.data[CONF_WEBHOOK_SECRET]
+        # Staged but not persisted: entry.data still holds the old secret.
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+        new_secret = flow._pending_data[CONF_WEBHOOK_SECRET]
         assert new_secret != "fixed-secret"
         assert len(new_secret) >= 40
+        assert flow._config_entry.data[CONF_WEBHOOK_SECRET] == "fixed-secret"
 
         # Step 2: submit categories so the flow advances to finish. The
         # categories step calls async_step_finish() internally to render the


### PR DESCRIPTION
## Summary

Closes the v1.5.0 options-flow atomicity gap. Two related defects fixed in one refactor.

- `async_step_credentials` no longer calls `async_update_entry` eagerly. New credentials, rotated webhook secrets, and `verify_ssl` flips are staged into `OptionsFlow._pending_data`. The finish step calls `async_update_entry` once on submit, so abandoning the dialog at the categories step leaves `entry.data` untouched.
- `verify_ssl` is now part of change detection. Flipping the checkbox without any other field change is staged and committed instead of being silently dropped.
- `async_step_finish` reads the displayed webhook secret from `_pending_data` first, so the URL display still shows the rotated secret as it did before.

## Changes

- `custom_components/unifi_alerts/config_flow.py`: add `_pending_data`; refactor the credentials step to stage; persist atomically in the finish step.
- `tests/unit/test_config_flow.py`: existing rotation/credential update tests rewritten to assert staging behaviour. Three new regression tests:
  - `test_abandoning_flow_after_credentials_does_not_persist`
  - `test_verify_ssl_only_toggle_stages_and_skips_auth`
  - `test_verify_ssl_only_toggle_persists_on_finish`
  - `test_verify_ssl_unchanged_no_op_skips_persist`
- `CHANGELOG.md`: bullet under `[Unreleased]` `### Fixed`.
- `docs/TODO.md` / `docs/ROADMAP.md`: drop the closed Security entries; tick the v1.5.0 Options-flow atomicity items.

## Test plan

- [x] `make check` passes locally (ruff + format + mypy + HACS validate + translation drift + 379 tests).
- [ ] Reviewer: confirm a real HA install allows mid-flow dialog closure without persisting; confirm `verify_ssl` toggle alone reloads with the new value.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HTrmtEbv59VH9emC8znjEM)_