### PR TITLE
docs(readme): add 'Updating the integration' section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an "Updating the integration" section to README.md between Installation and Setup, explaining that a full Home Assistant restart is required after every HACS update; the config-entry Reload action does not pick up new code or manifest changes.
+
 ### Fixed
 
 - Polled alarms with epoch-millisecond `timestamp`/`datetime` fields (numeric or numeric-string) are now parsed correctly. Previously `datetime.fromisoformat(str(ts))` rejected numeric strings, silently falling back to "now" and corrupting `received_at` for every polled alert on controllers that emit ms timestamps. Prerequisite for the v2 system-log polling switch.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ Copy `custom_components/unifi_alerts/` into your HA `config/custom_components/` 
 
 ---
 
+## Updating the integration
+
+After every HACS update (or manual file copy), restart Home Assistant. Do not rely on the integration's Reload action; it does not pick up new code or the new `manifest.json` version.
+
+Home Assistant caches imported Python modules in memory. The Reload action under **Settings > Devices & Services > UniFi Alerts > ⋮ > Reload** re-runs `async_setup_entry` and re-registers entities, but it does so against the cached in-memory module. The new files HACS copied to disk are not loaded until HA imports the module fresh, which only happens on a full restart.
+
+**Steps:**
+
+1. Open HACS, find UniFi Alerts, and click **Update**.
+2. Restart Home Assistant: **Settings > System > Restart Home Assistant > Restart Home Assistant**. HACS prompts you to do this on every update; follow the prompt.
+3. Verify the new version: open **Settings > Devices & Services > UniFi Alerts**, click into the controller device, and check the version field on the device-info pane.
+
+> **Note:** Clicking Reload after an update will appear successful (entities re-register, setup logs fire), but the integration is still running the old code. Always do a full restart.
+
+---
+
 ## Setup
 
 1. Go to **Settings > Devices & Services > Add Integration** > search **UniFi Alerts**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -52,7 +52,6 @@ Closes the remaining documentation gaps and the largest architecture items.
 
 ### QA
 
-- [ ] **Verify update-in-place**: HACS file copy + config-entry reload sufficient; no HA restart required.
 - [ ] **Optional: integration test for full rotation cycle**: options-flow > entry-update > reload > re-register, end-to-end.
 
 ---

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,10 +2,6 @@
 
 Outstanding work only. Items are removed when they ship; completion lives in `docs/HISTORY.md`, and the per-release plan lives in `docs/ROADMAP.md`.
 
-## 🟡 High-value
-
-- **Verify update-in-place**: confirm a HACS file copy + config-entry reload (Settings > Integrations > UniFi Alerts > ⋮ > Reload) is enough on a real HA install. A forced restart would be a friction point. Document the expected flow in `README.md`.
-
 ## 🟢 Nice-to-have
 
 - **HACS default catalogue submission**: open the PR to <https://github.com/hacs/default> once all v1.x items below are closed.


### PR DESCRIPTION
## Summary

- Adds "Updating the integration" section to README.md between Installation and Setup, explaining the full HA restart requirement.
- Closes the "Verify update-in-place" item in docs/TODO.md and docs/ROADMAP.md based on a live-install test against v1.5.0-pre3.
- CHANGELOG [Unreleased] [Added] bullet.

## Why

A live-install test confirmed that the integration's config-entry Reload re-runs setup against the cached in-memory module; only a full HA restart picks up new code and the new manifest version. The previous TODO line speculated that Reload might be sufficient; that is empirically false. The README now tells users plainly: restart after every update.

## Test plan

- Doc-only PR. `make doc-check` passes locally (validate_docs.py + check_translations.py).

https://claude.ai/code/session_01Jmc8j73zEmnvrzY2FUmxNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmc8j73zEmnvrzY2FUmxNS)_