### PR TITLE
ci(lint): cover tests/ in make lint target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `make lint` now covers `tests/` in addition to `custom_components/`. Zero pre-existing `I001`/`F401` issues were present at the time the scope was widened; the target was simply not wired up.
+
 ### Added
 
 - Added an "Updating the integration" section to README.md between Installation and Setup, explaining that a full Home Assistant restart is required after every HACS update; the config-entry Reload action does not pick up new code or manifest changes.

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ test:
 	$(VENV)/pytest$(EXE) tests/ -v
 
 lint:
-	$(VENV)/ruff$(EXE) check custom_components/
-	$(VENV)/ruff$(EXE) format --check custom_components/
+	$(VENV)/ruff$(EXE) check custom_components/ tests/
+	$(VENV)/ruff$(EXE) format --check custom_components/ tests/
 
 typecheck:
 	$(VENV)/mypy$(EXE) custom_components/unifi_alerts --ignore-missing-imports

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,7 +19,6 @@ Closes remaining correctness gaps and polishes testing. The watermark re-asserti
 
 ### Testing / tooling
 
-- [ ] **`make lint` to cover `tests/`**: expand the Makefile target; resolve the six pre-existing `I001`/`F401` issues.
 - [ ] **Webhook-mid-poll interleaving test** (`test_coordinator.py`): assert a webhook during `_async_update_data()` cannot regress `is_alerting`.
 
 ---

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -20,7 +20,6 @@ Outstanding work only. Items are removed when they ship; completion lives in `do
 ## Testing
 
 - **Webhook-mid-poll interleaving test** (`test_coordinator.py`): assert a webhook arriving while `_async_update_data()` is awaited does not regress `is_alerting`.
-- **`make lint` to cover `tests/`**: extend the Makefile target and resolve the six pre-existing `I001`/`F401` issues in `test_services.py` and `test_config_flow.py`.
 - **Optional: integration test for full rotation cycle**: options-flow > entry-update > reload > re-register, end-to-end. Each step is unit-tested already.
 
 ## Documentation

--- a/tests/unit/test_config_flow.py
+++ b/tests/unit/test_config_flow.py
@@ -334,7 +334,13 @@ async def test_options_flow_full_cycle() -> None:
     flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
 
     # Step 1: blank credentials → skip to categories
-    blank_creds = {CONF_CONTROLLER_URL: "", CONF_USERNAME: "", CONF_PASSWORD: "", CONF_API_KEY: "", CONF_VERIFY_SSL: True}
+    blank_creds = {
+        CONF_CONTROLLER_URL: "",
+        CONF_USERNAME: "",
+        CONF_PASSWORD: "",
+        CONF_API_KEY: "",
+        CONF_VERIFY_SSL: True,
+    }
     flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
     await flow.async_step_credentials(blank_creds)
 
@@ -764,9 +770,7 @@ class TestReauthFlow:
         confirm_result = {"type": "form", "step_id": "reauth_confirm"}
         flow.async_step_reauth_confirm = AsyncMock(return_value=confirm_result)
 
-        with patch(
-            "custom_components.unifi_alerts.config_flow._create_auth_failed_issue"
-        ):
+        with patch("custom_components.unifi_alerts.config_flow._create_auth_failed_issue"):
             result = await flow.async_step_reauth({})
 
         assert result == confirm_result
@@ -1034,9 +1038,7 @@ class TestOptionsFlowCredentials:
         from custom_components.unifi_alerts.unifi_client import InvalidAuthError
 
         flow = _make_options_flow()
-        flow.async_show_form = MagicMock(
-            return_value={"type": "form", "step_id": "credentials"}
-        )
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "credentials"})
 
         new_creds = {
             CONF_CONTROLLER_URL: "",
@@ -1069,9 +1071,7 @@ class TestOptionsFlowCredentials:
     async def test_invalid_url_scheme_shows_error(self) -> None:
         """A non-http/https URL scheme must show a field-level error without hitting the network."""
         flow = _make_options_flow()
-        flow.async_show_form = MagicMock(
-            return_value={"type": "form", "step_id": "credentials"}
-        )
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "credentials"})
 
         bad_url_input = {
             CONF_CONTROLLER_URL: "ftp://192.168.1.1",
@@ -1279,13 +1279,15 @@ class TestOptionsFlowCredentials:
         )
         flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
 
-        await flow.async_step_credentials({
-            CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
-            CONF_API_KEY: "",
-            CONF_VERIFY_SSL: False,
-        })
+        await flow.async_step_credentials(
+            {
+                CONF_CONTROLLER_URL: "",
+                CONF_USERNAME: "",
+                CONF_PASSWORD: "",
+                CONF_API_KEY: "",
+                CONF_VERIFY_SSL: False,
+            }
+        )
 
         cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
         cat_input[CONF_POLL_INTERVAL] = 60
@@ -1454,14 +1456,16 @@ class TestWebhookSecretRotation:
         flow.async_show_form = MagicMock(
             side_effect=lambda **kwargs: {"type": "form", "step_id": kwargs["step_id"]}
         )
-        await flow.async_step_credentials({
-            CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
-            CONF_API_KEY: "",
-            CONF_VERIFY_SSL: True,
-            CONF_REGENERATE_WEBHOOK_SECRET: True,
-        })
+        await flow.async_step_credentials(
+            {
+                CONF_CONTROLLER_URL: "",
+                CONF_USERNAME: "",
+                CONF_PASSWORD: "",
+                CONF_API_KEY: "",
+                CONF_VERIFY_SSL: True,
+                CONF_REGENERATE_WEBHOOK_SECRET: True,
+            }
+        )
 
         # Staged but not persisted: entry.data still holds the old secret.
         flow.hass.config_entries.async_update_entry.assert_not_called()

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -829,9 +829,7 @@ class TestWatermarks:
         for i, a in enumerate(alarms):
             a.received_at = datetime(2024, 6, 1, i, 0, 0, tzinfo=UTC)
 
-        client.categorise_alarms = AsyncMock(
-            return_value={CATEGORY_NETWORK_WAN: alarms}
-        )
+        client.categorise_alarms = AsyncMock(return_value={CATEGORY_NETWORK_WAN: alarms})
         config = {
             CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
             CONF_POLL_INTERVAL: 60,
@@ -920,9 +918,7 @@ class TestPollingWatermarkSuppressesIsAlerting:
         )
 
         client = MagicMock()
-        client.categorise_alarms = AsyncMock(
-            return_value={CATEGORY_NETWORK_WAN: [stale_alarm]}
-        )
+        client.categorise_alarms = AsyncMock(return_value={CATEGORY_NETWORK_WAN: [stale_alarm]})
 
         config = {
             CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
@@ -960,9 +956,7 @@ class TestPollingWatermarkSuppressesIsAlerting:
         )
 
         client = MagicMock()
-        client.categorise_alarms = AsyncMock(
-            return_value={CATEGORY_NETWORK_WAN: [stale, fresh]}
-        )
+        client.categorise_alarms = AsyncMock(return_value={CATEGORY_NETWORK_WAN: [stale, fresh]})
 
         config = {
             CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -51,9 +51,11 @@ def _make_coordinator(
     coordinator.any_alerting = any_alerting
     coordinator.rollup_alert_count = rollup_alert_count
     coordinator.rollup_open_count = rollup_open_count
-    coordinator.category_states = category_states if category_states is not None else {
-        cat: CategoryState(category=cat) for cat in ALL_CATEGORIES
-    }
+    coordinator.category_states = (
+        category_states
+        if category_states is not None
+        else {cat: CategoryState(category=cat) for cat in ALL_CATEGORIES}
+    )
     return coordinator
 
 
@@ -69,7 +71,9 @@ async def test_diagnostics_redacts_password() -> None:
 
 @pytest.mark.asyncio
 async def test_diagnostics_redacts_api_key() -> None:
-    entry = _make_entry_with_runtime(_make_coordinator(), extra_data={CONF_API_KEY: "super-secret-key"})
+    entry = _make_entry_with_runtime(
+        _make_coordinator(), extra_data={CONF_API_KEY: "super-secret-key"}
+    )
     hass = MagicMock()
 
     result = await async_get_config_entry_diagnostics(hass, entry)

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -572,14 +572,19 @@ class TestEntityCategories:
         from custom_components.unifi_alerts.sensor import UniFiCategoryMessageSensor
 
         # CachedProperties metaclass stores _attr_* backing values as __attr_* in __dict__
-        assert UniFiCategoryMessageSensor.__dict__.get("__attr_entity_category") == EntityCategory.DIAGNOSTIC
+        assert (
+            UniFiCategoryMessageSensor.__dict__.get("__attr_entity_category")
+            == EntityCategory.DIAGNOSTIC
+        )
 
     def test_clear_category_button_is_config(self):
         from homeassistant.const import EntityCategory
 
         from custom_components.unifi_alerts.button import UniFiClearCategoryButton
 
-        assert UniFiClearCategoryButton.__dict__.get("__attr_entity_category") == EntityCategory.CONFIG
+        assert (
+            UniFiClearCategoryButton.__dict__.get("__attr_entity_category") == EntityCategory.CONFIG
+        )
 
     def test_clear_all_button_is_config(self):
         from homeassistant.const import EntityCategory

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -131,9 +131,7 @@ class TestHandleClearCategory:
         coord_a = make_coordinator()
         coord_b = make_coordinator()
         hass = make_hass({"entry-a": coord_a, "entry-b": coord_b})
-        call = make_call(
-            hass, {ATTR_CATEGORY: CATEGORY_NETWORK_WAN, ATTR_ENTRY_ID: "entry-a"}
-        )
+        call = make_call(hass, {ATTR_CATEGORY: CATEGORY_NETWORK_WAN, ATTR_ENTRY_ID: "entry-a"})
 
         await _handle_clear_category(call)
 
@@ -303,9 +301,7 @@ class TestServicesWiredFromInit:
             ),
             patch("custom_components.unifi_alerts.WebhookManager", return_value=mock_wm),
             patch("custom_components.unifi_alerts.dr.async_get", return_value=MagicMock()),
-            patch(
-                "custom_components.unifi_alerts.async_register_services"
-            ) as mock_register,
+            patch("custom_components.unifi_alerts.async_register_services") as mock_register,
         ):
             await async_setup_entry(hass, entry)
 
@@ -328,9 +324,7 @@ class TestServicesWiredFromInit:
         entry.runtime_data.client = mock_client
         hass.config_entries.async_entries = MagicMock(return_value=[entry])
 
-        with patch(
-            "custom_components.unifi_alerts.async_unregister_services"
-        ) as mock_unregister:
+        with patch("custom_components.unifi_alerts.async_unregister_services") as mock_unregister:
             await async_unload_entry(hass, entry)
 
         mock_unregister.assert_called_once_with(hass)
@@ -354,9 +348,7 @@ class TestServicesWiredFromInit:
             entry.runtime_data.client = mock_client
         hass.config_entries.async_entries = MagicMock(return_value=[entry1, entry2])
 
-        with patch(
-            "custom_components.unifi_alerts.async_unregister_services"
-        ) as mock_unregister:
+        with patch("custom_components.unifi_alerts.async_unregister_services") as mock_unregister:
             # Unload only entry1 — entry2 still remains
             await async_unload_entry(hass, entry1)
 
@@ -424,9 +416,7 @@ class TestGetCoordinatorsGuard:
         hass.config_entries.async_get_entry = MagicMock(return_value=retry_entry)
         hass.config_entries.async_entries = MagicMock(return_value=[retry_entry])
 
-        call = make_call(
-            hass, {ATTR_CATEGORY: CATEGORY_NETWORK_WAN, ATTR_ENTRY_ID: "entry-retry"}
-        )
+        call = make_call(hass, {ATTR_CATEGORY: CATEGORY_NETWORK_WAN, ATTR_ENTRY_ID: "entry-retry"})
 
         with patch("custom_components.unifi_alerts.services._LOGGER") as mock_log:
             # Must not raise — the guard should log and return early

--- a/tests/unit/test_unifi_client.py
+++ b/tests/unit/test_unifi_client.py
@@ -528,9 +528,7 @@ class TestFetchAlarms:
             f"Expected exactly three GET calls walking the chain; got {len(captured_urls)}"
         )
         assert captured_urls[0].endswith("/list/alarm")
-        assert captured_urls[1].endswith("/alarm") and not captured_urls[1].endswith(
-            "/list/alarm"
-        )
+        assert captured_urls[1].endswith("/alarm") and not captured_urls[1].endswith("/list/alarm")
         assert captured_urls[2].endswith("/stat/alarm")
         assert result == []
 

--- a/tests/unit/test_webhook_handler.py
+++ b/tests/unit/test_webhook_handler.py
@@ -39,7 +39,11 @@ def make_request(token: str | None = "test-secret-123", json_body: dict | None =
     """Build a minimal mock aiohttp.web.Request."""
     req = MagicMock()
     req.query = {"token": token} if token is not None else {}
-    body_dict = json_body if json_body is not None else {"key": "EVT_GW_WANTransition", "message": "WAN down"}
+    body_dict = (
+        json_body
+        if json_body is not None
+        else {"key": "EVT_GW_WANTransition", "message": "WAN down"}
+    )
     req.content.read = AsyncMock(return_value=json.dumps(body_dict).encode())
     return req
 


### PR DESCRIPTION
## Summary

- `make lint` now runs ruff against both `custom_components/` and `tests/`.
- Zero pre-existing `I001`/`F401` issues were found at HEAD (the TODO entry was written against an older tree state); however, `ruff format --check` found 7 test files needing whitespace/style normalisation - those are reformatted by this commit.
- No test-logic changes; pure formatting fixes only.

## Why

The lint target excluded `tests/`, so formatting drift had accumulated unseen. Widening the scope keeps test code at the same lint bar as integration code and prevents future drift.

## Test plan

- [x] `make lint` passes.
- [x] `make check` passes (full suite, all 387 tests green).

https://claude.ai/code/session_01Jmc8j73zEmnvrzY2FUmxNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmc8j73zEmnvrzY2FUmxNS)_