### PR TITLE
chore: bump manifest to 1.7.0 stable, finalise CHANGELOG and HISTORY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-05-29
+
 ### Security
 
 - Webhook handler now rejects requests with HTTP 500 when no bearer secret is configured, rather than accepting them. Config entries missing `webhook_secret` are backfilled during migration to schema version 3. ([#94])
@@ -166,7 +168,8 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 - UCG-Ultra OS detection: two-stage fallback probe added.
 - Config-flow API-key field guidance reworded to be firmware-version agnostic.
 
-[Unreleased]: https://github.com/PHeonix25/unifi_alerts/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/PHeonix25/unifi_alerts/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.7.0
 [1.6.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.6.0
 [1.5.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.5.0
 [1.4.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.4.0

--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": [],
-  "version": "1.7.0-pre2"
+  "version": "1.7.0"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -2,6 +2,10 @@
 
 Dated record of completed work. Newest first. Format per entry: category, short description, PR or commit reference, short why.
 
+## 2026-05-29
+
+- **release**: v1.7.0 tagged. Promotes v1.7.0-pre2 to stable after on-controller validation confirmed byte-identical entity_id, unique_id, and friendly_name snapshots across the pre1 -> pre2 upgrade (the ARCH-2 translation-key migration regression test). Cycle headline: documentation + architecture. Ships SEC-1 (fail-closed webhook auth with schema v3 migration), ARCH-1 (`UniFiClientConfig` TypedDict), CI-1 (`mypy --strict` enabled), ARCH-2 (entity-name translation keys, unlocking localisation), ARCH-3 (config-flow test package split), ARCH-4 (`SensorStateClass.MEASUREMENT` confirmed on count sensors), DOC-A (35-point documentation accuracy reconciliation), DOC-B (new troubleshooting / privacy / tested-controllers / uninstall sections plus README + info.md restructure), QUAL-1 (WHY comments on dedup / watermark / system-log probe), plus off-plan tooling and docs (`scripts/run_lint.py` / `run_typecheck.py`, AGENTS.md rewrite, Copilot agent definitions, 232 lines of coverage tests). Closes all v1.7.0 ROADMAP items.
+
 ## 2026-05-18
 
 - **release**: v1.7.0-pre2 tagged. Ships ARCH-2 (the last v1.7 code item) plus the off-plan tooling and docs PRs that landed during the pre1 review window. Pre2 is the validation checkpoint for the maintainer's pre1 -> pre2 upgrade test plan on a real HA + UniFi controller; pass criteria are byte-identical entity_id, unique_id, and friendly_name snapshots across the two pre-releases.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,23 +2,9 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-05-15):** v1.7.0-pre1 cut from `dev`. Stable v1.7.0 promotion remains; `ARCH-2` (translation keys) is the only outstanding v1.7 code item before the stable release PR. Path to v2.0.0: v1.7.0 (documentation + architecture), v2.0.0 (HACS default).
+> **Status (2026-05-29):** v1.7.0 released. Path to v2.0.0: v1.8.0 (incremental polish; backlog lives in `docs/TODO.md`), v2.0.0 (HACS default).
 
 > **Branching model:** see `CLAUDE.md § Branching strategy and versioning`.
-
----
-
-## v1.7.0: Documentation + architecture
-
-Closes the remaining documentation gaps and the largest architecture items.
-
-### Architecture
-
-- [ ] **`has_entity_name = True` + `_attr_translation_key`**: move display strings out of platform files into `strings.json`. Unlocks localisation.
-
-### QA
-
-- [ ] **Optional: integration test for full rotation cycle**: options-flow > entry-update > reload > re-register, end-to-end.
 
 ---
 
@@ -26,7 +12,7 @@ Closes the remaining documentation gaps and the largest architecture items.
 
 Prerequisites for submitting to <https://github.com/hacs/default>.
 
-- [ ] All v1.x items above resolved.
+- [ ] All v1.x items in `docs/TODO.md` resolved.
 - [ ] Submit PR to `hacs/default`.
 
 ---
@@ -35,3 +21,4 @@ Prerequisites for submitting to <https://github.com/hacs/default>.
 
 - Extract `_device_info()` duplication into a shared `entity_base.py` mixin (only if maintenance burden grows).
 - Configurable site per category (power-user feature).
+- Optional integration test for the full rotation cycle (options-flow > entry-update > reload > re-register, end-to-end). Each step is unit-tested already; the integration test would catch wiring regressions.


### PR DESCRIPTION
## Summary

Promotes v1.7.0 from pre-release to stable after on-controller validation (PR #108 Phase A / Phase B checklist) confirmed byte-identical entity_id, unique_id, and friendly_name snapshots across the pre1 -> pre2 upgrade.

This is the **`dev` half** of the stable promotion. After this merges, the **`dev -> main`** PR follows using a merge commit (NOT squash; CLAUDE.md hard rule).

## What changed

- `custom_components/unifi_alerts/manifest.json`: `1.7.0-pre2` -> `1.7.0` (via `scripts/bump_version.py --stable`)
- `CHANGELOG.md`: `[Unreleased]` renamed to `[1.7.0] - 2026-05-29`, fresh empty `[Unreleased]` inserted above it, `[1.7.0]` reference link added at the bottom
- `docs/HISTORY.md`: `## 2026-05-29` release block summarising the cycle
- `docs/ROADMAP.md`:
  - v1.7.0 section removed entirely (CLAUDE.md: "once a release ships, drop its section from ROADMAP entirely")
  - Optional rotation-test item moved to `Deferred / low priority` so it does not get lost
  - Status line updated: points at v1.8.0 (TODO-driven, no fixed scope yet) and v2.0.0 (HACS default catalogue)

## v1.7.0 cycle headline

Documentation + architecture. Ships:

| Item | PR |
|---|---|
| SEC-1: fail-closed webhook auth + schema v3 migration | #94 |
| DOC-A: 35-point documentation accuracy reconciliation | #95 |
| ARCH-3: `tests/unit/config_flow/` package split | #96 |
| ARCH-4: `SensorStateClass.MEASUREMENT` confirmed on count sensors | #97 |
| DOC-B + QUAL-1: troubleshooting / privacy / tested-controllers / uninstall sections + WHY comments | #98 |
| README + info.md restructure | #99 |
| ARCH-1: `UniFiClientConfig` TypedDict | #100 |
| CI-1: `mypy --strict` enabled | #101 |
| Off-plan: lint/typecheck Python scripts | #103 |
| Off-plan: AGENTS.md rewrite + AI-readiness config | #104 |
| Off-plan: Copilot agent definitions | #105 |
| Off-plan: 232 lines of coverage tests | #106 |
| ARCH-2: entity-name translation keys (unlocks localisation) | #107 |

13 PRs since v1.6.0; pre1 and pre2 already on HACS pre-release channel and field-validated.

## Test plan

- [x] `make check` passes (476 tests, mypy --strict, HACS validate, prose linter, translation drift)
- [x] `scripts/bump_version.py --stable` ran cleanly; CHANGELOG link references resolved
- [x] On-controller validation passed (Phase A / Phase B in PR #108)
- [ ] After this merges: open `dev -> main` PR with **"Create a merge commit"** (NOT squash). The `main` ruleset enforces merge-commit-only; squash would break the next release cycle's merge base.
- [ ] After `main` PR merges: `git checkout main && git pull origin main && git tag v1.7.0 && git push origin v1.7.0`. `release.yml` will publish the GitHub stable release with auto-grouped notes via `gh release create --generate-notes`.

https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH

---
_Generated by [Claude Code](https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH)_