### PR TITLE
fix(polling): parse epoch-ms timestamps and surface 400-body parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Polled alarms with epoch-millisecond `timestamp`/`datetime` fields (numeric or numeric-string) are now parsed correctly. Previously `datetime.fromisoformat(str(ts))` rejected numeric strings, silently falling back to "now" and corrupting `received_at` for every polled alert on controllers that emit ms timestamps. Prerequisite for the v2 system-log polling switch.
+- 400-response bodies that fail JSON parsing during alarm-endpoint probing are now logged at DEBUG with the exception class. Previously a bare `except Exception: pass` masked malformed UniFi error bodies, hiding the `api.err.InvalidObject` fallback path.
+
 ## [1.5.0] - 2026-05-07
 
 ### Fixed

--- a/custom_components/unifi_alerts/models.py
+++ b/custom_components/unifi_alerts/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -55,12 +56,22 @@ class UniFiAlert:
     def from_api_alarm(cls, category: str, alarm: dict) -> UniFiAlert:
         """Build an alert from a polled UniFi controller alarm record."""
         message = alarm.get("msg") or alarm.get("message") or alarm.get("key") or "Unknown alert"
-        # UniFi stores timestamps as epoch milliseconds in some fields
+        # UniFi returns timestamps as epoch milliseconds (v2 system-log always; legacy
+        # /list/alarm sometimes) or ISO strings. fromisoformat rejects numeric strings,
+        # so try the numeric branch first.
         ts = alarm.get("datetime") or alarm.get("timestamp")
-        try:
-            received_at = datetime.fromisoformat(str(ts)) if ts else datetime.now(UTC)
-        except (ValueError, TypeError):
-            received_at = datetime.now(UTC)
+        received_at = datetime.now(UTC)
+        if ts is not None:
+            try:
+                epoch_ms = int(ts)
+            except (ValueError, TypeError):
+                epoch_ms = None
+            if epoch_ms is not None:
+                with suppress(OverflowError, OSError, ValueError):
+                    received_at = datetime.fromtimestamp(epoch_ms / 1000, tz=UTC)
+            else:
+                with suppress(ValueError, TypeError):
+                    received_at = datetime.fromisoformat(str(ts))
 
         return cls(
             category=category,

--- a/custom_components/unifi_alerts/unifi_client.py
+++ b/custom_components/unifi_alerts/unifi_client.py
@@ -144,8 +144,12 @@ class UniFiClient:
                     try:
                         body = await resp.json(content_type=None)
                         unifi_msg = body.get("meta", {}).get("msg", "")
-                    except Exception:  # noqa: BLE001
-                        pass
+                    except Exception as err:  # noqa: BLE001
+                        _LOGGER.debug(
+                            "Could not parse 400 response body from %s: %s",
+                            url,
+                            type(err).__name__,
+                        )
                     if unifi_msg == "api.err.InvalidObject":
                         _LOGGER.debug(
                             "Alarm URL %s returned 400 api.err.InvalidObject — trying next URL",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,8 +15,6 @@ Closes remaining correctness gaps and polishes testing. The watermark re-asserti
 ### Reliability
 
 - [ ] **`_category_states` rebuild discards counters on reload**: `alert_count` and `last_alert` are lost on every reload. Persist alongside watermarks in the `Store`.
-- [ ] **Epoch-ms timestamp parsing** (`models.py:54-63`): numeric strings silently fall back to `now(UTC)`. Add an epoch-ms branch + `test_from_api_alarm_epoch_ms`. Note: the v2 `system-log` API always returns epoch-ms in its `timestamp` field, so this fix is a prerequisite for the v2 polling strategy below.
-- [ ] **Silent JSON-parse failure during 400-error inspection** (`unifi_client.py`): `except Exception: pass` masks malformed UniFi error bodies. Log at DEBUG with the exception class name.
 - [ ] **Switch polling to v2 system-log API** (`unifi_client.py`): `/list/alarm` caps at ~3000 records oldest-first; on controllers with more than ~33 alarms/day, recent alarms are never in the polled response and `open_count` is always 0 via polling. The v2 `POST /proxy/network/v2/api/site/{site}/system-log/all` endpoint accepts `timestampFrom`/`timestampTo` (epoch ms) and `pageNumber`/`pageSize`; field-confirmed on Network 10.3.58. Implementation: probe `/system-log/count` on startup; if available, poll `system-log/all` with `timestampFrom = last_cleared_at or (now - 24h)` and page through results; fall back to legacy `/list/alarm` for older controllers. Requires `UniFiAlert.from_system_log_event()` (v2 schema uses `message_raw` + `parameters` templates, epoch-ms `timestamp`, `status: "NEW"`, and a new key format with no `EVT_` prefix) and a separate v2 key-to-category map. See `docs/UNIFI.md § v2 system-log API` and `docs/research/alert-endpoints.md`.
 
 ### Testing / tooling

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14,10 +14,8 @@ Outstanding work only. Items are removed when they ship; completion lives in `do
 
 ## Reliability / correctness
 
-- **Epoch-ms timestamps dropped** (`models.py:54-63`): `datetime.fromisoformat(str(ts))` rejects numeric strings, so polled alerts using epoch-ms `datetime`/`timestamp` fields silently fall back to `now(UTC)`. Add an epoch-ms branch before the ISO fallback.
 - **Polling strategy must switch to v2 system-log API for busy controllers** (`unifi_client.py`): `/list/alarm` caps at ~3000 records oldest-first. The v2 `POST /proxy/network/v2/api/site/{site}/system-log/all` endpoint supports `timestampFrom`/`timestampTo` (epoch ms) and `pageNumber`/`pageSize` pagination; field-confirmed working on Network 10.3.58. Implementation: probe `/system-log/count` on startup; if available, use `system-log/all` with `timestampFrom = last_cleared_at or (now - 24h)` for polling; fall back to legacy `/list/alarm` for older controllers. Requires a new `UniFiAlert.from_system_log_event()` parser (the v2 schema uses `message_raw` + `parameters` templates, epoch-ms `timestamp`, `status: "NEW"`, and a new key format with no `EVT_` prefix) and a separate v2 key-to-category map. See `docs/research/alert-endpoints.md` and `docs/UNIFI.md § v2 system-log API`.
 - **`_category_states` rebuilt on reload** (`coordinator.py`): `alert_count` and `last_alert` are discarded on every options change. Persist them alongside watermarks in the existing `Store`.
-- **Silent JSON-parse failure during 400-error inspection** (`unifi_client.py`): `except Exception: pass` swallows malformed UniFi error bodies, hiding the `api.err.InvalidObject` fallback. Log at DEBUG with the exception class name.
 
 ## Type safety / tech debt
 
@@ -27,7 +25,6 @@ Outstanding work only. Items are removed when they ship; completion lives in `do
 
 ## Testing
 
-- **`test_from_api_alarm_epoch_ms`**: assert a numeric epoch-ms timestamp produces the correct UTC datetime.
 - **Webhook-mid-poll interleaving test** (`test_coordinator.py`): assert a webhook arriving while `_async_update_data()` is awaited does not regress `is_alerting`.
 - **`make lint` to cover `tests/`**: extend the Makefile target and resolve the six pre-existing `I001`/`F401` issues in `test_services.py` and `test_config_flow.py`.
 - **Optional: integration test for full rotation cycle**: options-flow > entry-update > reload > re-register, end-to-end. Each step is unit-tested already.

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -54,6 +54,23 @@ class TestUniFiAlert:
         alert = UniFiAlert.from_api_alarm(CATEGORY_SECURITY_THREAT, alarm)
         assert isinstance(alert.received_at, datetime)
 
+    def test_from_api_alarm_epoch_ms(self):
+        """Numeric epoch-ms timestamps must be parsed, not silently dropped."""
+        epoch_ms = 1705320600000
+        expected = datetime.fromtimestamp(epoch_ms / 1000, tz=UTC)
+        alarm = {"msg": "test", "timestamp": epoch_ms}
+        alert = UniFiAlert.from_api_alarm(CATEGORY_SECURITY_THREAT, alarm)
+        assert alert.received_at == expected
+        assert alert.received_at.tzinfo == UTC
+
+    def test_from_api_alarm_epoch_ms_string(self):
+        """Numeric-string epoch-ms timestamps are also accepted (fromisoformat rejects them)."""
+        epoch_ms = 1705320600000
+        expected = datetime.fromtimestamp(epoch_ms / 1000, tz=UTC)
+        alarm = {"msg": "test", "timestamp": str(epoch_ms)}
+        alert = UniFiAlert.from_api_alarm(CATEGORY_SECURITY_THREAT, alarm)
+        assert alert.received_at == expected
+
     def test_from_webhook_payload_received_at_is_timezone_aware(self):
         """received_at must be UTC-aware so HA time comparisons work."""
         alert = UniFiAlert.from_webhook_payload(CATEGORY_NETWORK_WAN, {"message": "test"})


### PR DESCRIPTION
## Summary

Two small reliability fixes from the v1.6.0 backlog:

- **`models.py`** — `UniFiAlert.from_api_alarm` now recognises numeric and numeric-string epoch-ms `timestamp`/`datetime` fields before falling back to `datetime.fromisoformat`. Previously `fromisoformat(str(ts))` rejected numeric strings, so polled alerts with epoch-ms timestamps silently fell back to `now(UTC)` and corrupted `received_at`. This is a prerequisite for the v2 `system-log` polling switch (which always returns epoch-ms).
- **`unifi_client.py`** — replaced the bare `except Exception: pass` during 400-response JSON parsing with a `_LOGGER.debug` call that includes the exception class and URL. Previously this masked malformed UniFi error bodies and hid the `api.err.InvalidObject` fallback path during diagnostics.

Backlog bookkeeping: dropped both items from `docs/TODO.md` and `docs/ROADMAP.md § v1.6.0` and added matching `[Unreleased]` bullets in `CHANGELOG.md`.

## Test plan

- [x] `make check` clean locally: ruff lint + format, mypy, HACS preflight, strings.json drift, full pytest suite (381 tests).
- [x] New `test_from_api_alarm_epoch_ms` covers numeric `int` epoch-ms.
- [x] New `test_from_api_alarm_epoch_ms_string` covers numeric-string epoch-ms (the case `fromisoformat` rejected).
- [x] Existing `test_from_api_alarm` (ISO string) and `test_from_api_alarm_bad_datetime_falls_back` continue to pass — fallback semantics unchanged for non-numeric, non-ISO inputs.

https://claude.ai/code/session_01Jmc8j73zEmnvrzY2FUmxNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmc8j73zEmnvrzY2FUmxNS)_