### PR TITLE
docs: fold #111 workflow-permissions fix into the 1.7.0 CHANGELOG / HISTORY entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,12 @@
 
 ## [Unreleased]
 
-### Security
-
-- Added explicit `permissions: contents: read` to `ci.yml`, `version-check.yml`, and `copilot-setup-steps.yml`. Closes a CodeQL "Workflow does not contain permissions" finding on `copilot-setup-steps.yml` and pre-emptively scopes the other two read-only workflows to the same minimum. `release.yml` and `pr-labeler.yml` already had explicit blocks. ([#PR])
-
 ## [1.7.0] - 2026-05-29
 
 ### Security
 
 - Webhook handler now rejects requests with HTTP 500 when no bearer secret is configured, rather than accepting them. Config entries missing `webhook_secret` are backfilled during migration to schema version 3. ([#94])
+- Added explicit `permissions: contents: read` to `ci.yml`, `version-check.yml`, and `copilot-setup-steps.yml`. Closes a CodeQL "Workflow does not contain permissions" finding on `copilot-setup-steps.yml` and pre-emptively scopes the other two read-only workflows to the same minimum. `release.yml` and `pr-labeler.yml` already had explicit blocks. ([#111])
 
 ### Documentation
 

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -5,6 +5,7 @@ Dated record of completed work. Newest first. Format per entry: category, short 
 ## 2026-05-29
 
 - **release**: v1.7.0 tagged. Promotes v1.7.0-pre2 to stable after on-controller validation confirmed byte-identical entity_id, unique_id, and friendly_name snapshots across the pre1 -> pre2 upgrade (the ARCH-2 translation-key migration regression test). Cycle headline: documentation + architecture. Ships SEC-1 (fail-closed webhook auth with schema v3 migration), ARCH-1 (`UniFiClientConfig` TypedDict), CI-1 (`mypy --strict` enabled), ARCH-2 (entity-name translation keys, unlocking localisation), ARCH-3 (config-flow test package split), ARCH-4 (`SensorStateClass.MEASUREMENT` confirmed on count sensors), DOC-A (35-point documentation accuracy reconciliation), DOC-B (new troubleshooting / privacy / tested-controllers / uninstall sections plus README + info.md restructure), QUAL-1 (WHY comments on dedup / watermark / system-log probe), plus off-plan tooling and docs (`scripts/run_lint.py` / `run_typecheck.py`, AGENTS.md rewrite, Copilot agent definitions, 232 lines of coverage tests). Closes all v1.7.0 ROADMAP items.
+- **security**: scope read-only GitHub Actions workflows to `permissions: contents: read` ([#111]). Closes a CodeQL "Workflow does not contain permissions" finding on `.github/workflows/copilot-setup-steps.yml` (shipped in #104) and pre-emptively applies the same minimum scope to `ci.yml` and `version-check.yml`, which were latent CodeQL warnings outside the diff of any individual feature PR. `release.yml` and `pr-labeler.yml` already had explicit permissions blocks.
 
 ## 2026-05-18
 
@@ -248,6 +249,7 @@ Dated record of completed work. Newest first. Format per entry: category, short 
 [#105]: https://github.com/PHeonix25/unifi_alerts/pull/105
 [#106]: https://github.com/PHeonix25/unifi_alerts/pull/106
 [#107]: https://github.com/PHeonix25/unifi_alerts/pull/107
+[#111]: https://github.com/PHeonix25/unifi_alerts/pull/111
 
 [0d951b3]: https://github.com/PHeonix25/unifi_alerts/commit/0d951b3
 [0f17afb]: https://github.com/PHeonix25/unifi_alerts/commit/0f17afb


### PR DESCRIPTION
## Summary

Folds the **#111 workflow-permissions fix** into the v1.7.0 release entry, where it belongs.

PR #111 shipped between the 1.7.0 stable bump (#109) and the `dev -> main` release PR (#110). Its CHANGELOG bullet landed under `[Unreleased]`, but the work is part of the 1.7.0 cycle:

- The CodeQL finding it closes was flagged on the v1.7.0 release PR (#110) itself
- The fix lands on `dev` before v1.7.0 is tagged
- There is no v1.7.1 planned that would otherwise carry it

## Changes

- `CHANGELOG.md`: bullet moved from `[Unreleased]` `### Security` (now empty) into `[1.7.0] - 2026-05-29` `### Security`. `([#PR])` placeholder resolved to `([#111])`.
- `docs/HISTORY.md`: paired bullet added under the existing `## 2026-05-29` block so the historical record of v1.7.0 reflects #111 alongside the release entry. New `[#111]` reference link at the bottom.

## Release sequence (after this merges)

1. PR #110 auto-rebases against the new `dev` tip
2. CodeQL re-scans against the new merge ref; the existing stale comment on copilot-setup-steps.yml resolves
3. You merge PR #110 with **"Create a merge commit"**
4. Locally: `git checkout main && git pull origin main && git tag v1.7.0 && git push origin v1.7.0`

## Verification

- [x] `make doc-check` passes (prose linter + translation drift)
- [x] CHANGELOG `[1.7.0]` Security section now has both bullets (#94, #111), `[Unreleased]` is empty
- [x] HISTORY 2026-05-29 block has both the release entry and the #111 bullet
- [x] Reference-style `[#111]` link added to HISTORY footer

https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH

---
_Generated by [Claude Code](https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH)_