### PR TITLE
fix(coordinator): persist alert_count and last_alert across reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - 400-response bodies that fail JSON parsing during alarm-endpoint probing are now logged at DEBUG with the exception class. Previously a bare `except Exception: pass` masked malformed UniFi error bodies, hiding the `api.err.InvalidObject` fallback path.
 - Per-category Clear buttons now report unavailable when their category is disabled in options. Previously they appeared clickable but no-oped on press. The all-clear button is also now unavailable when no categories are enabled. Both button classes now inherit `CoordinatorEntity` so they respond to coordinator updates consistently with the other platforms. (`button.py`)
 - README and info.md entity-ID examples now match what HA generates from the integration's entity names; stale short-form IDs (e.g. `binary_sensor.unifi_alerts_network_device`) replaced with the correct slugified forms (e.g. `binary_sensor.unifi_alerts_network_device_offline_online`). Credential setup copy updated to remove references to "older controllers" and self-hosted Network Application installs now that UniFi OS is required.
+- `alert_count` and `last_alert` now persist across config-entry reloads. Previously every options change discarded both counters; they are now saved alongside the existing watermark in the integration's `Store` and restored on startup.
 
 ## [1.5.0] - 2026-05-07
 

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -196,6 +196,11 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
             state.open_count += 1
         _LOGGER.debug("Alert pushed to category %s: %s", category, alert.message)
 
+        # Persist alert_count and last_alert so they survive a config-entry
+        # reload triggered by an options change. Scheduled as a background
+        # task because push_alert is synchronous.
+        self._schedule_persist()
+
         # Cancel any existing clear timer and start a fresh one
         self._schedule_clear(category)
 
@@ -235,26 +240,54 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
     # ── Watermark persistence ─────────────────────────────────────────────
 
     async def async_restore_watermarks(self) -> None:
-        """Load persisted acknowledgement watermarks from storage on startup."""
+        """Load persisted category state from storage on startup.
+
+        Restores ``last_cleared_at``, ``alert_count``, and ``last_alert`` for
+        each category. Legacy payloads that only contain ``last_cleared_at``
+        (a plain ISO string, pre-v1.6.0) are handled transparently: the dict
+        branch runs when the stored value is a dict; the string branch handles
+        the old format so existing installs are not disrupted.
+        """
         data: dict | None = await self._store.async_load()
         if not data:
             return
-        for cat, ts_str in data.items():
+        for cat, entry in data.items():
             state = self._category_states.get(cat)
             if state is None:
                 continue
-            try:
-                state.last_cleared_at = datetime.fromisoformat(ts_str)
-            except (ValueError, TypeError):
-                _LOGGER.warning("Ignoring invalid stored watermark for %s: %r", cat, ts_str)
+            if isinstance(entry, str):
+                # Legacy format: bare ISO string watermark only.
+                try:
+                    state.last_cleared_at = datetime.fromisoformat(entry)
+                except (ValueError, TypeError):
+                    _LOGGER.warning("Ignoring invalid stored watermark for %s: %r", cat, entry)
+            elif isinstance(entry, dict):
+                ts_str = entry.get("last_cleared_at")
+                if ts_str is not None:
+                    try:
+                        state.last_cleared_at = datetime.fromisoformat(ts_str)
+                    except (ValueError, TypeError):
+                        _LOGGER.warning("Ignoring invalid stored watermark for %s: %r", cat, ts_str)
+                state.alert_count = int(entry.get("alert_count", 0))
+                raw_alert = entry.get("last_alert")
+                if raw_alert is not None:
+                    try:
+                        state.last_alert = UniFiAlert.from_dict(raw_alert)
+                    except (KeyError, TypeError, ValueError):
+                        _LOGGER.warning("Ignoring invalid stored last_alert for %s", cat)
 
     async def _async_persist_watermarks(self) -> None:
-        """Persist current acknowledgement watermarks to storage."""
-        data = {
-            cat: state.last_cleared_at.isoformat()
-            for cat, state in self._category_states.items()
-            if state.last_cleared_at is not None
-        }
+        """Persist current category state (watermark, alert_count, last_alert) to storage."""
+        data: dict[str, dict] = {}
+        for cat, state in self._category_states.items():
+            entry: dict = {}
+            if state.last_cleared_at is not None:
+                entry["last_cleared_at"] = state.last_cleared_at.isoformat()
+            entry["alert_count"] = state.alert_count
+            entry["last_alert"] = (
+                state.last_alert.to_dict() if state.last_alert is not None else None
+            )
+            data[cat] = entry
         await self._store.async_save(data)
 
     # ── Clear entry points (called by buttons and services) ───────────────
@@ -298,6 +331,19 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
             create_task = getattr(self.hass, "async_create_task", None)
             task = create_task(coro) if create_task is not None else asyncio.ensure_future(coro)
         self._clear_tasks[category] = task
+
+    def _schedule_persist(self) -> None:
+        """Schedule a fire-and-forget persist so push_alert (sync) can trigger a save."""
+        coro = self._async_persist_watermarks()
+        create_bg = getattr(self.hass, "async_create_background_task", None)
+        if create_bg is not None:
+            create_bg(coro, name="unifi_alerts_persist_state")
+        else:
+            create_task = getattr(self.hass, "async_create_task", None)
+            if create_task is not None:
+                create_task(coro)
+            else:
+                asyncio.ensure_future(coro)
 
     def cancel_clear(self, category: str) -> None:
         """Cancel any pending auto-clear task for the given category."""

--- a/custom_components/unifi_alerts/models.py
+++ b/custom_components/unifi_alerts/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from contextlib import suppress
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -82,6 +82,31 @@ class UniFiAlert:
             device_name=alarm.get("device_name") or alarm.get("ap_name") or "",
             site=alarm.get("site_name") or "",
             severity=alarm.get("severity") or alarm.get("subsystem") or "",
+        )
+
+    def to_dict(self) -> dict:
+        """Serialise this alert to a JSON-safe dict for Store persistence."""
+        d = asdict(self)
+        d["received_at"] = self.received_at.isoformat()
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict) -> UniFiAlert:
+        """Deserialise an alert previously written by ``to_dict``."""
+        received_at_raw = data.get("received_at", "")
+        try:
+            received_at = datetime.fromisoformat(received_at_raw)
+        except (ValueError, TypeError):
+            received_at = datetime.now(UTC)
+        return cls(
+            category=data.get("category", ""),
+            message=data.get("message", ""),
+            received_at=received_at,
+            raw=data.get("raw", {}),
+            key=data.get("key", ""),
+            device_name=data.get("device_name", ""),
+            site=data.get("site", ""),
+            severity=data.get("severity", ""),
         )
 
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,6 @@ Closes remaining correctness gaps and polishes testing. The watermark re-asserti
 
 ### Reliability
 
-- [ ] **`_category_states` rebuild discards counters on reload**: `alert_count` and `last_alert` are lost on every reload. Persist alongside watermarks in the `Store`.
 - [ ] **Switch polling to v2 system-log API** (`unifi_client.py`): `/list/alarm` caps at ~3000 records oldest-first; on controllers with more than ~33 alarms/day, recent alarms are never in the polled response and `open_count` is always 0 via polling. The v2 `POST /proxy/network/v2/api/site/{site}/system-log/all` endpoint accepts `timestampFrom`/`timestampTo` (epoch ms) and `pageNumber`/`pageSize`; field-confirmed on Network 10.3.58. Implementation: probe `/system-log/count` on startup; if available, poll `system-log/all` with `timestampFrom = last_cleared_at or (now - 24h)` and page through results; fall back to legacy `/list/alarm` for older controllers. Requires `UniFiAlert.from_system_log_event()` (v2 schema uses `message_raw` + `parameters` templates, epoch-ms `timestamp`, `status: "NEW"`, and a new key format with no `EVT_` prefix) and a separate v2 key-to-category map. See `docs/UNIFI.md § v2 system-log API` and `docs/research/alert-endpoints.md`.
 
 ---

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10,7 +10,6 @@ Outstanding work only. Items are removed when they ship; completion lives in `do
 ## Reliability / correctness
 
 - **Polling strategy must switch to v2 system-log API for busy controllers** (`unifi_client.py`): `/list/alarm` caps at ~3000 records oldest-first. The v2 `POST /proxy/network/v2/api/site/{site}/system-log/all` endpoint supports `timestampFrom`/`timestampTo` (epoch ms) and `pageNumber`/`pageSize` pagination; field-confirmed working on Network 10.3.58. Implementation: probe `/system-log/count` on startup; if available, use `system-log/all` with `timestampFrom = last_cleared_at or (now - 24h)` for polling; fall back to legacy `/list/alarm` for older controllers. Requires a new `UniFiAlert.from_system_log_event()` parser (the v2 schema uses `message_raw` + `parameters` templates, epoch-ms `timestamp`, `status: "NEW"`, and a new key format with no `EVT_` prefix) and a separate v2 key-to-category map. See `docs/research/alert-endpoints.md` and `docs/UNIFI.md § v2 system-log API`.
-- **`_category_states` rebuilt on reload** (`coordinator.py`): `alert_count` and `last_alert` are discarded on every options change. Persist them alongside watermarks in the existing `Store`.
 
 ## Type safety / tech debt
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1131,3 +1131,98 @@ class TestPushAlertOptimisticOpenCount:
         await coord._async_update_data()
 
         assert coord.get_category_state(CATEGORY_NETWORK_WAN).open_count == 0
+
+
+class TestCounterPersistence:
+    """Tests for alert_count and last_alert persistence across reloads."""
+
+    def _make_coord_with_mock_store(self):
+        """Coordinator with a Store mock so async_load/async_save are controllable."""
+        coord = make_coordinator()
+        coord._store = MagicMock()
+        coord._store.async_load = AsyncMock(return_value=None)
+        coord._store.async_save = AsyncMock()
+        return coord
+
+    @pytest.mark.asyncio
+    async def test_alert_count_persists_across_reload(self):
+        """alert_count written by push_alert is restored by a freshly created coordinator."""
+        coord = self._make_coord_with_mock_store()
+        coord.async_set_updated_data = MagicMock()
+
+        # Push 3 distinct alerts so alert_count reaches 3.
+        for i in range(3):
+            coord.push_alert(
+                CATEGORY_NETWORK_WAN,
+                make_alert(CATEGORY_NETWORK_WAN, f"alert {i}", key=f"EVT_TEST_{i}"),
+            )
+        assert coord.get_category_state(CATEGORY_NETWORK_WAN).alert_count == 3
+
+        # Capture what was saved by the last _schedule_persist call.
+        # _schedule_persist is fire-and-forget via hass background tasks which
+        # are mocked to no-ops in make_coordinator; call the save directly.
+        await coord._async_persist_watermarks()
+        saved = coord._store.async_save.await_args.args[0]
+
+        # Simulate a reload: new coordinator, same store data.
+        coord2 = self._make_coord_with_mock_store()
+        coord2._store.async_load.return_value = saved
+        await coord2.async_restore_watermarks()
+
+        assert coord2.get_category_state(CATEGORY_NETWORK_WAN).alert_count == 3
+
+    @pytest.mark.asyncio
+    async def test_last_alert_persists_across_reload(self):
+        """last_alert round-trips through the Store correctly."""
+        coord = self._make_coord_with_mock_store()
+        coord.async_set_updated_data = MagicMock()
+
+        alert = make_alert(CATEGORY_NETWORK_WAN, "persistent alert", key="EVT_PERSIST")
+        coord.push_alert(CATEGORY_NETWORK_WAN, alert)
+
+        await coord._async_persist_watermarks()
+        saved = coord._store.async_save.await_args.args[0]
+
+        coord2 = self._make_coord_with_mock_store()
+        coord2._store.async_load.return_value = saved
+        await coord2.async_restore_watermarks()
+
+        restored = coord2.get_category_state(CATEGORY_NETWORK_WAN).last_alert
+        assert restored is not None
+        assert restored.message == "persistent alert"
+        assert restored.category == CATEGORY_NETWORK_WAN
+        assert restored.received_at == alert.received_at
+
+    @pytest.mark.asyncio
+    async def test_restore_handles_legacy_payload_without_counters(self):
+        """A store payload with only last_cleared_at (pre-v1.6.0) restores cleanly.
+
+        alert_count must default to 0 and last_alert to None.
+        """
+        coord = self._make_coord_with_mock_store()
+        # Old-format payload: bare ISO string per category.
+        legacy_payload = {CATEGORY_NETWORK_WAN: "2024-06-01T10:00:00+00:00"}
+        coord._store.async_load.return_value = legacy_payload
+
+        await coord.async_restore_watermarks()
+
+        state = coord.get_category_state(CATEGORY_NETWORK_WAN)
+        assert state.last_cleared_at is not None
+        assert state.alert_count == 0
+        assert state.last_alert is None
+
+    @pytest.mark.asyncio
+    async def test_apply_alert_triggers_save(self):
+        """push_alert must schedule a persist (via _schedule_persist) after apply_alert.
+
+        We verify by patching _schedule_persist and asserting it is called.
+        """
+        from unittest.mock import patch as _patch
+
+        coord = self._make_coord_with_mock_store()
+        coord.async_set_updated_data = MagicMock()
+
+        with _patch.object(coord, "_schedule_persist") as mock_persist:
+            coord.push_alert(CATEGORY_NETWORK_WAN, make_alert(CATEGORY_NETWORK_WAN))
+
+        mock_persist.assert_called_once()


### PR DESCRIPTION
## Summary

- Extends the existing watermark `Store` payload to also persist `alert_count` and `last_alert` per category, restored on startup via `async_restore_watermarks()`.
- Save path triggers on `apply_alert` (the existing watermark-save path is reused for atomicity).
- Backward-compat: legacy payloads with only `last_cleared_at` restore cleanly; `alert_count` defaults to 0, `last_alert` to None.

## Why

Every options-flow change reloads the config entry, which rebuilds `_category_states` from scratch. Watermarks survived; counters didn't. Users saw `alert_count` jump back to 0 and `last_alert` cleared after toggling an unrelated category, even though the underlying alarm history hadn't changed.

## Test plan

- [x] `make check` passes locally.
- [x] `test_alert_count_persists_across_reload`
- [x] `test_last_alert_persists_across_reload`
- [x] `test_restore_handles_legacy_payload_without_counters`
- [x] `test_apply_alert_triggers_save`

https://claude.ai/code/session_01Jmc8j73zEmnvrzY2FUmxNS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmc8j73zEmnvrzY2FUmxNS)_