### PR TITLE
docs(readme): refresh entity-id examples and drop self-hosted controller references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Polled alarms with epoch-millisecond `timestamp`/`datetime` fields (numeric or numeric-string) are now parsed correctly. Previously `datetime.fromisoformat(str(ts))` rejected numeric strings, silently falling back to "now" and corrupting `received_at` for every polled alert on controllers that emit ms timestamps. Prerequisite for the v2 system-log polling switch.
 - 400-response bodies that fail JSON parsing during alarm-endpoint probing are now logged at DEBUG with the exception class. Previously a bare `except Exception: pass` masked malformed UniFi error bodies, hiding the `api.err.InvalidObject` fallback path.
+- README and info.md entity-ID examples now match what HA generates from the integration's entity names; stale short-form IDs (e.g. `binary_sensor.unifi_alerts_network_device`) replaced with the correct slugified forms (e.g. `binary_sensor.unifi_alerts_network_device_offline_online`). Credential setup copy updated to remove references to "older controllers" and self-hosted Network Application installs now that UniFi OS is required.
 
 ## [1.5.0] - 2026-05-07
 

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Copy `custom_components/unifi_alerts/` into your HA `config/custom_components/` 
 
 1. Go to **Settings > Devices & Services > Add Integration** > search **UniFi Alerts**
 2. Enter your controller URL (e.g. `https://192.168.1.1`) and credentials
-   - **API key** (UDM Pro, UCG Ultra, and other UniFi OS devices): generate one in the UniFi OS web UI (see [Generating an API key](#generating-an-api-key) below), leave Username/Password blank
-   - **Username / password** (older controllers, Cloud Key): fill in Username and Password, leave API Key blank
+   - **API key** (recommended): generate one in the UniFi OS web UI (see [Generating an API key](#generating-an-api-key) below), leave Username/Password blank
+   - **Username / password**: fill in Username and Password, leave API Key blank
 3. Select the alert categories you want to monitor (see table above - client/device categories are noisy by default)
 4. Configure polling interval and auto-clear timeout
 5. **Copy the webhook URLs** shown on the final screen into UniFi Alarm Manager (see next section). Click **Submit** to save - the integration is not created until you click Submit.
@@ -83,7 +83,7 @@ Copy `custom_components/unifi_alerts/` into your HA `config/custom_components/` 
 
 ## Generating an API key
 
-API keys are supported on **UniFi OS consoles only** (UDM, UDM Pro, UDM SE, UCG-Ultra, Cloud Key Gen2+). They are not available on self-hosted (Linux/Windows) controllers.
+API keys are a UniFi OS feature, available on all supported consoles (UDM, UDM Pro, UDM SE, UCG-Ultra, UCG-Max, Cloud Key Gen2+).
 
 The navigation path to create a key varies by firmware version:
 
@@ -118,23 +118,23 @@ For each enabled category, create an alarm in **UniFi Network > Settings > Notif
 
 ## Entities created
 
-For each enabled category (example: `network_device`):
+Entity IDs are derived from the entity's display name, which HA slugifies on first install. The unique_id format is `{entry_id}_{category}_{sensor_type}`; the entity_id is the slugified device name plus the entity name. Examples below use `network_device` as the category; the same pattern applies to all categories.
 
-| Entity | ID pattern | Type |
+| Entity | Example entity ID | Type |
 | --- | --- | --- |
-| Binary sensor | `binary_sensor.unifi_alerts_network_device` | ON = alert active |
-| Message sensor | `sensor.unifi_alerts_network_device_last_message` | Last alert text |
-| Count sensor | `sensor.unifi_alerts_network_device_open_count` | Open alarm count |
-| Event entity | `event.unifi_alerts_network_device` | Fires per alert |
-| Clear button | `button.unifi_alerts_clear_network_device` | Manual clear |
+| Binary sensor | `binary_sensor.unifi_alerts_network_device_offline_online` | ON = alert active |
+| Message sensor | `sensor.unifi_alerts_network_device_offline_online_last_message` | Last alert text |
+| Count sensor | `sensor.unifi_alerts_network_device_offline_online_open_count` | Open alarm count |
+| Event entity | `event.unifi_alerts_network_device_offline_online_event` | Fires per alert |
+| Clear button | `button.unifi_alerts_clear_network_device_offline_online` | Manual clear |
 
-Plus rollup entities:
+Plus rollup entities (one per config entry, regardless of which categories are enabled):
 
 | Entity | ID | Type |
 | --- | --- | --- |
 | Rollup binary | `binary_sensor.unifi_alerts_any_alert` | Any category alerting |
 | Rollup count | `sensor.unifi_alerts_total_open_alerts` | Total open count |
-| Clear all button | `button.unifi_alerts_clear_all` | Clear everything |
+| Clear all button | `button.unifi_alerts_clear_all_alerts` | Clear everything |
 
 ---
 
@@ -153,15 +153,15 @@ entities:
     name: Any Alert Active
 
   # Per-category binary sensors (ON = alert active)
-  - entity: binary_sensor.unifi_alerts_network_device
+  - entity: binary_sensor.unifi_alerts_network_device_offline_online
     name: Device Offline/Online
-  - entity: binary_sensor.unifi_alerts_network_wan
+  - entity: binary_sensor.unifi_alerts_network_wan_offline_latency
     name: WAN Offline/Latency
-  - entity: binary_sensor.unifi_alerts_security_threat
+  - entity: binary_sensor.unifi_alerts_security_threat_ids_detected
     name: Threat / IDS
-  - entity: binary_sensor.unifi_alerts_security_firewall
+  - entity: binary_sensor.unifi_alerts_security_firewall_block
     name: Firewall Block
-  - entity: binary_sensor.unifi_alerts_power
+  - entity: binary_sensor.unifi_alerts_power_poe_power_loss
     name: Power / PoE
 
   # Total open-alarm count (polled from controller)
@@ -169,7 +169,7 @@ entities:
     name: Total Open Alerts
 ```
 
-> **Tip:** For a more compact view, replace `type: entities` with `type: glance`. Per-category message sensors (`sensor.unifi_alerts_<category>_last_message`) and open-count sensors (`sensor.unifi_alerts_<category>_open_count`) can be added the same way.
+> **Tip:** For a more compact view, replace `type: entities` with `type: glance`. Per-category message and open-count sensors follow the same naming pattern, for example: `sensor.unifi_alerts_network_device_offline_online_last_message` and `sensor.unifi_alerts_network_device_offline_online_open_count`.
 
 ---
 
@@ -194,7 +194,7 @@ automation:
   - alias: "Notify on UniFi security threat"
     trigger:
       - platform: state
-        entity_id: event.unifi_alerts_security_threat
+        entity_id: event.unifi_alerts_security_threat_ids_detected_event
     condition:
       # Only act when the entity actually fired a new event (state changes on each alert)
       - condition: template
@@ -210,7 +210,7 @@ automation:
           notification_id: "unifi_security_threat"
 ```
 
-> **Tip:** Replace `event.unifi_alerts_security_threat` with any per-category event entity (e.g. `event.unifi_alerts_network_device`, `event.unifi_alerts_power`). Swap `persistent_notification.create` for `notify.mobile_app_your_phone` or any other notify action.
+> **Tip:** Replace `event.unifi_alerts_security_threat_ids_detected_event` with any per-category event entity (e.g. `event.unifi_alerts_network_device_offline_online_event`, `event.unifi_alerts_power_poe_power_loss_event`). Swap `persistent_notification.create` for `notify.mobile_app_your_phone` or any other notify action.
 
 #### Automation caveats
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5,7 +5,6 @@ Outstanding work only. Items are removed when they ship; completion lives in `do
 ## 🟡 High-value
 
 - **Verify update-in-place**: confirm a HACS file copy + config-entry reload (Settings > Integrations > UniFi Alerts > ⋮ > Reload) is enough on a real HA install. A forced restart would be a friction point. Document the expected flow in `README.md`.
-- **README + info.md examples sweep**: confirm sensor names in the dashboard / automation YAML match the current `unique_id` format and that no copy still references self-hosted controllers.
 
 ## 🟢 Nice-to-have
 

--- a/info.md
+++ b/info.md
@@ -38,7 +38,7 @@ Aggregates **UniFi Network controller alerts** into Home Assistant sensors, bina
 
 - Home Assistant 2026.1.0 or later
 - UniFi Network controller reachable on the same local network as your HA instance
-- Credentials: API key (UniFi OS consoles) **or** username + password (older controllers)
+- Credentials: API key (recommended) **or** username + password
 
 > **Local network only:** webhook URLs are not reachable over Nabu Casa remote access or from cloud-hosted controllers.
 


### PR DESCRIPTION
## Summary

- Corrected all entity-ID examples in `README.md` (entities table, Lovelace card snippet, automation example, tip text). The old short-form IDs (e.g. `binary_sensor.unifi_alerts_network_device`) do not match what HA generates; the correct slugified forms include the full category label (e.g. `binary_sensor.unifi_alerts_network_device_offline_online`).
- Dropped "older controllers" and "self-hosted (Linux/Windows) controllers" copy from the Setup section and the API-key section of `README.md`. These paths have been unsupported since v1.4.0.
- Fixed the same "older controllers" phrasing in `info.md` Requirements.
- Deleted the completed README-sweep item from `docs/TODO.md § High-value`.
- Added a `### Fixed` bullet to `CHANGELOG.md [Unreleased]`.

## Audit findings

**Wrong:** every per-category entity-ID example in `README.md` used the raw category slug (e.g. `binary_sensor.unifi_alerts_network_device`). HA generates entity IDs by slugifying `"{device_name} {_attr_name}"`. With device name "UniFi Alerts" and `_attr_name = CATEGORY_LABELS[category]` (e.g. "Network: Device offline/online"), the actual ID is `binary_sensor.unifi_alerts_network_device_offline_online`. The rollup entities (`binary_sensor.unifi_alerts_any_alert`, `sensor.unifi_alerts_total_open_alerts`) were already correct. The "Clear all" button was also wrong: `button.unifi_alerts_clear_all` vs. the correct `button.unifi_alerts_clear_all_alerts`.

**Wrong:** `README.md` credential-setup copy and API-key section referenced "older controllers", "Cloud Key" as a username/password use case, and described API keys as "not available on self-hosted (Linux/Windows) controllers". All legacy framing removed in v1.4.0.

**Already correct:** the top-level "Requires UniFi OS" prerequisites block, the Alarm Manager setup instructions, the event attribute table, and all automation caveats were accurate with no changes needed. `info.md` structure and content were accurate except for the single "older controllers" phrase.

**Flagged for follow-up (not in scope):** `docs/TODO.md` still lists items requesting screenshots of the config flow UI. Images cannot be updated via text edits alone; that work remains outstanding.

## Test plan

- Doc-only PR (`README.md`, `info.md`, `docs/TODO.md`, `CHANGELOG.md`); no code changed.
- `make doc-check` passes locally (`scripts/validate_docs.py` + `scripts/check_translations.py`).
- Branch was rebased onto current `dev` (originally based on v1.4.0 due to a worktree-isolation default; corrected by force-push). Substantive edits survived the rebase; conflict resolution merged Agent's substantive copy fixes with dev's punctuation-style sweep from #69.

https://claude.ai/code/session_01Jmc8j73zEmnvrzY2FUmxNS