### PR TITLE
fix(buttons): inherit CoordinatorEntity and gate availability on enabled state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Polled alarms with epoch-millisecond `timestamp`/`datetime` fields (numeric or numeric-string) are now parsed correctly. Previously `datetime.fromisoformat(str(ts))` rejected numeric strings, silently falling back to "now" and corrupting `received_at` for every polled alert on controllers that emit ms timestamps. Prerequisite for the v2 system-log polling switch.
 - 400-response bodies that fail JSON parsing during alarm-endpoint probing are now logged at DEBUG with the exception class. Previously a bare `except Exception: pass` masked malformed UniFi error bodies, hiding the `api.err.InvalidObject` fallback path.
+- Per-category Clear buttons now report unavailable when their category is disabled in options. Previously they appeared clickable but no-oped on press. The all-clear button is also now unavailable when no categories are enabled. Both button classes now inherit `CoordinatorEntity` so they respond to coordinator updates consistently with the other platforms. (`button.py`)
 - README and info.md entity-ID examples now match what HA generates from the integration's entity names; stale short-form IDs (e.g. `binary_sensor.unifi_alerts_network_device`) replaced with the correct slugified forms (e.g. `binary_sensor.unifi_alerts_network_device_offline_online`). Credential setup copy updated to remove references to "older controllers" and self-hosted Network Application installs now that UniFi OS is required.
 
 ## [1.5.0] - 2026-05-07

--- a/custom_components/unifi_alerts/button.py
+++ b/custom_components/unifi_alerts/button.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
@@ -20,8 +18,6 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import UniFiAlertsCoordinator
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(

--- a/custom_components/unifi_alerts/button.py
+++ b/custom_components/unifi_alerts/button.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
@@ -9,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ALL_CATEGORIES,
@@ -17,6 +20,8 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import UniFiAlertsCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -35,7 +40,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class UniFiClearCategoryButton(ButtonEntity):
+class UniFiClearCategoryButton(CoordinatorEntity[UniFiAlertsCoordinator], ButtonEntity):
     """Button that manually clears the alert state for one category."""
 
     _attr_has_entity_name = True
@@ -48,17 +53,24 @@ class UniFiClearCategoryButton(ButtonEntity):
         entry: ConfigEntry,
         category: str,
     ) -> None:
-        self._coordinator = coordinator
+        super().__init__(coordinator)
         self._category = category
         self._attr_unique_id = f"{entry.entry_id}_{category}_clear"
         self._attr_name = f"Clear {CATEGORY_LABELS[category]}"
         self._attr_device_info = _device_info(entry)
 
+    @property
+    def available(self) -> bool:
+        state = self.coordinator.get_category_state(self._category)
+        if state is None:
+            return False
+        return state.enabled
+
     async def async_press(self) -> None:
-        await self._coordinator.async_clear_category(self._category)
+        await self.coordinator.async_clear_category(self._category)
 
 
-class UniFiClearAllButton(ButtonEntity):
+class UniFiClearAllButton(CoordinatorEntity[UniFiAlertsCoordinator], ButtonEntity):
     """Button that clears alert state for all categories at once."""
 
     _attr_has_entity_name = True
@@ -71,12 +83,16 @@ class UniFiClearAllButton(ButtonEntity):
         coordinator: UniFiAlertsCoordinator,
         entry: ConfigEntry,
     ) -> None:
-        self._coordinator = coordinator
+        super().__init__(coordinator)
         self._attr_unique_id = f"{entry.entry_id}_clear_all"
         self._attr_device_info = _device_info(entry)
 
+    @property
+    def available(self) -> bool:
+        return any(state.enabled for state in self.coordinator.category_states.values())
+
     async def async_press(self) -> None:
-        await self._coordinator.async_clear_all()
+        await self.coordinator.async_clear_all()
 
 
 def _device_info(entry: ConfigEntry) -> DeviceInfo:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -22,10 +22,6 @@ Closes remaining correctness gaps and polishes testing. The watermark re-asserti
 - [ ] **`make lint` to cover `tests/`**: expand the Makefile target; resolve the six pre-existing `I001`/`F401` issues.
 - [ ] **Webhook-mid-poll interleaving test** (`test_coordinator.py`): assert a webhook during `_async_update_data()` cannot regress `is_alerting`.
 
-### Tech debt
-
-- [ ] **Buttons inherit `CoordinatorEntity`** (`button.py`): add the mixin + `available` property tied to `state.enabled`, consistent with the other platforms.
-
 ---
 
 ## v1.7.0: Documentation + architecture

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16,7 +16,6 @@ Outstanding work only. Items are removed when they ship; completion lives in `do
 
 - **`mypy strict = false`**: migrate `UniFiClient.config: dict[str, Any]` to a `TypedDict` or frozen dataclass, then bump `pyproject.toml` to `strict = true`.
 - **No sensor `device_class`** (`sensor.py`): open-count and rollup-count sensors have no class. None of HA's built-ins map cleanly; consider richer `state_class` instead.
-- **Buttons don't inherit `CoordinatorEntity`** (`button.py`): `UniFiClearCategoryButton` and `UniFiClearAllButton` extend `ButtonEntity` directly, so they always appear available even when their category is disabled. Add the mixin and an `available` property.
 
 ## Testing
 

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -451,12 +451,26 @@ class TestUniFiClearCategoryButton:
         state = make_state(is_alerting=True)
         entity = self._make(state)
         await entity.async_press()
-        entity._coordinator.async_clear_category.assert_awaited_once_with(CATEGORY_NETWORK_WAN)
+        entity.coordinator.async_clear_category.assert_awaited_once_with(CATEGORY_NETWORK_WAN)
 
     def test_unique_id_format(self):
         state = make_state()
         entity = self._make(state)
         assert entity.unique_id == f"entry-abc_{CATEGORY_NETWORK_WAN}_clear"
+
+    def test_available_true_when_enabled(self):
+        state = make_state(enabled=True)
+        entity = self._make(state)
+        assert entity.available is True
+
+    def test_available_false_when_disabled(self):
+        state = make_state(enabled=False)
+        entity = self._make(state)
+        assert entity.available is False
+
+    def test_available_false_when_state_missing(self):
+        entity = self._make(None)
+        assert entity.available is False
 
 
 class TestUniFiClearAllButton:
@@ -473,7 +487,27 @@ class TestUniFiClearAllButton:
         states = {CATEGORY_NETWORK_WAN: wan_state}
         entity = self._make(states)
         await entity.async_press()
-        entity._coordinator.async_clear_all.assert_awaited_once()
+        entity.coordinator.async_clear_all.assert_awaited_once()
+
+    def test_available_true_when_any_category_enabled(self):
+        states = {
+            CATEGORY_NETWORK_WAN: make_state(enabled=True),
+            CATEGORY_SECURITY_THREAT: make_state(enabled=False),
+        }
+        entity = self._make(states)
+        assert entity.available is True
+
+    def test_available_false_when_all_categories_disabled(self):
+        states = {
+            CATEGORY_NETWORK_WAN: make_state(enabled=False),
+            CATEGORY_SECURITY_THREAT: make_state(enabled=False),
+        }
+        entity = self._make(states)
+        assert entity.available is False
+
+    def test_available_false_when_no_categories(self):
+        entity = self._make({})
+        assert entity.available is False
 
 
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Both button classes now inherit `CoordinatorEntity[UniFiAlertsCoordinator]` as a mixin (before `ButtonEntity` in MRO, consistent with `binary_sensor.py`, `sensor.py`, and `event.py`), wired via `super().__init__(coordinator)`.
- `UniFiClearCategoryButton` exposes a dynamic `available` property: `True` iff `coordinator.get_category_state(category).enabled`; `False` if the state is `None` (defensive fallback) or the category is disabled.
- `UniFiClearAllButton` exposes a dynamic `available` property: `True` iff at least one category in `coordinator.category_states` is enabled; `False` when all are disabled or no states exist.

## Test plan

- [x] `make check` passed locally: lint (ruff), typecheck (mypy), HACS preflight, doc drift, 381 tests all green.
- [x] `TestUniFiClearCategoryButton.test_available_true_when_enabled`: category enabled returns `True`.
- [x] `TestUniFiClearCategoryButton.test_available_false_when_disabled`: category disabled returns `False`.
- [x] `TestUniFiClearCategoryButton.test_available_false_when_state_missing`: `get_category_state` returning `None` falls back to `False`.
- [x] `TestUniFiClearAllButton.test_available_true_when_any_category_enabled`: mixed enabled/disabled returns `True`.
- [x] `TestUniFiClearAllButton.test_available_false_when_all_categories_disabled`: all disabled returns `False`.
- [x] `TestUniFiClearAllButton.test_available_false_when_no_categories`: empty states returns `False`.
- [x] Existing press-delegation tests updated to reference `entity.coordinator` instead of the removed `entity._coordinator` attribute.

https://claude.ai/code/session_01Jmc8j73zEmnvrzY2FUmxNS