### PR TITLE
security: scope read-only workflows to permissions: contents: read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, dev]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate with hassfest

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -7,6 +7,9 @@ name: "Copilot Setup Steps"
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
     branches: [main, dev]
 
+permissions:
+  contents: read
+
 jobs:
   version-format:
     name: Validate version format for branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Security
+
+- Added explicit `permissions: contents: read` to `ci.yml`, `version-check.yml`, and `copilot-setup-steps.yml`. Closes a CodeQL "Workflow does not contain permissions" finding on `copilot-setup-steps.yml` and pre-emptively scopes the other two read-only workflows to the same minimum. `release.yml` and `pr-labeler.yml` already had explicit blocks. ([#PR])
+
 ## [1.7.0] - 2026-05-29
 
 ### Security


### PR DESCRIPTION
## Summary

Closes the GitHub Advanced Security / CodeQL finding **"Workflow does not contain permissions"** flagged on PR #110 against `.github/workflows/copilot-setup-steps.yml`, and pre-emptively applies the same fix to two other read-only workflows that had latent CodeQL warnings outside #110's diff.

## What changed

Added `permissions: contents: read` to three workflows:

| Workflow | What it does | Reason `contents: read` is enough |
|---|---|---|
| `ci.yml` | Runs hassfest, HACS validate, ruff, mypy, pytest | Pure read-only validation |
| `version-check.yml` | Greps `manifest.json` for the right version format per branch | Pure read-only validation |
| `copilot-setup-steps.yml` | Installs Python 3.12 + dev deps for Copilot agent sessions | Only checks out the repo and installs from pip |

None of these workflows modify the repo, post comments, create releases, or call external APIs that require write tokens.

## Workflows unchanged

- `release.yml` already has `permissions: contents: write` (needs it to create GitHub releases).
- `pr-labeler.yml` already has `permissions: contents: read` + `pull-requests: write` (needs the latter to apply labels).

## Why this needs to land before PR #110

PR #110 is the `dev -> main` release boundary for v1.7.0. Landing the permissions fix on `dev` first means the v1.7.0 stable release includes the closed CodeQL finding. Without this, v1.7.0 ships with a known security-tooling warning.

After this merges to `dev`, PR #110 will auto-update to include the fix.

## Test plan

- [x] `make check` passes (476 tests, mypy --strict, HACS validate, prose linter, translation drift)
- [ ] CI passes on push (the workflows themselves still run correctly under the tightened scope)
- [ ] After merge: pull `dev` into PR #110's view (auto-rebased by GitHub); confirm the CodeQL review thread resolves; then merge #110 and tag v1.7.0

https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH

---
_Generated by [Claude Code](https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH)_