### PR TITLE
test(coordinator): assert webhook-during-poll cannot regress is_alerting

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,10 +17,6 @@ Closes remaining correctness gaps and polishes testing. The watermark re-asserti
 - [ ] **`_category_states` rebuild discards counters on reload**: `alert_count` and `last_alert` are lost on every reload. Persist alongside watermarks in the `Store`.
 - [ ] **Switch polling to v2 system-log API** (`unifi_client.py`): `/list/alarm` caps at ~3000 records oldest-first; on controllers with more than ~33 alarms/day, recent alarms are never in the polled response and `open_count` is always 0 via polling. The v2 `POST /proxy/network/v2/api/site/{site}/system-log/all` endpoint accepts `timestampFrom`/`timestampTo` (epoch ms) and `pageNumber`/`pageSize`; field-confirmed on Network 10.3.58. Implementation: probe `/system-log/count` on startup; if available, poll `system-log/all` with `timestampFrom = last_cleared_at or (now - 24h)` and page through results; fall back to legacy `/list/alarm` for older controllers. Requires `UniFiAlert.from_system_log_event()` (v2 schema uses `message_raw` + `parameters` templates, epoch-ms `timestamp`, `status: "NEW"`, and a new key format with no `EVT_` prefix) and a separate v2 key-to-category map. See `docs/UNIFI.md § v2 system-log API` and `docs/research/alert-endpoints.md`.
 
-### Testing / tooling
-
-- [ ] **Webhook-mid-poll interleaving test** (`test_coordinator.py`): assert a webhook during `_async_update_data()` cannot regress `is_alerting`.
-
 ---
 
 ## v1.7.0: Documentation + architecture

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -19,7 +19,6 @@ Outstanding work only. Items are removed when they ship; completion lives in `do
 
 ## Testing
 
-- **Webhook-mid-poll interleaving test** (`test_coordinator.py`): assert a webhook arriving while `_async_update_data()` is awaited does not regress `is_alerting`.
 - **Optional: integration test for full rotation cycle**: options-flow > entry-update > reload > re-register, end-to-end. Each step is unit-tested already.
 
 ## Documentation

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -975,6 +975,72 @@ class TestPollingWatermarkSuppressesIsAlerting:
         assert state.open_count == 1
 
 
+class TestWebhookMidPollRace:
+    """A webhook arriving while _async_update_data() is mid-await must not regress is_alerting.
+
+    The coordinator's polling path only sets is_alerting=True when it finds open
+    alarms and is_alerting is currently False. It never clears is_alerting on its
+    own. So if a webhook fires during a poll and asserts is_alerting=True, the
+    poll completing with an empty result cannot clobber that state — the poll
+    simply zeroes open_count and leaves is_alerting untouched.
+    """
+
+    @pytest.mark.asyncio
+    async def test_webhook_during_poll_does_not_regress_is_alerting(self):
+        import asyncio
+
+        gate = asyncio.Event()  # held open until the test releases it
+
+        async def blocking_categorise_alarms(site):  # noqa: ARG001
+            # Block the poll mid-await until the test fires the webhook
+            await gate.wait()
+            # Return empty list — the regression scenario: poll sees no alarms
+            return {}
+
+        hass = MagicMock()
+
+        def _create_task(coro, **kwargs):
+            coro.close()  # discard auto-clear coroutines — not under test
+            return MagicMock()
+
+        hass.async_create_task = _create_task
+        hass.async_create_background_task = _create_task
+
+        client = MagicMock()
+        client.categorise_alarms = blocking_categorise_alarms
+
+        config = {
+            CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+            CONF_POLL_INTERVAL: 60,
+            CONF_CLEAR_TIMEOUT: 30,
+        }
+        coord = UniFiAlertsCoordinator(hass, client, config)
+        coord.async_set_updated_data = MagicMock()
+
+        state = coord.get_category_state(CATEGORY_NETWORK_WAN)
+        assert state.is_alerting is False
+
+        # Start the poll as a concurrent task; it will block on gate.wait()
+        poll_task = asyncio.ensure_future(coord._async_update_data())
+
+        # Yield to the event loop so poll_task enters blocking_categorise_alarms
+        # and parks on gate.wait() before we interact with coordinator state.
+        await asyncio.sleep(0)
+
+        # Webhook arrives while the poll is suspended — asserts is_alerting
+        webhook_alert = make_alert(CATEGORY_NETWORK_WAN, "webhook during poll", key="EVT_RACE")
+        coord.push_alert(CATEGORY_NETWORK_WAN, webhook_alert)
+        assert state.is_alerting is True
+
+        # Release the gate: poll resumes, calls categorise_alarms, gets {}, and
+        # zeroes open_count for categories with no alarms. It must NOT flip
+        # is_alerting back to False.
+        gate.set()
+        await poll_task
+
+        assert state.is_alerting is True
+
+
 class TestPushAlertOptimisticOpenCount:
     """push_alert must increment open_count optimistically.
 


### PR DESCRIPTION
## Summary

- Adds `test_webhook_during_poll_does_not_regress_is_alerting` to `tests/unit/test_coordinator.py`.
- Documents the interleaving contract: a webhook arrival during an in-flight poll must not be clobbered by the poll's "no current alarms" return.
- Test-only. No production code change.

## Why

The coordinator's watermark logic protects against this race in production, but there was no test asserting the invariant. Future refactors to the polling or webhook paths could regress it silently. This test makes the contract visible.

## Test plan

- [x] New test passes.
- [x] `make check` passes (full suite green).

https://claude.ai/code/session_01Jmc8j73zEmnvrzY2FUmxNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmc8j73zEmnvrzY2FUmxNS)_