### PR TITLE
feat(sensor): confirm SensorStateClass.MEASUREMENT on count sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Internal
+
+- Confirmed `SensorStateClass.MEASUREMENT` on open-count and rollup-count sensors; no `SensorDeviceClass` is set (none of the HA built-ins fit an alert counter).
+
+
 ## [1.6.0] - 2026-05-11
 
 ### Changed

--- a/custom_components/unifi_alerts/sensor.py
+++ b/custom_components/unifi_alerts/sensor.py
@@ -95,6 +95,7 @@ class UniFiCategoryCountSensor(CoordinatorEntity[UniFiAlertsCoordinator], Sensor
     """Sensor whose state is the number of open (unarchived) alarms for a category."""
 
     _attr_has_entity_name = True
+    # No SensorDeviceClass fits an alert counter; MEASUREMENT suits a resettable integer.
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "alerts"
     _attr_icon = "mdi:counter"
@@ -127,6 +128,7 @@ class UniFiRollupCountSensor(CoordinatorEntity[UniFiAlertsCoordinator], SensorEn
 
     _attr_has_entity_name = True
     _attr_name = "Total Open Alerts"
+    # No SensorDeviceClass fits an alert counter; MEASUREMENT suits a resettable integer.
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "alerts"
     _attr_icon = "mdi:bell-alert"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,7 +17,6 @@ Closes the remaining documentation gaps and the largest architecture items.
 - [ ] **`mypy strict = true`**: migrate `UniFiClient.config: dict[str, Any]` to a `TypedDict` or frozen dataclass; bump `pyproject.toml`.
 - [ ] **`has_entity_name = True` + `_attr_translation_key`**: move display strings out of platform files into `strings.json`. Unlocks localisation.
 - [ ] **Split `tests/unit/test_config_flow.py` into a package**: ~1405 lines, four independent classes. Convert to `tests/unit/config_flow/{__init__,conftest,test_setup,test_options,test_reauth}.py`.
-- [ ] **Sensor `device_class` / `state_class`** (`sensor.py`): decide whether a class fits the open-count / rollup-count sensors.
 
 ### Documentation
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -14,7 +14,6 @@ Outstanding work only. Items are removed when they ship; completion lives in `do
 ## Type safety / tech debt
 
 - **`mypy strict = false`**: migrate `UniFiClient.config: dict[str, Any]` to a `TypedDict` or frozen dataclass, then bump `pyproject.toml` to `strict = true`.
-- **No sensor `device_class`** (`sensor.py`): open-count and rollup-count sensors have no class. None of HA's built-ins map cleanly; consider richer `state_class` instead.
 
 ## Testing
 

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -305,6 +305,16 @@ class TestUniFiCategoryCountSensor:
         assert entity_on.available is True
         assert entity_off.available is False
 
+    def test_state_class_is_measurement(self):
+        from homeassistant.components.sensor import SensorStateClass
+
+        entity = self._make(make_state())
+        assert entity.state_class == SensorStateClass.MEASUREMENT
+
+    def test_device_class_is_none(self):
+        entity = self._make(make_state())
+        assert entity.device_class is None
+
 
 class TestUniFiRollupCountSensor:
     def _make(self, states: dict[str, CategoryState]):
@@ -340,6 +350,16 @@ class TestUniFiRollupCountSensor:
         attrs = entity.extra_state_attributes
         assert "last_message" not in attrs
         assert attrs["total_webhook_count"] == 0
+
+    def test_state_class_is_measurement(self):
+        from homeassistant.components.sensor import SensorStateClass
+
+        entity = self._make({})
+        assert entity.state_class == SensorStateClass.MEASUREMENT
+
+    def test_device_class_is_none(self):
+        entity = self._make({})
+        assert entity.device_class is None
 
 
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Closes the v1.7 roadmap item "Sensor device_class / state_class decision". `SensorStateClass.MEASUREMENT` was already set on both count sensor classes (`UniFiCategoryCountSensor` and `UniFiRollupCountSensor`); this PR confirms that decision with an explanatory comment and locks it in with tests so a future contributor does not silently regress it.
- No `SensorDeviceClass` is set: none of HA's built-ins map cleanly to "alert count" (it's not a temperature, humidity, power, or any other physical quantity). The comment above each `_attr_state_class` documents this rationale.
- Removes the item from `docs/ROADMAP.md` (v1.7.0 Architecture) and `docs/TODO.md` (Type safety / tech debt) so the open-work list reflects the closed decision.

## Test plan

- [x] `make check` passes (453 tests, 4 new assertions added across the two count sensors)
- [x] `tests/unit/test_entities.py::TestUniFiCategoryCountSensor` gains `test_state_class_is_measurement` and `test_device_class_is_none`
- [x] `tests/unit/test_entities.py::TestUniFiRollupCountSensor` gains the same pair
- [x] Merge resolution against `dev` (after #94, #95, #96 landed): only CHANGELOG `[Unreleased]` needed reconciling; bullet appended to the existing `### Internal` section rather than creating a duplicate header

https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH

---
_Generated by [Claude Code](https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH)_