### PR TITLE
ci: moving lint+typecheck to python

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,5 @@
     }
   ],
   "chat.promptFiles": true,
-  "chat.mcp.enabled": true
+  "chat.mcp.access": "all"
 }

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,10 @@ test:
 	$(VENV)/pytest$(EXE) tests/ -v
 
 lint:
-	$(VENV)/ruff$(EXE) check custom_components/ tests/
-	$(VENV)/ruff$(EXE) format --check custom_components/ tests/
+	$(VENV)/python$(EXE) scripts/run_lint.py
 
 typecheck:
-	$(VENV)/mypy$(EXE) custom_components/unifi_alerts --ignore-missing-imports
+	$(VENV)/python$(EXE) scripts/run_typecheck.py
 
 # `validate` and `doc-check` use the system python via $(PY312) wrapper - both
 # scripts are pure stdlib so they don't need the venv at all. Falls back to
@@ -58,5 +57,6 @@ doc-check:
 	$(PY312) scripts/check_translations.py
 
 check: lint typecheck validate test
+	@echo All checks passed.
 
 .DEFAULT_GOAL := help

--- a/scripts/run_lint.py
+++ b/scripts/run_lint.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Run repository lint checks in a single maintainable entry point."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run_step(command: list[str], success_message: str) -> None:
+    """Run a lint command and stop immediately if it fails."""
+    print(f"Running: {' '.join(command)}")
+    subprocess.run(command, check=True)
+    print(success_message)
+
+
+def main() -> int:
+    """Run all lint steps and return the exit code."""
+    try:
+        _run_step(
+            [sys.executable, "-m", "ruff", "check", "custom_components/", "tests/"],
+            "✅ Ruff check passed.",
+        )
+        print("")
+        _run_step(
+            [
+                sys.executable,
+                "-m",
+                "ruff",
+                "format",
+                "--check",
+                "custom_components/",
+                "tests/",
+            ],
+            "✅ Ruff format passed.",
+        )
+    except subprocess.CalledProcessError as error:
+        return error.returncode
+
+    print("")
+    print("✅ All lint checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_typecheck.py
+++ b/scripts/run_typecheck.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Run repository type checks in a single maintainable entry point."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run_step(command: list[str], success_message: str) -> None:
+    """Run a typecheck command and stop immediately if it fails."""
+    print(f"Running: {' '.join(command)}")
+    subprocess.run(command, check=True)
+    print(success_message)
+
+def main() -> int:
+    """Run all typecheck steps and return the exit code."""
+    try:
+        _run_step(
+            [
+                sys.executable,
+                "-m",
+                "mypy",
+                "custom_components/unifi_alerts",
+                "--ignore-missing-imports",
+            ],
+            "✅ MyPy type check passed.",
+        )
+    except subprocess.CalledProcessError as error:
+        return error.returncode
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Simple little PR to move the remaining CI steps to Python scripts (allowing for unicode & x-plat consistency)