### PR TITLE
chore: bump manifest to 1.7.0-pre2, write v1.7.0-pre2 HISTORY block

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": [],
-  "version": "1.7.0-pre1"
+  "version": "1.7.0-pre2"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -2,6 +2,16 @@
 
 Dated record of completed work. Newest first. Format per entry: category, short description, PR or commit reference, short why.
 
+## 2026-05-18
+
+- **release**: v1.7.0-pre2 tagged. Ships ARCH-2 (the last v1.7 code item) plus the off-plan tooling and docs PRs that landed during the pre1 review window. Pre2 is the validation checkpoint for the maintainer's pre1 -> pre2 upgrade test plan on a real HA + UniFi controller; pass criteria are byte-identical entity_id, unique_id, and friendly_name snapshots across the two pre-releases.
+- **feat**: migrate entity names to `_attr_translation_key` + `_attr_translation_placeholders` (ARCH-2) ([#107]). Display strings move from hard-coded `_attr_name = f"{CATEGORY_LABELS[cat]} ..."` formatting to `strings.json` and byte-identical `translations/en.json` under the HA-standard `entity.{platform}.{key}.name` schema; English-rendered names are preserved byte-for-byte, `_attr_unique_id` is untouched. Unlocks localisation without code changes.
+- **docs**: backfill CHANGELOG entries for off-plan PRs and resolve the `[#PR]` placeholder on the SEC-1 bullet to `[#94]` ([#107]). The four off-plan PRs (#103-#106) merged without their own `[Unreleased]` bullets; backfilled now so the v1.7.0 stable promotion PR has a complete starting point.
+- **ci**: move `make lint` and `make typecheck` from inline shell invocations to `scripts/run_lint.py` and `scripts/run_typecheck.py` ([#103]). Same logic now runs identically on Linux, macOS, and Windows without per-platform shims; replaces the `ifeq ($(OS),Windows_NT)` cross-platform branching previously needed in the Makefile.
+- **docs**: rewrite `AGENTS.md` as a self-contained agent context file ([#104]). Adds repo structure map, six-step category-registration walkthrough, and common-pitfalls list so agents that cannot follow cross-file links (web-based tools, third-party AI) get the conventions inline. Also adds a maintenance matrix to `.github/copilot-instructions.md` covering the four common change cascades, a `.github/PULL_REQUEST_TEMPLATE.md`, a `copilot-setup-steps.yml` workflow for one-command Copilot session provisioning, and an "AI Ready" badge to README.
+- **docs**: add six Copilot agent definitions under `.github/agents/` (SE Lead, QE Lead, Security Lead, Responsible AI, Product Manager, Technical Debt Remediation) ([#105]). Unified Identity / Mission / Core Principles / Workflow / Output Format / Anti-Patterns structure across all six, named personas for self-identification in reviews. Also widens `scripts/validate_docs.py` to scan every `*.md` recursively rather than a fixed glob list so new markdown anywhere in the tree inherits the prose rules automatically.
+- **tests**: 232 lines of targeted branch-path unit tests across `test_options.py`, `test_reauth.py`, `test_coordinator.py`, and `test_models.py` ([#106]). Pure coverage uplift; no production-code changes.
+
 ## 2026-05-15
 
 - **release**: v1.7.0-pre1 tagged. Ships the v1.7.0 documentation + architecture scope: fail-closed webhook auth with schema v3 migration that backfills missing secrets on legacy entries (SEC-1), `UniFiClientConfig` TypedDict that closed the largest `dict[str, Any]` surface and unblocked `mypy --strict` (ARCH-1), `strict = true` flipped with zero `# type: ignore` debt (CI-1), `tests/unit/config_flow/` package split (ARCH-3), `SensorStateClass.MEASUREMENT` confirmed on count sensors (ARCH-4), end-to-end documentation accuracy pass (DOC-A), new troubleshooting / privacy / tested-controllers / uninstall sections (DOC-B), WHY comments on dedup / watermark / system-log probe (QUAL-1), and a README + info.md restructure that dropped README from 331 to 186 lines.
@@ -229,6 +239,11 @@ Dated record of completed work. Newest first. Format per entry: category, short 
 [#99]: https://github.com/PHeonix25/unifi_alerts/pull/99
 [#100]: https://github.com/PHeonix25/unifi_alerts/pull/100
 [#101]: https://github.com/PHeonix25/unifi_alerts/pull/101
+[#103]: https://github.com/PHeonix25/unifi_alerts/pull/103
+[#104]: https://github.com/PHeonix25/unifi_alerts/pull/104
+[#105]: https://github.com/PHeonix25/unifi_alerts/pull/105
+[#106]: https://github.com/PHeonix25/unifi_alerts/pull/106
+[#107]: https://github.com/PHeonix25/unifi_alerts/pull/107
 
 [0d951b3]: https://github.com/PHeonix25/unifi_alerts/commit/0d951b3
 [0f17afb]: https://github.com/PHeonix25/unifi_alerts/commit/0f17afb


### PR DESCRIPTION
## Summary

Cuts the **v1.7.0-pre2** checkpoint from `dev`. Pre2 is the validation tag: maintainer installs pre1 on the real HA + UniFi controller, snapshots state, upgrades to pre2, and confirms byte-identical entity behaviour before promoting to v1.7.0 stable.

- Bumps `custom_components/unifi_alerts/manifest.json` from `1.7.0-pre1` to `1.7.0-pre2` via `scripts/bump_version.py --pre`.
- Adds a single `## 2026-05-18` block to `docs/HISTORY.md` covering the 5 PRs merged since `v1.7.0-pre1`.
- `CHANGELOG.md` is **not** touched (per CLAUDE.md, only the stable promotion PR rewrites it).

## PRs included in v1.7.0-pre2

| PR | Theme | What |
|---|---|---|
| #103 | ci | `make lint` / `make typecheck` moved to `scripts/run_lint.py` + `scripts/run_typecheck.py`; cross-platform shims removed from Makefile |
| #104 | docs | AGENTS.md rewrite, maintenance matrix in copilot-instructions, PR template, copilot-setup-steps.yml, AI-Ready badge |
| #105 | docs | Six Copilot agent definitions under `.github/agents/`; widened doc linter to scan all `*.md` recursively |
| #106 | tests | 232 lines of targeted branch-path coverage tests |
| #107 | feat | ARCH-2: entity names migrated to `_attr_translation_key` + populated `strings.json` / `translations/en.json`; CHANGELOG hygiene fixes |

---

## Validation plan for the maintainer

Walk this checklist on your real HA + UniFi controller after CI tags pre2 and HACS picks it up. Phase A is a baseline capture; Phase B is the actual ARCH-2 regression test.

### Phase A: validate `v1.7.0-pre1` (baseline, current state)

**Setup**
- [x] HACS > UniFi Alerts > Versions > install `v1.7.0-pre1`
- [x] **Full HA restart** (not Reload). Verify version on **Settings > Devices & Services > UniFi Alerts > device-info** reads `1.7.0-pre1`

**Config flow + migration (SEC-1)**
- [x] If you have an existing v1 or v2 schema config entry, the HA log on startup should contain an INFO line: `Backfilled webhook secret on legacy entry ...`. New entries skip this.
- [x] Open **Settings > Devices & Services > UniFi Alerts > Configure**. Copy a webhook URL for one category.
- [x] From the UniFi controller (SSH in), run:
  ```bash
  curl -i -X POST '<url>' -H 'Content-Type: application/json' -d '{}'
  ```
  Expect HTTP 200. Then strip the `?token=...` query param and re-run: expect HTTP 401.

**Entities (baseline snapshot for Phase B comparison)**
- [x] **Developer Tools > States > filter `unifi_alerts`** - capture total entity count, full `entity_id` list, friendly-name column. Save as plain text.
- [x] For one entity from each platform (e.g. `binary_sensor.unifi_alerts_network_device_offline_online`, `sensor.unifi_alerts_total_open_alerts`, `event.unifi_alerts_security_threat_ids_detected_event`, `button.unifi_alerts_clear_all_alerts`), expand and note: `friendly_name` attribute value. These are the strings we'll compare against pre2.
- [x] **Settings > Devices & Services > UniFi Alerts > device > each entity > pencil > Advanced** - copy the `unique_id` for the same 4 entities. These must NOT change in Phase B.

**Webhooks (smoke test live alerts)**
- [x] In UniFi Alarm Manager, hit **Test Alarm** on one configured alarm. Confirm the corresponding `binary_sensor.unifi_alerts_<category>` flips to `on`, `sensor.unifi_alerts_<category>_open_count` increments, and the `event.unifi_alerts_<category>_event` updates.
- [x] Hit the matching **Clear** button in HA. Confirm the binary sensor flips back to `off` and `open_count` drops to 0.

**Documentation surface (DOC-A / DOC-B)**
- [x] Open `info.md` view in HACS - top callout reads `Local network only: ...`. Quick setup section is present.
- [x] Visit the README on GitHub - Troubleshooting link goes to `docs/TROUBLESHOOTING.md`; Examples link goes to `docs/EXAMPLES.md`; tested-controllers matrix is present.

---

### Phase B: validate `v1.7.0-pre2` (after ARCH-2 translation-key migration)

**Setup**
- [x] HACS > UniFi Alerts > Versions > install `v1.7.0-pre2`
- [x] **Full HA restart**. Verify version reads `1.7.0-pre2`.

**Critical ARCH-2 invariants**
- [x] **Total entity count unchanged** from Phase A. No missing entities, no new ghost entities.
- [x] **All `entity_id` strings unchanged** from your Phase A snapshot. (If even one differs, this is a regression - ARCH-2 must not change `unique_id`-derived IDs.)
- [x] **All `unique_id` values unchanged** for the 4 entities you captured in Phase A.
- [x] **`friendly_name` values render in English and are byte-identical** to Phase A for the 4 entities. Specifically:
  - `Network: Device offline/online` (or whatever your Phase A binary_sensor friendly name was)
  - `Total Open Alerts`
  - `<Category> — Event`
  - `Clear All Alerts`

  If any of these now shows the literal translation key (e.g. `category_binary`) or a literal `{category}` placeholder, the translation wiring is broken.

**Localisation smoke test (bonus, validates the translation layer is actually being used)**
- [ ] **Settings > System > General > Language** - switch to a non-English language (any will do, e.g. French). Reload the page. UniFi Alerts entity names should remain English (we only ship `en.json`); HA falls back rather than rendering keys. Switch back to English when done. If entities show raw translation keys here, the JSON schema is wrong.

**Regression coverage (re-run all of Phase A)**
- [ ] Repeat the config flow, webhook curl, Test Alarm, and Clear-button checks from Phase A. All should behave identically.

**Automation compatibility**
- [ ] If you have any existing automations that reference UniFi Alerts entities (by `entity_id`, not friendly name), confirm they still trigger. Since `unique_id` and `entity_id` are unchanged, these should be transparent.

---

### Pass criteria

Pre2 passes if and only if every Phase B box is green. Any mismatch in entity_id, unique_id, or friendly_name vs Phase A baseline is a blocker; comment here with the diff and we'll triage before promoting to v1.7.0 stable.

### Rollback

If Phase B fails irrecoverably: HACS > UniFi Alerts > Versions > install `v1.7.0-pre1` > full HA restart. No data loss; only the translation layer changed.

---

## Local verification (before tag)

- [x] `make check` passes (476 tests, mypy --strict, HACS validate, prose linter, translation drift)
- [x] `scripts/bump_version.py --pre` produced a clean diff
- [x] `docs/HISTORY.md` h2 format passes the doc linter
- [x] Every PR merged since `v1.7.0-pre1` has a HISTORY entry (audited: 5 merges, 5 PR bullets + 1 release bullet)
- [x] After merge: tag with `git checkout dev && git pull origin dev && git tag v1.7.0-pre2 && git push origin v1.7.0-pre2`

https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH

---
_Generated by [Claude Code](https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH)_