### PR TITLE
refactor: introduce UniFiClientConfig TypedDict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Split `tests/unit/test_config_flow.py` (1565 lines) into `tests/unit/config_flow/` package with separate files per flow type to reduce rebase conflicts.
 - Confirmed `SensorStateClass.MEASUREMENT` on open-count and rollup-count sensors; no `SensorDeviceClass` is set (none of the HA built-ins fit an alert counter).
 - Improved code comments on webhook dedup, polling-vs-webhook alert_count invariant, acknowledgement watermark, and system-log probe. Clarified webhook body decode-failure log message.
+- Introduced `UniFiClientConfig` TypedDict in `models.py` to replace `dict[str, Any]` config dicts passed to `UniFiClient`, `UniFiAlertsCoordinator`, and `WebhookManager`. Pure refactor; no behaviour change. Prerequisite for flipping `mypy strict = true`.
 
 ## [1.6.0] - 2026-05-11
 

--- a/custom_components/unifi_alerts/__init__.py
+++ b/custom_components/unifi_alerts/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import secrets
+from typing import cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -20,7 +21,7 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import UniFiAlertsCoordinator
-from .models import RuntimeData
+from .models import RuntimeData, UniFiClientConfig
 from .services import async_register_services, async_unregister_services
 from .unifi_client import InvalidAuthError, UniFiClient
 from .webhook_handler import WebhookManager
@@ -75,7 +76,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data.get("controller_url", "unknown"),
         )
     session = async_get_clientsession(hass, verify_ssl=verify_ssl)
-    client = UniFiClient(session, entry.data["controller_url"], dict(entry.data))
+    # HA's ConfigEntry.data is Mapping[str, Any]; cast at the boundary so
+    # internal call sites are typed via UniFiClientConfig.
+    client = UniFiClient(
+        session,
+        entry.data["controller_url"],
+        cast(UniFiClientConfig, dict(entry.data)),
+    )
 
     try:
         await client.authenticate()
@@ -104,7 +111,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     coordinator = UniFiAlertsCoordinator(
-        hass, client, dict(entry.data) | dict(entry.options), entry.entry_id
+        hass,
+        client,
+        cast(UniFiClientConfig, dict(entry.data) | dict(entry.options)),
+        entry.entry_id,
     )
 
     # Restore persisted acknowledgement watermarks before first poll so that
@@ -121,7 +131,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     webhook_manager = WebhookManager(
         hass,
         entry.entry_id,
-        dict(entry.data) | dict(entry.options),
+        cast(UniFiClientConfig, dict(entry.data) | dict(entry.options)),
         coordinator.push_alert,
     )
     webhook_urls = webhook_manager.register_all()

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import secrets
-from typing import Any
+from typing import Any, cast
 
 import voluptuous as vol
 from homeassistant.components.webhook import async_generate_url
@@ -38,6 +38,7 @@ from .const import (
     DOMAIN,
     webhook_id_for_category,
 )
+from .models import UniFiClientConfig
 from .unifi_client import CannotConnectError, InvalidAuthError, UniFiClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -82,7 +83,7 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                     self.hass,
                     verify_ssl=user_input.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
                 )
-                client = UniFiClient(session, url, user_input)
+                client = UniFiClient(session, url, cast(UniFiClientConfig, user_input))
                 try:
                     auth_method = await client.authenticate()
                     await client.fetch_alarms()  # validate alarm endpoint reachable
@@ -245,7 +246,7 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.hass,
                 verify_ssl=entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
             )
-            client = UniFiClient(session, url, user_input)
+            client = UniFiClient(session, url, cast(UniFiClientConfig, user_input))
             try:
                 auth_method = await client.authenticate()
             except InvalidAuthError:
@@ -377,7 +378,7 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
                     test_data[CONF_API_KEY] = new_api_key
 
                 session = async_get_clientsession(self.hass, verify_ssl=new_verify_ssl)
-                client = UniFiClient(session, effective_url, test_data)
+                client = UniFiClient(session, effective_url, cast(UniFiClientConfig, test_data))
                 try:
                     auth_method = await client.authenticate()
                     await client.fetch_alarms()

--- a/custom_components/unifi_alerts/const.py
+++ b/custom_components/unifi_alerts/const.py
@@ -2,24 +2,29 @@
 
 from __future__ import annotations
 
+from typing import Final
+
 DOMAIN = "unifi_alerts"
 
 # ──────────────────────────────────────────────
 # Config entry keys
 # ──────────────────────────────────────────────
-CONF_CONTROLLER_URL = "controller_url"
-CONF_USERNAME = "username"
-CONF_PASSWORD = "password"
-CONF_API_KEY = "api_key"
-CONF_AUTH_METHOD = "auth_method"
-CONF_POLL_INTERVAL = "poll_interval"
-CONF_CLEAR_TIMEOUT = "clear_timeout"
-CONF_ENABLED_CATEGORIES = "enabled_categories"
-CONF_VERIFY_SSL = "verify_ssl"
-CONF_WEBHOOK_SECRET = "webhook_secret"
-CONF_WEBHOOK_ID_SUFFIX = "webhook_id_suffix"
-CONF_REGENERATE_WEBHOOK_SECRET = "regenerate_webhook_secret"
-CONF_SITE = "site"
+# Typed as Final so mypy resolves them to literal types when used as
+# UniFiClientConfig TypedDict keys; without this, `.get(key, default)`
+# returns `object` instead of the field's declared type.
+CONF_CONTROLLER_URL: Final = "controller_url"
+CONF_USERNAME: Final = "username"
+CONF_PASSWORD: Final = "password"
+CONF_API_KEY: Final = "api_key"
+CONF_AUTH_METHOD: Final = "auth_method"
+CONF_POLL_INTERVAL: Final = "poll_interval"
+CONF_CLEAR_TIMEOUT: Final = "clear_timeout"
+CONF_ENABLED_CATEGORIES: Final = "enabled_categories"
+CONF_VERIFY_SSL: Final = "verify_ssl"
+CONF_WEBHOOK_SECRET: Final = "webhook_secret"
+CONF_WEBHOOK_ID_SUFFIX: Final = "webhook_id_suffix"
+CONF_REGENERATE_WEBHOOK_SECRET: Final = "regenerate_webhook_secret"
+CONF_SITE: Final = "site"
 
 AUTH_METHOD_USERPASS = "userpass"
 AUTH_METHOD_APIKEY = "apikey"

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -6,7 +6,6 @@ import asyncio
 import logging
 import time
 from datetime import datetime, timedelta
-from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -25,7 +24,7 @@ from .const import (
     DOMAIN,
     WEBHOOK_DEDUP_WINDOW_SECONDS,
 )
-from .models import CategoryState, UniFiAlert
+from .models import CategoryState, UniFiAlert, UniFiClientConfig
 from .unifi_client import CannotConnectError, InvalidAuthError, UniFiClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -49,7 +48,7 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         self,
         hass: HomeAssistant,
         client: UniFiClient,
-        config: dict[str, Any],
+        config: UniFiClientConfig,
         entry_id: str = "",
     ) -> None:
         poll_interval = config.get(CONF_POLL_INTERVAL, DEFAULT_POLL_INTERVAL)
@@ -60,7 +59,7 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
             update_interval=timedelta(seconds=poll_interval),
         )
         self._client = client
-        self._config = config
+        self._config: UniFiClientConfig = config
         self._clear_timeout_minutes: int = config.get(CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT)
         self._enabled_categories: list[str] = config.get(CONF_ENABLED_CATEGORIES, ALL_CATEGORIES)
         self._site: str = config.get(CONF_SITE, DEFAULT_SITE)

--- a/custom_components/unifi_alerts/models.py
+++ b/custom_components/unifi_alerts/models.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,6 +18,31 @@ _unknown_system_log_keys: set[str] = set()
 if TYPE_CHECKING:
     from .coordinator import UniFiAlertsCoordinator
     from .unifi_client import UniFiClient
+
+
+class UniFiClientConfig(TypedDict, total=False):
+    """Shape of the dict passed to UniFiClient, UniFiAlertsCoordinator, and WebhookManager.
+
+    total=False because legacy entries and credential subsets may omit fields;
+    call sites use .get(key, default) for optional fields.
+
+    auth_method is typed as str (not Literal["userpass", "apikey"]) because the
+    value originates from user input and is validated in unifi_client.authenticate();
+    constraining the type here would force casts at the validation boundary.
+    """
+
+    controller_url: str
+    username: str
+    password: str
+    api_key: str
+    auth_method: str
+    verify_ssl: bool
+    webhook_secret: str
+    webhook_id_suffix: str
+    enabled_categories: list[str]
+    poll_interval: int
+    clear_timeout: int
+    site: str
 
 
 def _render_message_raw(message_raw: str, parameters: dict) -> str:

--- a/custom_components/unifi_alerts/unifi_client.py
+++ b/custom_components/unifi_alerts/unifi_client.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime, timedelta
-from typing import Any
 
 import aiohttp
 
@@ -22,7 +21,7 @@ from .const import (
     SYSTEM_LOG_PAGE_SIZE,
     UNIFI_KEY_TO_CATEGORY,
 )
-from .models import UniFiAlert
+from .models import UniFiAlert, UniFiClientConfig
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,11 +61,11 @@ class UniFiClient:
         self,
         session: aiohttp.ClientSession,
         controller_url: str,
-        config: dict[str, Any],
+        config: UniFiClientConfig,
     ) -> None:
         self._session = session
         self._base = controller_url.rstrip("/")
-        self._config = config
+        self._config: UniFiClientConfig = config
         self._auth_method: str | None = None
         self._authenticated: bool = False
         # None = not yet probed. authenticate() detects v2 system-log availability

--- a/custom_components/unifi_alerts/webhook_handler.py
+++ b/custom_components/unifi_alerts/webhook_handler.py
@@ -25,7 +25,7 @@ from .const import (
     WEBHOOK_MAX_BODY_BYTES,
     webhook_id_for_category,
 )
-from .models import UniFiAlert
+from .models import UniFiAlert, UniFiClientConfig
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,12 +47,12 @@ class WebhookManager:
         self,
         hass: HomeAssistant,
         entry_id: str,
-        config: dict,
+        config: UniFiClientConfig,
         push_callback: Callable[[str, UniFiAlert], None],
     ) -> None:
         self._hass = hass
         self._entry_id = entry_id
-        self._config = config
+        self._config: UniFiClientConfig = config
         self._push_callback = push_callback
         self._registered: list[str] = []
 


### PR DESCRIPTION
## Summary

Implements **ARCH-1** from the v1.7 release plan: replaces every `config: dict[str, Any]` parameter and `self._config: dict[str, Any]` storage in the integration with a `UniFiClientConfig` TypedDict defined in `models.py`. Pure refactor; runtime behaviour unchanged.

Prerequisite for **CI-1** (flipping `mypy strict = true`).

## What changed

- **`models.py`** - new `UniFiClientConfig(TypedDict, total=False)` with the 12 keys actually consumed by `UniFiClient` / `UniFiAlertsCoordinator` / `WebhookManager`. `total=False` because credential-only subsets (reauth flow) and legacy entries may omit fields; every read site already uses `.get(key, default)`.
- **`const.py`** - added `Final` annotations to the 13 `CONF_*` config-entry keys. Required so mypy resolves them to literal types when used as TypedDict keys; without this, `config.get(CONF_VERIFY_SSL, default)` returns `object` instead of `bool` at every call site. Contained to `const.py`; no runtime effect.
- **`unifi_client.py`, `coordinator.py`, `webhook_handler.py`** - constructor signatures and `self._config` storage now typed `UniFiClientConfig`.
- **`__init__.py`** (3 sites) and **`config_flow.py`** (3 sites) - `cast(UniFiClientConfig, ...)` at the HA-`ConfigEntry` boundary where the source is `Mapping[str, Any]` (entry.data, entry.options, dict-unpacking patterns with conditional `__setitem__`).
- No test fixture changes needed - `total=False` accepts the existing partial mock dicts.

## Verification

```
make check  # lint + format + mypy + HACS validate + translation drift + 453 tests
```

All green locally. CI will confirm on push.

## Scope discipline

- No behavioural change. No removed features. No new dependencies.
- `pyproject.toml` `mypy strict` flag is **not** touched here - that's CI-1's job.
- `Final` annotations limited to the 13 `CONF_*` config-entry keys; other constants in `const.py` (`DEFAULT_*`, `AUTH_METHOD_*`, `CATEGORY_*`) left alone since they don't need literal narrowing for `UniFiClientConfig`.

## Test plan

- [x] `make check` passes locally (453 tests, mypy non-strict still clean)
- [ ] CI passes on push
- [ ] Spot-check one config-flow walkthrough in a local HA dev instance after merge (optional; pure-refactor, but the cast sites cross the user-facing boundary)

https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH

---
_Generated by [Claude Code](https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH)_