### PR TITLE
docs: retire main->dev sync-merge step from release process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ This project uses a two-branch model. All active development happens on `dev`; `
 | Branch | Purpose | Version format | Example |
 |--------|---------|---------------|---------|
 | `main` | Stable releases only. CI enforces no pre-release suffix. | `X.Y.Z` | `1.0.0`, `1.1.0` |
-| `dev` | Active development. CI accepts `-preN` during development, or stable `X.Y.Z` when preparing a release. After each stable release, a sync merge from `main` back to `dev` is required (see release workflow step 3b). | `X.Y.Z-preN` or `X.Y.Z` | `1.1.0-pre1`, `1.1.0` |
+| `dev` | Active development. CI accepts `-preN` during development, or stable `X.Y.Z` when preparing a release. | `X.Y.Z-preN` or `X.Y.Z` | `1.1.0-pre1`, `1.1.0` |
 | `feature/*` or `claude/*` | Short-lived work. **Must branch off `dev`, not `main`.** No version format enforced by CI. | Any | - |
 
 ### Versioning conventions
@@ -85,8 +85,7 @@ dev  ──┬── (work) ──► tag v1.1.0-pre1  ──► GitHub pre-rele
        │
        ├── bump manifest to 1.1.0 (via claude/* PR > dev)
        │    └─► PR dev > main  [MERGE COMMIT - never squash]
-       │         ├─► tag v1.1.0  ──► GitHub stable release  (automated)
-       │         └─► PR main > dev  [sync merge - keep 389841a in dev ancestry]
+       │         └─► tag v1.1.0  ──► GitHub stable release  (automated)
        │
        └── bump manifest to 1.2.0-pre1 (via claude/* PR > dev)  (start next cycle)
 ```
@@ -107,11 +106,9 @@ dev  ──┬── (work) ──► tag v1.1.0-pre1  ──► GitHub pre-rele
    ```
    GitHub Actions creates a stable release automatically; the auto-generated notes are grouped by the labels on PRs merged between the previous tag and this one.
 
-   > **CRITICAL - use "Create a merge commit", never "Squash and merge", for the `dev > main` PR.** Squashing creates a new commit on `main` whose only parent is the previous `main` tip; dev's individual commits have no ancestry path through it. The merge base between `main` and `dev` never advances past the last stable release, so the next release produces a conflict storm across every file that both branches touched. A regular merge commit preserves both parents and keeps the merge base current.
+   > **CRITICAL - use "Create a merge commit", never "Squash and merge", for the `dev > main` PR.** Squashing creates a new commit on `main` whose only parent is the previous `main` tip; dev's individual commits have no ancestry path through it. The merge base between `main` and `dev` never advances past the last stable release, so the next release produces a conflict storm across every file that both branches touched. A regular merge commit preserves both parents and keeps the merge base current. The `main` ruleset is configured to enforce merge-commit-only.
 
-3b. **Sync merge: main > dev (mandatory after every stable release).** Immediately after the `dev > main` release PR merges, open a short-lived `claude/sync-main-to-dev-X.Y.Z` branch **from `dev`**, run `git merge origin/main`, resolve any trivial conflicts (take dev's version number), push, and open a PR targeting `dev`. Merge it as a **merge commit** (not squash). This makes the release's squash commit an ancestor of `dev`, so the next `dev > main` PR will have the correct merge base and be a clean fast-forward.
-
-   > **Why this step must target the new squash commit:** In the past (v1.3.0, PR #47) a sync merge was attempted but accidentally merged the *previous* stable tag (`v1.2.0`) rather than the new squash commit (`v1.3.0`). The tree content was identical so CI passed, but the parent pointer was wrong - the merge base never advanced. Always verify the second parent of the merge commit is the tip of `origin/main` *after* the release, not before.
+   > **No `main > dev` sync merge needed.** Earlier releases (v1.3.0, v1.4.0) ran a `claude/sync-main-to-dev-X.Y.Z` PR after every stable release because the `dev > main` PR was squash-merged, which left the release commit out of dev's ancestry. With merge-commit-only on `main` (above), dev's tip is already the second parent of the release commit; the merge base advances correctly and no sync is required. Attempting one now contradicts the squash-only-on-dev ruleset.
 
 4. **Start next cycle:** run `python3 scripts/bump_version.py --next-cycle` to bump manifest to `X.(Y+1).0-pre1` on a `claude/bump-*` branch, open PR targeting `dev`, merge. Development continues forward. Notable changes between releases accumulate under `CHANGELOG.md` `[Unreleased]` as their PRs land - don't batch them at release time.
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -99,7 +99,7 @@ HA requires `strings.json` and `translations/en.json` to match exactly. Edit bot
 
 ## Release process
 
-Stable releases require **three** PRs, in order. Skipping or mis-ordering them causes merge-base drift that turns the next release into a conflict storm.
+Stable releases require **two** PRs, in order. Skipping or mis-ordering them causes merge-base drift that turns the next release into a conflict storm.
 
 ### PR 1 - version bump + CHANGELOG (feature/* > dev)
 
@@ -120,18 +120,4 @@ git checkout main && git pull origin main
 git tag vX.Y.Z && git push origin vX.Y.Z
 ```
 
-### PR 3 - main > dev (sync merge, mandatory)
-
-Immediately after PR 2 merges, bring the new squash commit into `dev`'s ancestry:
-
-```bash
-git checkout dev && git pull origin dev
-git checkout -b claude/sync-main-to-dev-X.Y.Z
-git merge origin/main          # merge the new squash commit as a second parent
-# resolve any trivial conflicts (version number: take dev's X.(Y+1).0-pre1)
-git push -u origin claude/sync-main-to-dev-X.Y.Z
-```
-
-Open a PR targeting `dev`. **Merge as "Create a merge commit"** - not squash. The resulting commit will have `origin/main`'s tip as its second parent, making `git merge-base dev main` point at the new `vX.Y.Z` squash commit rather than the previous release.
-
-> **Common mistake (v1.3.0 / PR #47):** merging `origin/main` while `main` still points at the *previous* stable tag instead of the new squash commit. The tree content looks correct so CI passes, but the parent pointer is wrong and the merge base does not advance. Always run `git fetch origin main && git log --oneline origin/main -1` to confirm `main` is at the new release commit before running `git merge origin/main`.
+> **No `main > dev` sync merge needed.** Earlier releases (v1.3.0, v1.4.0) ran a third PR (`claude/sync-main-to-dev-X.Y.Z`) because the `dev > main` PR was squash-merged, which left the release commit out of dev's ancestry. With merge-commit-only on `main` (PR 2 above), dev's tip is already the second parent of the release commit; the merge base advances correctly and no sync is required. Attempting one now also conflicts with the squash-only-on-dev ruleset.


### PR DESCRIPTION
## Summary

Retires the `main -> dev` sync-merge step from the release process. It was a workaround for squash-merged `dev -> main` releases and is now both unnecessary and impossible: the `main` ruleset enforces merge-commit-only (so dev's tip is already the second parent of the release commit on main), and the `dev` ruleset enforces squash-only (so a sync PR cannot be merged correctly anyway). Hit by #80.

## Why this is safe

- For v1.5.0, the `dev -> main` PR (#79) merged as a real merge commit (`6ef3778`) with two parents: previous main (`820dd41`) and dev tip (`a8ef709`). Verified via `git log -1 --pretty='%P'`.
- Dev's tip `a8ef709` is therefore already an ancestor of main's tip `6ef3778`. `git merge-base dev main` returns `a8ef709` -- the merge base advanced correctly without any sync.
- Main has no content changes between `a8ef709` and `6ef3778` (the merge commit's tree equals dev's tree at that moment), so the next `dev -> main` PR will be a clean merge.

## Changes

- `CLAUDE.md`: removed step 3b ("Sync merge: main > dev"), removed the `sync merge` line from the release flow diagram, removed the sync-merge clause from the dev row of the branches table, replaced the removed text with a short note explaining the historical context.
- `docs/DEVELOPING.md`: changed "three PRs" to "two PRs", removed PR 3 entirely, replaced with the same short note.

The historical HISTORY.md entry from v1.4.0 (which mentions the trap and the original fix) is preserved -- it remains an accurate record of what happened at the time.

## Test plan

- [x] `make doc-check` passes (validate_docs.py + translation drift).
- [x] `grep` confirms no orphaned mentions of "sync merge" / "sync-main-to-dev" outside intentional ones (HISTORY.md historical entry; the new explanatory notes in CLAUDE.md and DEVELOPING.md).


---
_Generated by [Claude Code](https://claude.ai/code/session_01HTrmtEbv59VH9emC8znjEM)_