### PR TITLE
chore: start v1.8.0-pre1 development cycle

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": [],
-  "version": "1.7.0"
+  "version": "1.8.0-pre1"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -6,6 +6,7 @@ Dated record of completed work. Newest first. Format per entry: category, short 
 
 - **release**: v1.7.0 tagged. Promotes v1.7.0-pre2 to stable after on-controller validation confirmed byte-identical entity_id, unique_id, and friendly_name snapshots across the pre1 -> pre2 upgrade (the ARCH-2 translation-key migration regression test). Cycle headline: documentation + architecture. Ships SEC-1 (fail-closed webhook auth with schema v3 migration), ARCH-1 (`UniFiClientConfig` TypedDict), CI-1 (`mypy --strict` enabled), ARCH-2 (entity-name translation keys, unlocking localisation), ARCH-3 (config-flow test package split), ARCH-4 (`SensorStateClass.MEASUREMENT` confirmed on count sensors), DOC-A (35-point documentation accuracy reconciliation), DOC-B (new troubleshooting / privacy / tested-controllers / uninstall sections plus README + info.md restructure), QUAL-1 (WHY comments on dedup / watermark / system-log probe), plus off-plan tooling and docs (`scripts/run_lint.py` / `run_typecheck.py`, AGENTS.md rewrite, Copilot agent definitions, 232 lines of coverage tests). Closes all v1.7.0 ROADMAP items.
 - **security**: scope read-only GitHub Actions workflows to `permissions: contents: read` ([#111]). Closes a CodeQL "Workflow does not contain permissions" finding on `.github/workflows/copilot-setup-steps.yml` (shipped in #104) and pre-emptively applies the same minimum scope to `ci.yml` and `version-check.yml`, which were latent CodeQL warnings outside the diff of any individual feature PR. `release.yml` and `pr-labeler.yml` already had explicit permissions blocks.
+- **chore**: start v1.8.0-pre1 development cycle ([#113]). Manifest bumped to `1.8.0-pre1`; no tag pushed. Next bump (`bump_version.py --pre`) produces the `v1.8.0-pre1` tag once the first batch of v1.8 work has merged.
 
 ## 2026-05-18
 
@@ -250,6 +251,7 @@ Dated record of completed work. Newest first. Format per entry: category, short 
 [#106]: https://github.com/PHeonix25/unifi_alerts/pull/106
 [#107]: https://github.com/PHeonix25/unifi_alerts/pull/107
 [#111]: https://github.com/PHeonix25/unifi_alerts/pull/111
+[#113]: https://github.com/PHeonix25/unifi_alerts/pull/113
 
 [0d951b3]: https://github.com/PHeonix25/unifi_alerts/commit/0d951b3
 [0f17afb]: https://github.com/PHeonix25/unifi_alerts/commit/0f17afb


### PR DESCRIPTION
## Summary

Starts the **v1.8.0** development cycle on `dev`. Bumps `custom_components/unifi_alerts/manifest.json` from `1.7.0` to `1.8.0-pre1` via `scripts/bump_version.py --next-cycle`.

No tag is pushed for this bump. The `v1.8.0-pre1` tag comes later once the first batch of feature work for v1.8 has merged.

## What this PR contains

- `manifest.json`: `1.7.0` -> `1.8.0-pre1`
- Follow-up commit to add a paired `chore` entry to `docs/HISTORY.md` under the existing `## 2026-05-29` block (matches the PR #82 precedent for cycle-start entries — they land in the previous tag's block since they fall on the same day as the stable promotion)

## Not touched

- `CHANGELOG.md` - per CLAUDE.md, pre-release version bumps do not touch CHANGELOG (no user-visible behaviour change).
- `docs/ROADMAP.md` - status line was already refreshed in the v1.7.0 stable bump (PR #109). v1.7 section removed; v2.0 + Deferred remain.
- `docs/TODO.md` - v1.8.0 candidates were intentionally not pre-seeded; backlog grows organically as items surface. Current items: `SYSTEM_LOG_KEY_TO_CATEGORY` growth (Reliability), markdownlint Tier 2 docs linter (Nice-to-have), HACS default catalogue prep (Nice-to-have, blocks v2.0.0).

## Verification

- [x] `make check` passes (476 tests, mypy --strict, HACS validate, prose linter, translation drift)
- [x] `scripts/bump_version.py --next-cycle` produced a clean diff
- [ ] After merge: tag is NOT pushed for this bump; the next time `bump_version.py --pre` runs (whenever the first v1.8 work is ready to checkpoint), it will produce `v1.8.0-pre1`

https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH

---
_Generated by [Claude Code](https://claude.ai/code/session_016B8Eqr3SuBTVLfjfu8pHwH)_