### PR TITLE
chore: bump manifest to 1.7.0-pre1, write v1.7.0-pre1 HISTORY block

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": [],
-  "version": "1.6.0"
+  "version": "1.7.0-pre1"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -2,6 +2,18 @@
 
 Dated record of completed work. Newest first. Format per entry: category, short description, PR or commit reference, short why.
 
+## 2026-05-15
+
+- **release**: v1.7.0-pre1 tagged. Ships the v1.7.0 documentation + architecture scope: fail-closed webhook auth with schema v3 migration that backfills missing secrets on legacy entries (SEC-1), `UniFiClientConfig` TypedDict that closed the largest `dict[str, Any]` surface and unblocked `mypy --strict` (ARCH-1), `strict = true` flipped with zero `# type: ignore` debt (CI-1), `tests/unit/config_flow/` package split (ARCH-3), `SensorStateClass.MEASUREMENT` confirmed on count sensors (ARCH-4), end-to-end documentation accuracy pass (DOC-A), new troubleshooting / privacy / tested-controllers / uninstall sections (DOC-B), WHY comments on dedup / watermark / system-log probe (QUAL-1), and a README + info.md restructure that dropped README from 331 to 186 lines.
+- **security**: fail-closed webhook auth and schema v3 migration that backfills `webhook_secret` / `webhook_id_suffix` on legacy entries ([#94]). Webhook handler now returns HTTP 500 when no bearer secret is configured (previously accepting); migration generates a fresh secret and suffix only when missing or empty, leaving correctly-configured entries untouched.
+- **docs**: reconcile documentation against current code (DOC-A) ([#95]). 35 verified drift points across REPO_LAYOUT test paths, HOMEASSISTANT button row, info.md HA baseline (2024.5 not 2026.1.0), DEVELOPING HISTORY guidance, TESTING conftest tree.
+- **tests**: split `tests/unit/test_config_flow.py` (1565 lines) into `tests/unit/config_flow/` package (ARCH-3) ([#96]). Four files (`test_setup`, `test_options`, `test_reauth`, plus shared `conftest`); same test count, smaller rebase blast radius.
+- **feat**: confirm `SensorStateClass.MEASUREMENT` on open-count and rollup-count sensors (ARCH-4) ([#97]). No `SensorDeviceClass` is set (none of HA's built-ins fit an alert counter); comment added so a future reader does not re-open the question.
+- **docs**: v1.7 user docs (DOC-B) and WHY comments (QUAL-1) ([#98]). Troubleshooting / privacy / tested-controllers / uninstall sections in README; `info.md` local-network warning; setup-flow finish step copy stresses copying webhook URLs before Submit. Code-side WHY comments cover the webhook 5s dedup window, polling-vs-webhook `alert_count` invariant, acknowledgement watermark, and system-log probe.
+- **docs**: restructure README and info.md, dedupe content, move examples to `docs/EXAMPLES.md` ([#99]). Standard flow (Features > Requirements > Installation > Setup > Entities > Privacy > Uninstall > Support > Contributing); merged the two duplicate "tested consoles" tables; README dropped from 331 to 186 lines with no content cut.
+- **chore**: introduce `UniFiClientConfig` TypedDict for the client / coordinator / webhook config dict (ARCH-1) ([#100]). Replaces `dict[str, Any]` parameters and storage; `cast()` at the HA `ConfigEntry` boundary; `Final` annotations on the 13 `CONF_*` keys so mypy resolves them as literal types. Prerequisite for CI-1.
+- **ci**: enable `mypy --strict` across the integration (CI-1) ([#101]). Fixed every issue with real type annotations and one import-path move (`DeviceInfo` from `helpers.device_registry` instead of the unmarked re-export on `helpers.entity`); zero `# type: ignore` lines added.
+
 ## 2026-05-11
 
 - **release**: v1.6.0 tagged. Ships the v1.6.0 reliability scope: v2 `system-log/all` polling switch with capability probe and legacy fallback (closes the ~3000-record cap on `/list/alarm` that left `open_count` stuck at 0 on busy controllers), persistent `alert_count` and `last_alert` across config-entry reloads, button-availability gating that respects category-enabled state, and the epoch-ms timestamp parser fix the v2 path depends on. Live-validated against a UCG-Ultra running Network 10.3.58 via the v1.6.0-pre2 canary before promotion; no functional changes between pre2 and stable.
@@ -209,6 +221,14 @@ Dated record of completed work. Newest first. Format per entry: category, short 
 [#88]: https://github.com/PHeonix25/unifi_alerts/pull/88
 [#89]: https://github.com/PHeonix25/unifi_alerts/pull/89
 [#90]: https://github.com/PHeonix25/unifi_alerts/pull/90
+[#94]: https://github.com/PHeonix25/unifi_alerts/pull/94
+[#95]: https://github.com/PHeonix25/unifi_alerts/pull/95
+[#96]: https://github.com/PHeonix25/unifi_alerts/pull/96
+[#97]: https://github.com/PHeonix25/unifi_alerts/pull/97
+[#98]: https://github.com/PHeonix25/unifi_alerts/pull/98
+[#99]: https://github.com/PHeonix25/unifi_alerts/pull/99
+[#100]: https://github.com/PHeonix25/unifi_alerts/pull/100
+[#101]: https://github.com/PHeonix25/unifi_alerts/pull/101
 
 [0d951b3]: https://github.com/PHeonix25/unifi_alerts/commit/0d951b3
 [0f17afb]: https://github.com/PHeonix25/unifi_alerts/commit/0f17afb

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-05-11):** v1.6.0 released; active development on `dev` at the next pre-release cycle. Path to v2.0.0: v1.7.0 (documentation + architecture), v2.0.0 (HACS default).
+> **Status (2026-05-15):** v1.7.0-pre1 cut from `dev`. Stable v1.7.0 promotion remains; `ARCH-2` (translation keys) is the only outstanding v1.7 code item before the stable release PR. Path to v2.0.0: v1.7.0 (documentation + architecture), v2.0.0 (HACS default).
 
 > **Branching model:** see `CLAUDE.md § Branching strategy and versioning`.
 
@@ -14,9 +14,7 @@ Closes the remaining documentation gaps and the largest architecture items.
 
 ### Architecture
 
-- [ ] **`mypy strict = true`**: migrate `UniFiClient.config: dict[str, Any]` to a `TypedDict` or frozen dataclass; bump `pyproject.toml`.
 - [ ] **`has_entity_name = True` + `_attr_translation_key`**: move display strings out of platform files into `strings.json`. Unlocks localisation.
-- [ ] **Split `tests/unit/test_config_flow.py` into a package**: ~1405 lines, four independent classes. Convert to `tests/unit/config_flow/{__init__,conftest,test_setup,test_options,test_reauth}.py`.
 
 ### QA
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -11,10 +11,6 @@ Outstanding work only. Items are removed when they ship; completion lives in `do
 
 - **`SYSTEM_LOG_KEY_TO_CATEGORY` is incomplete** (`const.py`): the v2 system-log key map was seeded from field-confirmed events on Network 10.3.58 (UCG-Ultra) and the documented API schema. Additional keys will surface in the wild; add them as users report unclassified v2 events. Coarse-grained fallback via `SYSTEM_LOG_CATEGORY_FALLBACK` (broad enum) keeps events in roughly the right category until key-level entries are added.
 
-## Type safety / tech debt
-
-- **`mypy strict = false`**: migrate `UniFiClient.config: dict[str, Any]` to a `TypedDict` or frozen dataclass, then bump `pyproject.toml` to `strict = true`.
-
 ## Testing
 
 - **Optional: integration test for full rotation cycle**: options-flow > entry-update > reload > re-register, end-to-end. Each step is unit-tested already.
@@ -22,7 +18,6 @@ Outstanding work only. Items are removed when they ship; completion lives in `do
 ## Architecture
 
 - **Entity naming via `_attr_translation_key`**: all four platform files hard-code `_attr_name = f"{CATEGORY_LABELS[cat]} ..."`. Migrate to `has_entity_name = True` + `_attr_translation_key` so strings live in `strings.json`. Unlocks localisation.
-- **Split `tests/unit/test_config_flow.py` into a package**: ~1405 lines with four logically independent classes; rebase chains across classes produce interleaved conflicts. Convert to `tests/unit/config_flow/{__init__,conftest,test_setup,test_options,test_reauth}.py`.
 
 ## Known issues
 


### PR DESCRIPTION
## Summary

Cuts the **v1.7.0-pre1** checkpoint from `dev`.

- Bumps `custom_components/unifi_alerts/manifest.json` from `1.6.0` to `1.7.0-pre1` via `scripts/bump_version.py --next-cycle`.
- Adds a single `## 2026-05-15` block to `docs/HISTORY.md` covering the 8 PRs merged since `v1.6.0`.
- Drops shipped items from `docs/ROADMAP.md` and `docs/TODO.md`; refreshes the ROADMAP status line.
- `CHANGELOG.md` is **not** touched (per CLAUDE.md, only the stable promotion PR rewrites it).

## PRs included in v1.7.0-pre1

| PR | Item | Theme |
|---|---|---|
| #94 | SEC-1 | fail-closed webhook auth + schema v3 migration |
| #95 | DOC-A | documentation accuracy pass |
| #96 | ARCH-3 | `tests/unit/config_flow/` package split |
| #97 | ARCH-4 | `SensorStateClass.MEASUREMENT` confirmation |
| #98 | DOC-B + QUAL-1 | user docs (troubleshooting, privacy, tested controllers) + WHY comments |
| #99 | (docs cleanup) | README + info.md restructure |
| #100 | ARCH-1 | `UniFiClientConfig` TypedDict |
| #101 | CI-1 | `mypy --strict` |

## Outstanding before v1.7.0 stable

- **ARCH-2** (`arch/translation-keys`): `_attr_translation_key` migration. Needs local HA testing to confirm rendering under the actual HA translation layer.
- The stable promotion PR itself: `scripts/bump_version.py --stable` + a second HISTORY block + `dev > main` merge commit.

## Verification

- [x] `make check` passes (453 tests, `mypy --strict`, HACS validate, translation drift, prose linter)
- [x] `python3 scripts/bump_version.py --next-cycle` produced a clean diff on a `claude/bump-1.7.0-pre1` branch
- [x] `docs/HISTORY.md` h2 format passes `scripts/validate_docs.py`
- [x] Every PR merged since `v1.6.0` has a HISTORY entry (audited: 8 merges, 8 PR bullets + 1 release bullet)
- [ ] After merge: tag locally with `git checkout dev && git pull origin dev && git tag v1.7.0-pre1 && git push origin v1.7.0-pre1`. The `release.yml` workflow will publish the HACS pre-release.

https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH

---
_Generated by [Claude Code](https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH)_