### PR TITLE
ci: enable mypy --strict across the integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Confirmed `SensorStateClass.MEASUREMENT` on open-count and rollup-count sensors; no `SensorDeviceClass` is set (none of the HA built-ins fit an alert counter).
 - Improved code comments on webhook dedup, polling-vs-webhook alert_count invariant, acknowledgement watermark, and system-log probe. Clarified webhook body decode-failure log message.
 - Introduced `UniFiClientConfig` TypedDict in `models.py` to replace `dict[str, Any]` config dicts passed to `UniFiClient`, `UniFiAlertsCoordinator`, and `WebhookManager`. Pure refactor; no behaviour change. Prerequisite for flipping `mypy strict = true`.
+- Enabled `mypy --strict` across the integration (`pyproject.toml`). All call sites use the `UniFiClientConfig` TypedDict from ARCH-1; residual fixes were limited to parameterising generic `dict`/`list`/`Store`/`Task` annotations and routing the `DeviceInfo` import through `homeassistant.helpers.device_registry` (its canonical module) so mypy accepts the export.
 
 ## [1.6.0] - 2026-05-11
 

--- a/custom_components/unifi_alerts/binary_sensor.py
+++ b/custom_components/unifi_alerts/binary_sensor.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -77,11 +78,11 @@ class UniFiCategoryBinarySensor(CoordinatorEntity[UniFiAlertsCoordinator], Binar
         return CATEGORY_ICONS_OK[self._category]
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         state: CategoryState | None = self.coordinator.get_category_state(self._category)
         if not state:
             return {}
-        attrs: dict = {
+        attrs: dict[str, Any] = {
             "category": self._category,
             "alert_count": state.alert_count,
             "open_count": state.open_count,
@@ -122,9 +123,9 @@ class UniFiRollupBinarySensor(CoordinatorEntity[UniFiAlertsCoordinator], BinaryS
         return "mdi:shield-alert" if self.is_on else "mdi:shield-check"
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         last = self.coordinator.rollup_last_alert
-        attrs: dict = {
+        attrs: dict[str, Any] = {
             "total_alert_count": self.coordinator.rollup_alert_count,
             "total_open_count": self.coordinator.rollup_open_count,
         }

--- a/custom_components/unifi_alerts/button.py
+++ b/custom_components/unifi_alerts/button.py
@@ -6,8 +6,7 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -173,7 +173,7 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                 return await self.async_step_finish()
 
         # Build a schema with one boolean per category
-        fields: dict = {}
+        fields: dict[Any, Any] = {}
         # Default noisy client/device categories to OFF; exceptional events ON
         _chatty = {"network_device", "network_client"}
         for cat in ALL_CATEGORIES:
@@ -206,7 +206,7 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
         enabled: list[str] = self._entry_data.get(CONF_ENABLED_CATEGORIES, ALL_CATEGORIES)
         secret: str = self._entry_data.get(CONF_WEBHOOK_SECRET, "")
         suffix: str = self._entry_data.get(CONF_WEBHOOK_ID_SUFFIX, "")
-        fields: dict = {}
+        fields: dict[Any, Any] = {}
         for cat in ALL_CATEGORIES:
             if cat in enabled:
                 url = (
@@ -479,7 +479,7 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
             self._config_entry.data.get(CONF_SITE, DEFAULT_SITE),
         )
 
-        fields: dict = {}
+        fields: dict[Any, Any] = {}
         for cat in ALL_CATEGORIES:
             fields[vol.Optional(f"cat_{cat}", default=(cat in current_enabled))] = bool
         fields[vol.Optional(CONF_POLL_INTERVAL, default=current_poll)] = vol.All(
@@ -517,7 +517,7 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
             self._config_entry.data.get(CONF_WEBHOOK_SECRET, ""),
         )
         suffix: str = self._config_entry.data.get(CONF_WEBHOOK_ID_SUFFIX, "")
-        fields: dict = {}
+        fields: dict[Any, Any] = {}
         for cat in ALL_CATEGORIES:
             if cat in enabled:
                 url = (

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import time
 from datetime import datetime, timedelta
+from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -63,7 +64,9 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         self._clear_timeout_minutes: int = config.get(CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT)
         self._enabled_categories: list[str] = config.get(CONF_ENABLED_CATEGORIES, ALL_CATEGORIES)
         self._site: str = config.get(CONF_SITE, DEFAULT_SITE)
-        self._store: Store = Store(hass, _STORAGE_VERSION, f"{DOMAIN}_watermarks_{entry_id}")
+        self._store: Store[dict[str, Any]] = Store(
+            hass, _STORAGE_VERSION, f"{DOMAIN}_watermarks_{entry_id}"
+        )
 
         # Category state is long-lived; do NOT reset between coordinator refreshes
         self._category_states: dict[str, CategoryState] = {
@@ -72,7 +75,7 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         }
 
         # Tracks pending auto-clear tasks keyed by category
-        self._clear_tasks: dict[str, asyncio.Task] = {}
+        self._clear_tasks: dict[str, asyncio.Task[None]] = {}
 
         # Per-(category, alert_key) monotonic timestamps of the last webhook
         # push that was actually applied. Subsequent pushes for the same pair
@@ -313,7 +316,7 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         branch runs when the stored value is a dict; the string branch handles
         the old format so existing installs are not disrupted.
         """
-        data: dict | None = await self._store.async_load()
+        data: dict[str, Any] | None = await self._store.async_load()
         if not data:
             return
         for cat, entry in data.items():
@@ -343,9 +346,9 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
 
     async def _async_persist_watermarks(self) -> None:
         """Persist current category state (watermark, alert_count, last_alert) to storage."""
-        data: dict[str, dict] = {}
+        data: dict[str, dict[str, Any]] = {}
         for cat, state in self._category_states.items():
-            entry: dict = {}
+            entry: dict[str, Any] = {}
             if state.last_cleared_at is not None:
                 entry["last_cleared_at"] = state.last_cleared_at.isoformat()
             entry["alert_count"] = state.alert_count

--- a/custom_components/unifi_alerts/event.py
+++ b/custom_components/unifi_alerts/event.py
@@ -9,8 +9,7 @@ from __future__ import annotations
 from homeassistant.components.event import EventEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 

--- a/custom_components/unifi_alerts/models.py
+++ b/custom_components/unifi_alerts/models.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ class UniFiClientConfig(TypedDict, total=False):
     site: str
 
 
-def _render_message_raw(message_raw: str, parameters: dict) -> str:
+def _render_message_raw(message_raw: str, parameters: dict[str, Any]) -> str:
     """Substitute {KEY} placeholders in message_raw with values from parameters.
 
     The v2 system-log schema uses a template string (message_raw) with
@@ -73,7 +73,7 @@ class UniFiAlert:
     category: str
     message: str
     received_at: datetime
-    raw: dict = field(default_factory=dict)
+    raw: dict[str, Any] = field(default_factory=dict)
 
     # Optional enrichment fields parsed from the UniFi payload
     key: str = ""
@@ -82,7 +82,7 @@ class UniFiAlert:
     severity: str = ""
 
     @classmethod
-    def from_webhook_payload(cls, category: str, payload: dict) -> UniFiAlert:
+    def from_webhook_payload(cls, category: str, payload: dict[str, Any]) -> UniFiAlert:
         """Build an alert from a raw UniFi Alarm Manager webhook POST body."""
         message = (
             payload.get("message")
@@ -106,7 +106,7 @@ class UniFiAlert:
         )
 
     @classmethod
-    def from_api_alarm(cls, category: str, alarm: dict) -> UniFiAlert:
+    def from_api_alarm(cls, category: str, alarm: dict[str, Any]) -> UniFiAlert:
         """Build an alert from a polled UniFi controller alarm record."""
         message = alarm.get("msg") or alarm.get("message") or alarm.get("key") or "Unknown alert"
         # UniFi returns timestamps as epoch milliseconds (v2 system-log always; legacy
@@ -138,7 +138,7 @@ class UniFiAlert:
         )
 
     @classmethod
-    def from_system_log_event(cls, payload: dict) -> UniFiAlert:
+    def from_system_log_event(cls, payload: dict[str, Any]) -> UniFiAlert:
         """Build an alert from a v2 system-log/all event record.
 
         The v2 schema differs substantially from the legacy /list/alarm format:
@@ -207,14 +207,14 @@ class UniFiAlert:
             severity=payload.get("severity") or "",
         )
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Serialise this alert to a JSON-safe dict for Store persistence."""
         d = asdict(self)
         d["received_at"] = self.received_at.isoformat()
         return d
 
     @classmethod
-    def from_dict(cls, data: dict) -> UniFiAlert:
+    def from_dict(cls, data: dict[str, Any]) -> UniFiAlert:
         """Deserialise an alert previously written by ``to_dict``."""
         received_at_raw = data.get("received_at", "")
         try:

--- a/custom_components/unifi_alerts/sensor.py
+++ b/custom_components/unifi_alerts/sensor.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceEntryType
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -78,7 +79,7 @@ class UniFiCategoryMessageSensor(CoordinatorEntity[UniFiAlertsCoordinator], Sens
         return CATEGORY_ICONS_OK[self._category]
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         state: CategoryState | None = self.coordinator.get_category_state(self._category)
         if not state or not state.last_alert:
             return {}
@@ -147,9 +148,9 @@ class UniFiRollupCountSensor(CoordinatorEntity[UniFiAlertsCoordinator], SensorEn
         return self.coordinator.rollup_open_count
 
     @property
-    def extra_state_attributes(self) -> dict:
+    def extra_state_attributes(self) -> dict[str, Any]:
         last = self.coordinator.rollup_last_alert
-        attrs: dict = {"total_webhook_count": self.coordinator.rollup_alert_count}
+        attrs: dict[str, Any] = {"total_webhook_count": self.coordinator.rollup_alert_count}
         if last:
             attrs["last_message"] = last.message
             attrs["last_category"] = last.category

--- a/custom_components/unifi_alerts/services.py
+++ b/custom_components/unifi_alerts/services.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
+from typing import TYPE_CHECKING
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntryState
@@ -10,6 +12,9 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 
 from .const import ALL_CATEGORIES, DOMAIN
+
+if TYPE_CHECKING:
+    from .coordinator import UniFiAlertsCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,7 +38,9 @@ CLEAR_ALL_SCHEMA = vol.Schema(
 )
 
 
-def _get_coordinators(hass: HomeAssistant, entry_id: str | None):
+def _get_coordinators(
+    hass: HomeAssistant, entry_id: str | None
+) -> Iterator[UniFiAlertsCoordinator]:
     """Yield coordinator(s) from loaded entries, optionally filtered by entry_id."""
     if entry_id is not None:
         entry = hass.config_entries.async_get_entry(entry_id)

--- a/custom_components/unifi_alerts/unifi_client.py
+++ b/custom_components/unifi_alerts/unifi_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import aiohttp
 
@@ -97,7 +98,7 @@ class UniFiClient:
         _LOGGER.debug("Authenticated via username/password")
         return AUTH_METHOD_USERPASS
 
-    async def fetch_alarms(self, site: str = "default") -> list[dict]:
+    async def fetch_alarms(self, site: str = "default") -> list[dict[str, Any]]:
         """Return all unarchived alarms from the controller."""
         if not self._authenticated:
             await self.authenticate()
@@ -124,7 +125,7 @@ class UniFiClient:
             f"Could not find the alarm endpoint for site '{site}'. Tried: {', '.join(alarm_paths)}"
         )
 
-    async def _try_fetch_alarms(self, url: str, site: str) -> list[dict] | None:
+    async def _try_fetch_alarms(self, url: str, site: str) -> list[dict[str, Any]] | None:
         """Fetch alarms from one URL. Returns None on 404 (caller tries next URL)."""
         _LOGGER.debug("Fetching alarms from %s", url)
         try:
@@ -236,7 +237,7 @@ class UniFiClient:
         self,
         site: str = "default",
         since: datetime | None = None,
-    ) -> list[dict]:
+    ) -> list[dict[str, Any]]:
         """Fetch alarms from the v2 system-log/all endpoint with pagination.
 
         Uses timestampFrom = since (or now - DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS
@@ -260,7 +261,7 @@ class UniFiClient:
         timestamp_to = int(now.timestamp() * 1000)
 
         url = f"{self._base}{UNIFI_OS_NETWORK_PREFIX}/v2/api/site/{site}/system-log/all"
-        results: list[dict] = []
+        results: list[dict[str, Any]] = []
 
         for page in range(MAX_SYSTEM_LOG_PAGES):
             body = {
@@ -292,7 +293,7 @@ class UniFiClient:
             except aiohttp.ClientError as err:
                 raise CannotConnectError(type(err).__name__) from err
 
-            page_data: list[dict] = data.get("data") or []
+            page_data: list[dict[str, Any]] = data.get("data") or []
             # Filter to open/unacknowledged events only (status="NEW")
             new_events = [e for e in page_data if e.get("status") == "NEW"]
             results.extend(new_events)
@@ -412,7 +413,7 @@ class UniFiClient:
         return headers
 
     @staticmethod
-    def _classify(alarm: dict) -> str | None:
+    def _classify(alarm: dict[str, Any]) -> str | None:
         """Map a raw alarm dict to a category string, or None if unrecognised."""
         key = alarm.get("key", "")
         for prefix, category in UNIFI_KEY_TO_CATEGORY.items():

--- a/custom_components/unifi_alerts/webhook_handler.py
+++ b/custom_components/unifi_alerts/webhook_handler.py
@@ -6,7 +6,7 @@ import contextlib
 import hmac
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 from aiohttp.web import Request, Response
 from homeassistant.components.webhook import (
@@ -106,7 +106,9 @@ class WebhookManager:
                 async_unregister(self._hass, webhook_id)
         self._registered.clear()
 
-    def _make_handler(self, category: str, secret: str):
+    def _make_handler(
+        self, category: str, secret: str
+    ) -> Callable[[HomeAssistant, str, Request], Awaitable[Response | None]]:
         """Return an async webhook handler bound to a specific category."""
 
         async def handle_webhook(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,6 @@ ignore = ["E501"]
 
 [tool.mypy]
 python_version = "3.12"
-strict = false
+strict = true
 ignore_missing_imports = true
 warn_unused_ignores = true


### PR DESCRIPTION
## Summary

Implements **CI-1** from the v1.7 release plan: flips `[tool.mypy] strict = true` in `pyproject.toml` and resolves every issue mypy surfaces with real type fixes (no `# type: ignore` lines added).

Builds on **ARCH-1** (#100), which removed the largest `dict[str, Any]` surface. This is the last code-change PR before the v1.7.0-pre tag.

## What changed

| File | Reason |
|---|---|
| `pyproject.toml` | `strict = false` -> `strict = true` |
| `models.py` | Parameterised `dict` / `dict[str, Any]` on `UniFiAlert` factories, `_render_message_raw`, `to_dict` / `from_dict` (7 sites) |
| `unifi_client.py` | Parameterised `list[dict]` / `dict` on `fetch_alarms`, `_try_fetch_alarms`, `fetch_system_log_alarms`, `_classify` (6 sites) |
| `coordinator.py` | Parameterised `Store[dict[str, Any]]`, `asyncio.Task[None]`, plus the watermark persist / restore dicts |
| `services.py` | Annotated `_get_coordinators` as `Iterator[UniFiAlertsCoordinator]` (TYPE_CHECKING import to dodge the circular reference) |
| `webhook_handler.py` | Annotated `_make_handler` return as `Callable[[HomeAssistant, str, Request], Awaitable[Response \| None]]` |
| `sensor.py`, `event.py`, `button.py`, `binary_sensor.py` | Moved `DeviceInfo` import from `homeassistant.helpers.entity` (re-export, no `__all__`) to `homeassistant.helpers.device_registry` (its canonical module). Also parameterised the `extra_state_attributes` and rollup dict annotations. |
| `config_flow.py` | Widened 4 `fields: dict = {}` schema dicts to `dict[Any, Any]` |
| `CHANGELOG.md` | One Internal bullet |

**Total `# type: ignore` lines added: 0.** Every issue was fixed by a real type annotation or import re-routing.

## Verification

```
make check  # lint + format + mypy --strict + HACS validate + translation drift + tests
```

All green locally; **453 tests pass** (no change in count). CI will confirm on push.

## Scope discipline

- No behavioural change. No removed features. No widened public APIs.
- No `# type: ignore` shortcuts.
- `mypy` scope unchanged: still `custom_components/unifi_alerts` only (`tests/` was never in the mypy target per `pyproject.toml` and the Makefile, so no test annotations were needed).
- The `DeviceInfo` import path change is the only "interesting" edit. `homeassistant.helpers.entity` re-exports `DeviceInfo` from `device_registry`, but the re-export has no `__all__`, so mypy --strict won't follow it. The new path is what HA core itself uses internally.

## Test plan

- [x] `make check` passes locally under mypy --strict (453 tests)
- [ ] CI passes on push (mypy --strict in the lint job)
- [ ] Spot-check: load the integration on a local HA dev instance after merge (optional; this is a type-only change but the import path move crosses the entity boundary)

https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH

---
_Generated by [Claude Code](https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH)_