### PR TITLE
chore: start v1.6.0-pre1 development cycle

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": [],
-  "version": "1.5.0"
+  "version": "1.6.0-pre1"
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-05-07):** v1.5.0 released; active development on `dev` will start the v1.6.0 cycle. Path to v2.0.0: v1.6.0 (reliability + completeness), v1.7.0 (documentation + architecture), v2.0.0 (HACS default).
+> **Status (2026-05-07):** v1.5.0 released; active development on `dev` at `1.6.0-pre1`. Path to v2.0.0: v1.6.0 (reliability + completeness), v1.7.0 (documentation + architecture), v2.0.0 (HACS default).
 
 > **Branching model:** see `CLAUDE.md § Branching strategy and versioning`.
 


### PR DESCRIPTION
## Summary

Starts the v1.6.0 development cycle. Pure version bump, no functional change.

- `manifest.json`: `1.5.0` -> `1.6.0-pre1`.
- `docs/ROADMAP.md`: status line bumped to "active development on `dev` at `1.6.0-pre1`".

`CHANGELOG.md` and `docs/HISTORY.md` are intentionally untouched. There has been no new functional work since v1.5.0 -- this PR exists only to flip dev's manifest version into the new cycle so subsequent PRs can target `1.6.0-pre1`.

The v1.6.0 ROADMAP section already lists the planned reliability work (the `_category_states` rebuild fix, epoch-ms timestamp parsing, the v2 `system-log` API switch, the silent JSON-parse 400-inspection fix), the testing/tooling items, and the buttons-as-CoordinatorEntity tech debt.

## Test plan

- [x] `make check` passes (lint + format + mypy + HACS validate + translation drift + 379 tests).
- [x] `python3 scripts/bump_version.py --next-cycle` produced the manifest diff.
- [x] After merge, no tag is needed yet -- the first `v1.6.0-pre1` tag will be cut once there is real work to checkpoint.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HTrmtEbv59VH9emC8znjEM)_