### PR TITLE
docs: migrate work tracking from TODO.md to GitHub Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to suggest a feature. Before filing, please skim `docs/TODO.md` and `docs/ROADMAP.md` to see whether the idea is already tracked.
+        Thanks for taking the time to suggest a feature. Before filing, please search the open issues and skim `docs/ROADMAP.md` to see whether the idea is already tracked.
 
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,57 @@
+name: Task
+description: Track engineering work that is not a user-facing bug or feature (hardening, refactor, tests, docs, CI, tech debt)
+title: "[Task] "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for tracked engineering work: hardening, refactors, test coverage, docs, CI, or tech debt. Before filing, search open issues to avoid duplicates. Apply a category label (`security`, `fix`, `feat`, `tests`, `ci`, `documentation`), a `size: *` label, a `priority: *` label, and assign the target milestone.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences. What is the work, and where does it live (file or module)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context / why
+      description: Why is this worth doing now? Link the finding, the risk it addresses, or the quality attribute it improves.
+    validations:
+      required: true
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Scope and approach
+      description: The smallest viable change. Note files to touch and anything explicitly out of scope.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How we know it is done. Prefer a checklist.
+      placeholder: |
+        - [ ] ...
+        - [ ] Tests cover the change
+        - [ ] CHANGELOG `[Unreleased]` updated if user-visible
+    validations:
+      required: true
+
+  - type: dropdown
+    id: size
+    attributes:
+      label: Size
+      description: Rough effort and review-time guide.
+      options:
+        - "S (small, single-sitting)"
+        - "M (medium)"
+        - "L (large, may need decomposition)"
+    validations:
+      required: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Two data paths run in parallel:
 | Architecture & data flow | `docs/ARCHITECTURE.md` |
 | HA-specific patterns | `docs/HOMEASSISTANT.md` |
 | UniFi API & payloads | `docs/UNIFI.md` |
-| Outstanding work | `docs/TODO.md` |
+| Outstanding work | GitHub Issues (taxonomy in `docs/TODO.md`) |
 | Test guidance | `docs/TESTING.md` |
 | Per-file responsibilities | `docs/REPO_LAYOUT.md` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ This integration covers **UniFi Network** only (System Logs / SIEM events from t
 | `docs/UNIFI.md` | Understand the UniFi API, auth methods, alarm payloads, and event key taxonomy |
 | `docs/TESTING.md` | Run, write, or extend tests |
 | `docs/DEVELOPING.md` | Set up a local dev environment, run tests, contribute changes |
-| `docs/TODO.md` | Find the outstanding-work backlog. Items are removed when they ship; never struck through, never annotated. Historical record lives in `docs/HISTORY.md`; per-release plan lives in `docs/ROADMAP.md`. |
+| GitHub Issues | Find the outstanding-work backlog. Work is tracked in Issues (filter by milestone, sort by `priority:`, pick by `size:`), not in a file. `docs/TODO.md` is a pointer that documents the label and milestone taxonomy. Historical record lives in `docs/HISTORY.md`; per-release plan lives in `docs/ROADMAP.md`. |
 | `docs/ROADMAP.md` | See what's planned next per release (v1.5.0, v1.6.0, v1.7.0, v2.0.0). Open items only; completed releases are removed once they ship. |
 | `docs/HISTORY.md` | Dated record of completed work, newest first. **Updated only at tag time** (pre-release or stable) by the version-bump PR, which adds one date block listing every PR merged since the previous tag. Format: `## YYYY-MM-DD` heading, bullets `- **category**: short description ([#PR] or [SHA]). Short why.` Categories: `feat`, `fix`, `security`, `docs`, `ci`, `chore`, `tests`, `release`. No WHO. No "bundle/cluster/track/session N" framing. PR backlinks via reference-style at the bottom of the file. |
 | `CHANGELOG.md` | User-facing release summary in [common-changelog](https://common-changelog.org) format. Past tense, one line per change, references at the bottom. Update the `[Unreleased]` section as user-visible changes land. |
@@ -137,7 +137,7 @@ Recommended rules:
 - **Move into the working directory at the start of every session** - avoids needing path prefixes on every command.
 - Always run `make check` before committing - never commit broken code. `make check` runs lint, typecheck, HACS preflight, translation drift check, and the full test suite in one shot.
 - Update `docs/HISTORY.md` **only in the version-bump PR** (pre-release or stable), not on every PR. The bump PR adds a single `## YYYY-MM-DD` block (newest first) summarising every PR merged since the previous tag, plus the corresponding `[#PR]` reference links at the bottom. Format: `- **category**: short description ([#PR]). Short why.` Categories: `feat`, `fix`, `security`, `docs`, `ci`, `chore`, `tests`, `release`. No WHO, no multi-paragraph stories, no "bundle/cluster/session" framing. Feature/fix PRs do not touch HISTORY at all.
-- Always update `docs/TODO.md` by **deleting** the line for any completed item in the same PR that ships the change; never strike-through, never annotate "fixed in PR X". `docs/TODO.md` is outstanding work only. The historical record belongs in `docs/HISTORY.md`. Tick or remove items from `docs/ROADMAP.md` in the same PR that ships them, not at release time; once a release ships, drop its section from ROADMAP entirely. Add new items as they surface. Do not rely on memory or Git history alone.
+- **Outstanding work lives in GitHub Issues, not in a file.** Close an item by landing a PR that references it (`Closes #NN` in the PR body); never track completion by deleting prose. File new work with the **Task** template (or Bug / Feature where they fit) and apply a category label, a `size:` label, a `priority:` label, and the target milestone (taxonomy documented in `docs/TODO.md`). `scripts/seed_issues.py` is the idempotent bulk-seeder. When asked to "pick up issue #NN" or "the next one in the `vX.Y.Z` milestone", read the issue, do the work on a `claude/*` branch, and close it via the PR. Tick or remove items from `docs/ROADMAP.md` in the same PR that ships them, not at release time; once a release ships, drop its section from ROADMAP entirely. The historical record belongs in `docs/HISTORY.md`. Do not rely on memory or Git history alone.
 - At the end of the day, make sure there are no commits outstanding, no changes locally that need to be pushed, and that the `auto-memory\dirty-files` file is empty (if it exists on disk). This ensures a clean slate for the next session.
 
 ## Resuming an interrupted session
@@ -146,7 +146,7 @@ Interruptions (timeouts, hibernation, re-login) are common. When a new conversat
 
 1. **Read `docs/HISTORY.md`** - the last entry describes what was most recently completed.
 2. **Run `git status` and `git diff HEAD`** - uncommitted changes show exactly what was in-flight.
-3. **Read `docs/TODO.md`** - the top remaining item is what was probably being worked on.
+3. **Check the open GitHub Issues** for the active milestone (highest `priority:` first) - that is the likely in-flight work. `docs/TODO.md` describes the taxonomy.
 4. **If a version-bump PR is in flight, audit its HISTORY block** - run `git log <prev-tag>..HEAD --merges --oneline` and confirm every merge appears in the new `docs/HISTORY.md` date block. Missing entries are the most common gap left by an interrupted release-prep session. Feature/fix PRs do NOT need HISTORY entries (HISTORY is written at tag time only); skip this step unless a `claude/bump-*` branch is active.
 5. **Check the venv** - on Linux/Mac: `ls .venv/bin/pytest`; on Windows PowerShell: `Test-Path .venv\Scripts\pytest.exe`. If missing, recreate it:
    - **Linux/Mac:** `make setup` (or manually: `python3.12 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt --quiet`)
@@ -155,7 +155,7 @@ Interruptions (timeouts, hibernation, re-login) are common. When a new conversat
 
 ## Before making changes
 
-1. Check `docs/TODO.md` for context on what's known to be incomplete or broken.
+1. Check the open GitHub Issues for context on what's known to be incomplete or broken.
 2. Run `make check` to run all local validation in one shot:
    - ruff lint + format check
    - mypy type check

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,23 +2,42 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-05-29):** v1.7.0 released. Path to v2.0.0: v1.8.0 (incremental polish; backlog lives in `docs/TODO.md`), v2.0.0 (HACS default).
+> **Status (2026-05-29):** v1.7.0 released; v1.8.0-pre1 in development. Path to v2.0.0: v1.8.0 (Trust and Hardening), v1.9.0 (Localisation and Scale), then v2.0.0 (HACS default catalogue). Item-level detail and ordering live in `docs/TODO.md`.
 
 > **Branching model:** see `CLAUDE.md § Branching strategy and versioning`.
 
 ---
 
+## v1.8.0: Trust and Hardening
+
+Correctness, privacy, security, and onboarding-confidence polish. Themes:
+
+- Privacy: stop persisting raw payloads to disk; clarify retention and data handling.
+- Correctness: fix the stale event replay on reload; coalesce watermark persistence and surface its failures.
+- Onboarding: a webhook health signal; complete the Alarm Manager setup docs.
+- Structure: consolidate the two alert-classification paths; extract controller auth into its own seam.
+
+Item-level detail and ordering live in `docs/TODO.md`.
+
+## v1.9.0: Localisation and Scale
+
+- Localisation: translatable category labels and the remaining inline strings.
+- Scale and efficiency: clamp the watermark fetch window; add probe backoff.
+- Capability: severity filtering for noisy categories; a self-healing key map.
+- Process: adopt GitHub Issues for the backlog so work items carry stable identifiers.
+
+Item-level detail lives in `docs/TODO.md`.
+
 ## v2.0.0: HACS default catalogue
 
 Prerequisites for submitting to <https://github.com/hacs/default>.
 
-- [ ] All v1.x items in `docs/TODO.md` resolved.
+- [ ] All v1.x items in `docs/TODO.md` resolved, including the privacy and docs gates flagged there (raw-payload persistence, retention and data-handling statement, Alarm Manager onboarding docs, and localisation maturity).
 - [ ] Submit PR to `hacs/default`.
 
 ---
 
 ## Deferred / low priority
 
-- Extract `_device_info()` duplication into a shared `entity_base.py` mixin (only if maintenance burden grows).
+- Extract `_device_info()` duplication into a shared `entity_base.py` mixin (only if maintenance burden grows; currently intentional for platform isolation).
 - Configurable site per category (power-user feature).
-- Optional integration test for the full rotation cycle (options-flow > entry-update > reload > re-register, end-to-end). Each step is unit-tested already; the integration test would catch wiring regressions.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-05-29):** v1.7.0 released; v1.8.0-pre1 in development. Path to v2.0.0: v1.8.0 (Trust and Hardening), v1.9.0 (Localisation and Scale), then v2.0.0 (HACS default catalogue). Item-level detail and ordering live in `docs/TODO.md`.
+> **Status (2026-05-29):** v1.7.0 released; v1.8.0-pre1 in development. Path to v2.0.0: v1.8.0 (Trust and Hardening), v1.9.0 (Localisation and Scale), then v2.0.0 (HACS default catalogue). Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
 
 > **Branching model:** see `CLAUDE.md § Branching strategy and versioning`.
 
@@ -17,22 +17,22 @@ Correctness, privacy, security, and onboarding-confidence polish. Themes:
 - Onboarding: a webhook health signal; complete the Alarm Manager setup docs.
 - Structure: consolidate the two alert-classification paths; extract controller auth into its own seam.
 
-Item-level detail and ordering live in `docs/TODO.md`.
+Item-level detail: the `v1.8.0` [milestone](https://github.com/PHeonix25/unifi_alerts/milestones).
 
 ## v1.9.0: Localisation and Scale
 
 - Localisation: translatable category labels and the remaining inline strings.
 - Scale and efficiency: clamp the watermark fetch window; add probe backoff.
 - Capability: severity filtering for noisy categories; a self-healing key map.
-- Process: adopt GitHub Issues for the backlog so work items carry stable identifiers.
+- Process: GitHub Issues is now the work tracker (see `docs/TODO.md` for the taxonomy).
 
-Item-level detail lives in `docs/TODO.md`.
+Item-level detail: the `v1.9.0` [milestone](https://github.com/PHeonix25/unifi_alerts/milestones).
 
 ## v2.0.0: HACS default catalogue
 
 Prerequisites for submitting to <https://github.com/hacs/default>.
 
-- [ ] All v1.x items in `docs/TODO.md` resolved, including the privacy and docs gates flagged there (raw-payload persistence, retention and data-handling statement, Alarm Manager onboarding docs, and localisation maturity).
+- [ ] All `v2.0-gate` issues closed (raw-payload persistence, retention and data-handling statement, Alarm Manager onboarding docs, and localisation maturity).
 - [ ] Submit PR to `hacs/default`.
 
 ---

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,68 +1,29 @@
 # TODO
 
-Outstanding work only. Items are removed when they ship; completion lives in `docs/HISTORY.md`, and the per-release plan lives in `docs/ROADMAP.md`. Within each release the items are ordered by value (highest first); the trailing size tag (S/M/L) is a rough effort and review-time guide, so a free slot can take the next item that fits it.
+Outstanding work is tracked in **GitHub Issues**, not in this file. This page is a pointer and a description of how the tracker is organised.
 
-## v1.8.0: Trust and Hardening
+- Open backlog: <https://github.com/PHeonix25/unifi_alerts/issues>
+- Per-release plan and themes: `docs/ROADMAP.md`
+- Completed work: `docs/HISTORY.md` (written at tag time)
 
-Correctness, privacy, security, and onboarding-confidence work. The items marked "v2.0 gate" are also prerequisites for the HACS default submission (see `docs/ROADMAP.md`).
+## How the tracker is organised
 
-### High value
+Each issue carries a **milestone**, a **category** label, a **size** label, and a **priority** label. Pick work by filtering on the milestone and sorting by priority, then by the size that fits the time you have.
 
-- **Stop persisting raw alert payloads to disk** (`models.py`, `coordinator.py`) [S, v2.0 privacy gate]: `UniFiAlert.to_dict()` serialises the entire `raw` payload (client MACs, IPs, hostnames) into `.storage`, the one place those fields are not already redacted, and a non-JSON value in `raw` can break `Store.async_save`. Persist an explicit scalar field list (`message`, `received_at`, `key`, `device_name`, `site`, `severity`) and default `raw={}` in `from_dict`.
-- **Fix stale `alert_received` replay on reload** (`event.py`) [S]: `_last_seen_count` resets to 0 in `__init__`, so the first coordinator update after any options save (which triggers a full reload) re-fires the last alert into users' automations. Seed `_last_seen_count` from the restored `state.alert_count` in `async_added_to_hass`, before the first `_handle_coordinator_update`.
-- **Webhook health signal** (`webhook_handler.py`, `coordinator.py`, `diagnostics.py`) [S-M, v2.0-adjacent]: a per-category "last webhook received" timestamp plus a healthy/stale indicator, so a mis-pasted or never-pasted Alarm Manager URL surfaces as a visible state instead of indefinite silence. This is the single biggest source of "it does not work" reports for a push integration.
-- **Coalesce watermark persistence and surface failures** (`coordinator.py`) [S]: the per-push fire-and-forget `async_save` has a lost-update hazard under bursts and no error path, so a failed persist dies silently. Route writes through `Store.async_delay_save`, and run background tasks through a shared helper whose done-callback logs any non-`CancelledError` exception.
+| Dimension | Values | Notes |
+| --- | --- | --- |
+| Milestone | `v1.8.0`, `v1.9.0`, `v2.0.0` | The release the item is planned for. |
+| Category | `security`, `fix`, `feat`, `enhancement`, `tests`, `ci`, `documentation`, `github-actions`, `dependencies` | Mirrors `.github/release.yml` so release notes group correctly. |
+| Size | `size: S`, `size: M`, `size: L` | Rough effort and review-time guide. |
+| Priority | `priority: high`, `priority: medium`, `priority: low` | Order within a milestone. |
+| Gate | `v2.0-gate` | Prerequisite for the HACS default submission; lives in an earlier milestone. |
 
-### Medium value
+## Filing and closing work
 
-- **Consolidate alert classification into a single seam** (`unifi_client._classify` vs `models.from_system_log_event`) [M]: two parallel category resolvers (legacy prefix-match map in the client; exact-key plus enum fallback in the model) with two separate unknown-key warning mechanisms. Collapse the taxonomy into one location so the v2 path and the legacy path share resolution and warning dedup, and the process-global `_unknown_system_log_keys` set stops being shared mutable state.
-- **Extract controller auth into a dedicated seam** (`unifi_client.py`) [M-L]: auth-method autodetect, session state, login, key verification, and header construction are interleaved with transport, version probing, pagination, and parsing in one class. Pull the auth concern into its own strategy so a future third auth method or token refresh slots in cleanly and auth becomes unit-testable in isolation.
-- **End-to-end secret-rotation test** (`tests/integration/`) [M]: prove the full cycle (options finish -> entry update -> reload -> webhook re-register) so the rotated `?token=` and the handler's compared secret stay in agreement; assert the old token returns 401 and the new token returns 200 after reload. Rotation is a security boundary, so this is worth more than its previous "every step is unit-tested" framing implied.
-- **Catch `InvalidAuthError` on the re-auth retry** (`coordinator.py`) [S]: after a 401 triggers re-authentication, the retried fetch only catches `CannotConnectError`; a second `InvalidAuthError` escapes `_async_update_data` as a generic error instead of raising `ConfigEntryAuthFailed` to trigger HA re-auth. Catch it and add a coordinator test for the "re-auth succeeds, retry still 401" sequence.
-- **Harden `_render_message_raw` substitution** (`models.py`) [S, M if a fix is needed]: sequential `str.replace` over controller-supplied `parameters` is order-dependent and lets a parameter value that itself contains a `{TOKEN}` be re-substituted. Switch to single-pass substitution and add tests for embedded-token, overlapping-prefix (`{IP}` vs `{IP_DST}`), and non-string parameter values.
-- **Define the empty or malformed webhook contract** (`webhook_handler.py`, `coordinator.push_alert`) [S]: an authenticated POST with an empty or unrecognisable body currently flips the binary sensor to "Problem" and fires an event. Decide during implementation whether to skip `push_callback` when no recognisable fields are present, or to keep the behaviour; either way add a test that locks the chosen contract in.
-- **Retention and data-handling clarity** (`coordinator.py`, README) [S-M, v2.0 privacy gate]: `clear()` advances the watermark but leaves `last_alert` (message, device name) in state and on disk, so a "cleared" category still retains identifying content. Clear `last_alert` on `clear()` (or document that clearing is acknowledgement, not deletion), and add a short README "Data handled and retention" section covering what is stored, where, and how to purge it.
-- **Complete the Alarm Manager onboarding docs** (README, `docs/`) [S, v2.0 docs gate]: add a per-category trigger-mapping table and annotated screenshots for the Alarm Manager side (the most error-prone half of setup), and remove the "copy URLs before clicking Submit" footgun by re-showing the URLs after the entry is created (the options flow already supports this).
-
-### Low value and guardrails
-
-- **Disable redirect-following on authenticated outbound calls** (`unifi_client.py`) [S]: pass `allow_redirects=False` and treat a 3xx as an error, so the `X-API-Key` header and session cookie cannot ride a controller-issued redirect to another host.
-- **Length-validate inbound `key`, `severity`, `device_name`** (`models.from_webhook_payload`) [S]: truncate them the same way `message` is, so a token-bearing caller cannot push unbounded values into state and logs.
-- **Document the diagnostics content exclusion** (`diagnostics.py`) [S]: add a comment recording that per-category alert content (`message`, `device_name`, `raw`) is deliberately excluded and must stay excluded; if alert detail is ever added, route it through a field redactor.
-- **Optional host guard on the controller URL** (`config_flow.py`) [S]: validation is scheme-only today. Optionally reject loopback and link-local hosts, or document that the URL is fully trusted under the local-admin model. Low priority guardrail.
-- **Reconcile `docs/REPO_LAYOUT.md` with the file tree** [S]: add the missing `services.py`, `services.yaml`, `scripts/run_lint.py`, and `scripts/run_typecheck.py` rows; optionally add a `scripts/validate_docs.py` check that every `*.py` under `custom_components/` and `scripts/` appears at least once.
-- **Fix the Actions version comments in `copilot-setup-steps.yml`** [S]: the pinned SHAs carry `# v4` and `# v5` comments but resolve to `# v6`, breaking the human-readable pin contract that Dependabot review relies on.
-
-## v1.9.0: Localisation and Scale
-
-### High value
-
-- **Translatable category labels** (`const.py` `CATEGORY_LABELS`, platform files) [M]: entity name templates already use `_attr_translation_key`, but the `{category}` placeholder is filled from an English-only dict, leaving entity names half-translated for non-English Home Assistant. Give each category its own `translation_key` so the label resolves through the translation layer.
-- **Self-healing system-log key map** (`models.py`, `const.py`, `diagnostics.py`) [S]: `SYSTEM_LOG_KEY_TO_CATEGORY` is intentionally incomplete, and the `SYSTEM_LOG_CATEGORY_FALLBACK` enum keeps unmapped events in roughly the right category, but there is no user-visible signal when a key is unclassified, so the map only improves via users who dig through DEBUG logs. Add an "uncategorised" counter or a diagnostics field listing recently seen unmapped keys so every install passively contributes the keys that surface in the wild.
-
-### Medium value
-
-- **Severity filtering for noisy categories** (config and options flow, coordinator) [M]: noisy categories are blunt on/off toggles today. A min-severity option (or a consistently surfaced severity attribute users can key automations off) makes them usable instead of muted on day one.
-- **Clamp the watermark fetch window** (`coordinator.py`) [S-M]: `since = min(watermarks)` lets the fetch window grow without bound when one category is rarely cleared, re-paginating the full range every poll and risking recent alarms being pushed past `MAX_SYSTEM_LOG_PAGES`. Clamp to `max(min(watermarks), now - lookback_cap)` and log when the page cap is hit.
-- **Probe backoff for the system-log endpoint** (`unifi_client.probe_system_log_endpoint`) [S]: a persistent non-404 failure re-probes on every poll forever, doubling the request rate against a misbehaving endpoint. Add a transient-failure counter that caches "legacy" after a threshold, with periodic re-probe.
-- **Localise remaining inline strings** (`sensor.py` "No alerts yet", `strings.json`) [S]: move the code-level state string to a translation key, and replace emoji and em-dash-carried meaning in config descriptions with plain-text prefixes, so meaning survives translation and screen readers.
-- **Multi-controller docs clarity** (README) [S]: document the multi-controller and multi-site pattern and clarify the `site` field. Defer full per-category site config (parked below, low value).
-
-### Low value
-
-- **Unicode and large-volume round-trip tests** (`tests/`) [S]: assert that non-ASCII alert text (emoji, CJK, RTL) and 300-character strings survive parse -> store -> restore and 255-character truncation, and that a roughly 500-alert batch keeps counts and watermark filtering deterministic.
-- **Coverage measurement in CI** (`Makefile`, CI) [S]: add `--cov` reporting (not necessarily a gate) so thin-test regressions become visible.
-- **Pin dev dependencies** (`requirements-dev.txt`) [M]: the unpinned `homeassistant`, `ruff`, `mypy`, and `pytest` floats make CI and local `make check` non-reproducible. Maintainer call on whether a hashed constraints file is warranted without enabling the pip Dependabot ecosystem.
-
-### Process
-
-- **Adopt GitHub Issues for the backlog** [M]: move outstanding items from this file into tracked issues so each carries a stable identifier that can be referenced in PRs and release notes, instead of local shorthand. Target landing this during the v1.9 cycle.
-
-## Backlog: not yet scheduled
-
-- **HACS default catalogue submission**: open the PR to <https://github.com/hacs/default> once the v1.x items and the v2.0 gates above are closed.
-- **Tier 2 docs linter (markdownlint)**: layer `markdownlint-cli2` on top of `scripts/validate_docs.py` to catch structural issues (heading-level skips, mixed list markers, bare URLs, trailing whitespace) that a regex linter cannot. Adds a Node dependency; commit a `.markdownlint.json` config tuned for this repo. Run it from CI's `lint` job and the pre-push hook alongside the existing prose check. Low user value; revisit only if doc structure regressions recur.
+- File new work with the **Task** issue template (or Bug / Feature where they fit). Apply a category, `size`, and `priority` label and assign a milestone.
+- Close items by landing a PR that references the issue (`Closes #NN`); do not delete lines here.
+- The seed/migration tool is `scripts/seed_issues.py` (idempotent; re-run to add new backlog items in bulk).
 
 ## Known issues: intentional, do not action
 
-- **`_device_info()` duplication**: duplicated identically across `binary_sensor.py`, `sensor.py`, `event.py`, `button.py`. Intentional for platform isolation; extract to a shared `entity_base.py` only if it becomes a maintenance burden.
+- **`_device_info()` duplication**: duplicated identically across `binary_sensor.py`, `sensor.py`, `event.py`, `button.py`. Intentional for platform isolation; extract to a shared `entity_base.py` only if it becomes a maintenance burden. Not tracked as an issue on purpose.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,24 +1,68 @@
 # TODO
 
-Outstanding work only. Items are removed when they ship; completion lives in `docs/HISTORY.md`, and the per-release plan lives in `docs/ROADMAP.md`.
+Outstanding work only. Items are removed when they ship; completion lives in `docs/HISTORY.md`, and the per-release plan lives in `docs/ROADMAP.md`. Within each release the items are ordered by value (highest first); the trailing size tag (S/M/L) is a rough effort and review-time guide, so a free slot can take the next item that fits it.
 
-## 🟢 Nice-to-have
+## v1.8.0: Trust and Hardening
 
-- **HACS default catalogue submission**: open the PR to <https://github.com/hacs/default> once all v1.x items below are closed.
-- **Tier 2 docs linter (markdownlint)**: layer `markdownlint-cli2` on top of `scripts/validate_docs.py` to catch structural issues (heading-level skips, mixed list markers, bare URLs, trailing whitespace) that a regex linter cannot. Adds a Node dependency; commit a `.markdownlint.json` config tuned for this repo. Run it from CI's `lint` job and the pre-push hook alongside the existing prose check.
+Correctness, privacy, security, and onboarding-confidence work. The items marked "v2.0 gate" are also prerequisites for the HACS default submission (see `docs/ROADMAP.md`).
 
-## Reliability / correctness
+### High value
 
-- **`SYSTEM_LOG_KEY_TO_CATEGORY` is incomplete** (`const.py`): the v2 system-log key map was seeded from field-confirmed events on Network 10.3.58 (UCG-Ultra) and the documented API schema. Additional keys will surface in the wild; add them as users report unclassified v2 events. Coarse-grained fallback via `SYSTEM_LOG_CATEGORY_FALLBACK` (broad enum) keeps events in roughly the right category until key-level entries are added.
+- **Stop persisting raw alert payloads to disk** (`models.py`, `coordinator.py`) [S, v2.0 privacy gate]: `UniFiAlert.to_dict()` serialises the entire `raw` payload (client MACs, IPs, hostnames) into `.storage`, the one place those fields are not already redacted, and a non-JSON value in `raw` can break `Store.async_save`. Persist an explicit scalar field list (`message`, `received_at`, `key`, `device_name`, `site`, `severity`) and default `raw={}` in `from_dict`.
+- **Fix stale `alert_received` replay on reload** (`event.py`) [S]: `_last_seen_count` resets to 0 in `__init__`, so the first coordinator update after any options save (which triggers a full reload) re-fires the last alert into users' automations. Seed `_last_seen_count` from the restored `state.alert_count` in `async_added_to_hass`, before the first `_handle_coordinator_update`.
+- **Webhook health signal** (`webhook_handler.py`, `coordinator.py`, `diagnostics.py`) [S-M, v2.0-adjacent]: a per-category "last webhook received" timestamp plus a healthy/stale indicator, so a mis-pasted or never-pasted Alarm Manager URL surfaces as a visible state instead of indefinite silence. This is the single biggest source of "it does not work" reports for a push integration.
+- **Coalesce watermark persistence and surface failures** (`coordinator.py`) [S]: the per-push fire-and-forget `async_save` has a lost-update hazard under bursts and no error path, so a failed persist dies silently. Route writes through `Store.async_delay_save`, and run background tasks through a shared helper whose done-callback logs any non-`CancelledError` exception.
 
-## Testing
+### Medium value
 
-- **Optional: integration test for full rotation cycle**: options-flow > entry-update > reload > re-register, end-to-end. Each step is unit-tested already.
+- **Consolidate alert classification into a single seam** (`unifi_client._classify` vs `models.from_system_log_event`) [M]: two parallel category resolvers (legacy prefix-match map in the client; exact-key plus enum fallback in the model) with two separate unknown-key warning mechanisms. Collapse the taxonomy into one location so the v2 path and the legacy path share resolution and warning dedup, and the process-global `_unknown_system_log_keys` set stops being shared mutable state.
+- **Extract controller auth into a dedicated seam** (`unifi_client.py`) [M-L]: auth-method autodetect, session state, login, key verification, and header construction are interleaved with transport, version probing, pagination, and parsing in one class. Pull the auth concern into its own strategy so a future third auth method or token refresh slots in cleanly and auth becomes unit-testable in isolation.
+- **End-to-end secret-rotation test** (`tests/integration/`) [M]: prove the full cycle (options finish -> entry update -> reload -> webhook re-register) so the rotated `?token=` and the handler's compared secret stay in agreement; assert the old token returns 401 and the new token returns 200 after reload. Rotation is a security boundary, so this is worth more than its previous "every step is unit-tested" framing implied.
+- **Catch `InvalidAuthError` on the re-auth retry** (`coordinator.py`) [S]: after a 401 triggers re-authentication, the retried fetch only catches `CannotConnectError`; a second `InvalidAuthError` escapes `_async_update_data` as a generic error instead of raising `ConfigEntryAuthFailed` to trigger HA re-auth. Catch it and add a coordinator test for the "re-auth succeeds, retry still 401" sequence.
+- **Harden `_render_message_raw` substitution** (`models.py`) [S, M if a fix is needed]: sequential `str.replace` over controller-supplied `parameters` is order-dependent and lets a parameter value that itself contains a `{TOKEN}` be re-substituted. Switch to single-pass substitution and add tests for embedded-token, overlapping-prefix (`{IP}` vs `{IP_DST}`), and non-string parameter values.
+- **Define the empty or malformed webhook contract** (`webhook_handler.py`, `coordinator.push_alert`) [S]: an authenticated POST with an empty or unrecognisable body currently flips the binary sensor to "Problem" and fires an event. Decide during implementation whether to skip `push_callback` when no recognisable fields are present, or to keep the behaviour; either way add a test that locks the chosen contract in.
+- **Retention and data-handling clarity** (`coordinator.py`, README) [S-M, v2.0 privacy gate]: `clear()` advances the watermark but leaves `last_alert` (message, device name) in state and on disk, so a "cleared" category still retains identifying content. Clear `last_alert` on `clear()` (or document that clearing is acknowledgement, not deletion), and add a short README "Data handled and retention" section covering what is stored, where, and how to purge it.
+- **Complete the Alarm Manager onboarding docs** (README, `docs/`) [S, v2.0 docs gate]: add a per-category trigger-mapping table and annotated screenshots for the Alarm Manager side (the most error-prone half of setup), and remove the "copy URLs before clicking Submit" footgun by re-showing the URLs after the entry is created (the options flow already supports this).
 
-## Architecture
+### Low value and guardrails
 
-- **Entity naming via `_attr_translation_key`**: all four platform files hard-code `_attr_name = f"{CATEGORY_LABELS[cat]} ..."`. Migrate to `has_entity_name = True` + `_attr_translation_key` so strings live in `strings.json`. Unlocks localisation.
+- **Disable redirect-following on authenticated outbound calls** (`unifi_client.py`) [S]: pass `allow_redirects=False` and treat a 3xx as an error, so the `X-API-Key` header and session cookie cannot ride a controller-issued redirect to another host.
+- **Length-validate inbound `key`, `severity`, `device_name`** (`models.from_webhook_payload`) [S]: truncate them the same way `message` is, so a token-bearing caller cannot push unbounded values into state and logs.
+- **Document the diagnostics content exclusion** (`diagnostics.py`) [S]: add a comment recording that per-category alert content (`message`, `device_name`, `raw`) is deliberately excluded and must stay excluded; if alert detail is ever added, route it through a field redactor.
+- **Optional host guard on the controller URL** (`config_flow.py`) [S]: validation is scheme-only today. Optionally reject loopback and link-local hosts, or document that the URL is fully trusted under the local-admin model. Low priority guardrail.
+- **Reconcile `docs/REPO_LAYOUT.md` with the file tree** [S]: add the missing `services.py`, `services.yaml`, `scripts/run_lint.py`, and `scripts/run_typecheck.py` rows; optionally add a `scripts/validate_docs.py` check that every `*.py` under `custom_components/` and `scripts/` appears at least once.
+- **Fix the Actions version comments in `copilot-setup-steps.yml`** [S]: the pinned SHAs carry `# v4` and `# v5` comments but resolve to `# v6`, breaking the human-readable pin contract that Dependabot review relies on.
 
-## Known issues
+## v1.9.0: Localisation and Scale
+
+### High value
+
+- **Translatable category labels** (`const.py` `CATEGORY_LABELS`, platform files) [M]: entity name templates already use `_attr_translation_key`, but the `{category}` placeholder is filled from an English-only dict, leaving entity names half-translated for non-English Home Assistant. Give each category its own `translation_key` so the label resolves through the translation layer.
+- **Self-healing system-log key map** (`models.py`, `const.py`, `diagnostics.py`) [S]: `SYSTEM_LOG_KEY_TO_CATEGORY` is intentionally incomplete, and the `SYSTEM_LOG_CATEGORY_FALLBACK` enum keeps unmapped events in roughly the right category, but there is no user-visible signal when a key is unclassified, so the map only improves via users who dig through DEBUG logs. Add an "uncategorised" counter or a diagnostics field listing recently seen unmapped keys so every install passively contributes the keys that surface in the wild.
+
+### Medium value
+
+- **Severity filtering for noisy categories** (config and options flow, coordinator) [M]: noisy categories are blunt on/off toggles today. A min-severity option (or a consistently surfaced severity attribute users can key automations off) makes them usable instead of muted on day one.
+- **Clamp the watermark fetch window** (`coordinator.py`) [S-M]: `since = min(watermarks)` lets the fetch window grow without bound when one category is rarely cleared, re-paginating the full range every poll and risking recent alarms being pushed past `MAX_SYSTEM_LOG_PAGES`. Clamp to `max(min(watermarks), now - lookback_cap)` and log when the page cap is hit.
+- **Probe backoff for the system-log endpoint** (`unifi_client.probe_system_log_endpoint`) [S]: a persistent non-404 failure re-probes on every poll forever, doubling the request rate against a misbehaving endpoint. Add a transient-failure counter that caches "legacy" after a threshold, with periodic re-probe.
+- **Localise remaining inline strings** (`sensor.py` "No alerts yet", `strings.json`) [S]: move the code-level state string to a translation key, and replace emoji and em-dash-carried meaning in config descriptions with plain-text prefixes, so meaning survives translation and screen readers.
+- **Multi-controller docs clarity** (README) [S]: document the multi-controller and multi-site pattern and clarify the `site` field. Defer full per-category site config (parked below, low value).
+
+### Low value
+
+- **Unicode and large-volume round-trip tests** (`tests/`) [S]: assert that non-ASCII alert text (emoji, CJK, RTL) and 300-character strings survive parse -> store -> restore and 255-character truncation, and that a roughly 500-alert batch keeps counts and watermark filtering deterministic.
+- **Coverage measurement in CI** (`Makefile`, CI) [S]: add `--cov` reporting (not necessarily a gate) so thin-test regressions become visible.
+- **Pin dev dependencies** (`requirements-dev.txt`) [M]: the unpinned `homeassistant`, `ruff`, `mypy`, and `pytest` floats make CI and local `make check` non-reproducible. Maintainer call on whether a hashed constraints file is warranted without enabling the pip Dependabot ecosystem.
+
+### Process
+
+- **Adopt GitHub Issues for the backlog** [M]: move outstanding items from this file into tracked issues so each carries a stable identifier that can be referenced in PRs and release notes, instead of local shorthand. Target landing this during the v1.9 cycle.
+
+## Backlog: not yet scheduled
+
+- **HACS default catalogue submission**: open the PR to <https://github.com/hacs/default> once the v1.x items and the v2.0 gates above are closed.
+- **Tier 2 docs linter (markdownlint)**: layer `markdownlint-cli2` on top of `scripts/validate_docs.py` to catch structural issues (heading-level skips, mixed list markers, bare URLs, trailing whitespace) that a regex linter cannot. Adds a Node dependency; commit a `.markdownlint.json` config tuned for this repo. Run it from CI's `lint` job and the pre-push hook alongside the existing prose check. Low user value; revisit only if doc structure regressions recur.
+
+## Known issues: intentional, do not action
 
 - **`_device_info()` duplication**: duplicated identically across `binary_sensor.py`, `sensor.py`, `event.py`, `button.py`. Intentional for platform isolation; extract to a shared `entity_base.py` only if it becomes a maintenance burden.

--- a/docs/UNIFI.md
+++ b/docs/UNIFI.md
@@ -75,7 +75,7 @@ X-API-Key: your-key-here
 >
 > **If UniFi changes the endpoint again:** add the new path to the head of `alarm_paths` in `unifi_client.py::fetch_alarms`, update the table above, and add a fallback test in `tests/unit/test_unifi_client.py` (see `TestFetchAlarms::test_falls_back_*`).
 
-Default site name is `default`. Multi-site is configurable via `CONF_SITE` per entry; per-category site selection is not implemented (see `docs/TODO.md`).
+Default site name is `default`. Multi-site is configurable via `CONF_SITE` per entry; per-category site selection is not implemented (see `docs/ROADMAP.md`, Deferred).
 
 ### Response structure
 
@@ -296,7 +296,7 @@ The full mapping from key to category is in `UNIFI_KEY_TO_CATEGORY` in `const.py
 
 ## Expanding the key map
 
-When a user reports an alert that isn't being categorised (look for the DEBUG log from `unifi_client.py`), add the key to `UNIFI_KEY_TO_CATEGORY` in `const.py`. If the key belongs to a new category type not yet in `ALL_CATEGORIES`, that's a larger change; see `docs/TODO.md`.
+When a user reports an alert that isn't being categorised (look for the DEBUG log from `unifi_client.py`), add the key to `UNIFI_KEY_TO_CATEGORY` in `const.py`. If the key belongs to a new category type not yet in `ALL_CATEGORIES`, that's a larger change; track it as a GitHub Issue.
 
 Guidelines:
 
@@ -308,5 +308,5 @@ Guidelines:
 
 - **SSL certificates**: UniFi OS consoles ship with self-signed certificates by default. `verify_ssl` defaults to `True` (secure). Users with self-signed certs must disable verification via the config flow.
 - **Site names**: some controllers use `default`; others use the site ID (a hex string). `CONF_SITE` per entry covers this. Per-category site selection is not implemented.
-- **Timestamp format**: the `datetime` field in legacy alarm records is usually ISO 8601 but some controllers emit epoch milliseconds. `UniFiAlert.from_api_alarm()` falls back to `datetime.now(UTC)` when neither parses; epoch-ms parsing is on the v1.6.0 backlog (see `docs/TODO.md`). The v2 `system-log` API always uses epoch milliseconds in the `timestamp` field.
+- **Timestamp format**: the `datetime` field in legacy alarm records is usually ISO 8601 but some controllers emit epoch milliseconds. `UniFiAlert.from_api_alarm()` falls back to `datetime.now(UTC)` when neither parses. The v2 `system-log` API always uses epoch milliseconds in the `timestamp` field.
 - **`/list/alarm` 3000-record cap**: the legacy alarm endpoint returns at most ~3000 records sorted oldest-first. No query parameter overrides this. On controllers generating more than ~33 alarms per day, recent events are not present in the polled response and `open_count` will always read 0 via the legacy path. The v2 `system-log/all` endpoint (see above) is the correct fix; it supports timestamp-range filtering and pagination. Field-confirmed on Network 10.3.58. Full investigation in `docs/research/alert-endpoints.md`.

--- a/scripts/seed_issues.py
+++ b/scripts/seed_issues.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""Seed the GitHub Issues backlog for unifi_alerts.
+
+This is the one-time migration tool that moves the v1.8 / v1.9 / v2.0 backlog
+out of `docs/TODO.md` and into GitHub Issues, where work is tracked from now
+on. It is safe to re-run: labels, milestones, and issues that already exist are
+skipped (issues are matched by exact title), so the script doubles as a way to
+top up the backlog when new items are added to the ISSUES list below.
+
+Requires the `gh` CLI, authenticated against this repository (run from a clone
+of the repo, or pass --repo OWNER/NAME).
+
+Usage:
+    python3 scripts/seed_issues.py             # create labels, milestones, issues
+    python3 scripts/seed_issues.py --dry-run   # print the plan, change nothing
+    python3 scripts/seed_issues.py --repo PHeonix25/unifi_alerts
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+# --------------------------------------------------------------------------- #
+# Taxonomy
+# --------------------------------------------------------------------------- #
+
+# Labels referenced by the issues below. The category labels mirror those in
+# `.github/release.yml` so auto-generated release notes group correctly; the
+# `size:` / `priority:` / `v2.0-gate` labels are work-tracking metadata.
+LABELS: list[tuple[str, str, str]] = [
+    # category (kept in lockstep with .github/release.yml and setup-labels.sh)
+    ("security", "b60205", "Security-related changes (vulnerabilities, hardening)"),
+    ("feat", "a2eeef", "New feature or capability"),
+    ("enhancement", "a2eeef", "New feature or capability (GitHub default alias)"),
+    ("fix", "d73a4a", "Bug fix or correctness change"),
+    ("bug", "d73a4a", "Confirmed defect (GitHub default alias)"),
+    ("tests", "bfdadc", "Test changes (additions, refactors, fixtures)"),
+    ("ci", "ededed", "CI, build, tooling, or release-pipeline changes"),
+    ("documentation", "0075ca", "Documentation and process changes"),
+    ("github-actions", "000000", "GitHub Actions workflow or pinned-action changes"),
+    ("dependencies", "0366d6", "Dependency bumps and pinning"),
+    # work-tracking metadata
+    ("size: S", "c2e0c6", "Small: a single-sitting change"),
+    ("size: M", "fef2c0", "Medium: a focused piece of work"),
+    ("size: L", "f9d0c4", "Large: may need decomposition"),
+    ("priority: high", "d93f0b", "Do first within its milestone"),
+    ("priority: medium", "fbca04", "Standard priority"),
+    ("priority: low", "0e8a16", "Guardrail or nice-to-have"),
+    ("v2.0-gate", "5319e7", "Prerequisite for the HACS default catalogue submission"),
+]
+
+# Milestones. The base version matches the next planned release per CLAUDE.md.
+MILESTONES: list[tuple[str, str]] = [
+    (
+        "v1.8.0",
+        "Trust and Hardening: correctness, privacy, security, and "
+        "onboarding-confidence work on the road to v2.0.",
+    ),
+    (
+        "v1.9.0",
+        "Localisation and Scale: i18n readiness, efficiency under load, "
+        "and capability work on the road to v2.0.",
+    ),
+    (
+        "v2.0.0",
+        "HACS default catalogue submission. Gated on the v2.0-gate issues "
+        "carried in the v1.8.0 and v1.9.0 milestones.",
+    ),
+]
+
+
+@dataclass
+class Issue:
+    """A single backlog item destined for GitHub Issues."""
+
+    title: str
+    milestone: str
+    labels: list[str]
+    body: str = field(default="")
+
+
+# --------------------------------------------------------------------------- #
+# Backlog (source of truth, ordered by milestone then priority)
+# --------------------------------------------------------------------------- #
+
+ISSUES: list[Issue] = [
+    # ----- v1.8.0: High value ------------------------------------------------
+    Issue(
+        title="Stop persisting raw alert payloads to disk",
+        milestone="v1.8.0",
+        labels=["security", "size: S", "priority: high", "v2.0-gate"],
+        body=(
+            "`UniFiAlert.to_dict()` (`models.py`) does `asdict(self)`, which "
+            "serialises the entire `raw` payload (client MACs, IPs, hostnames) "
+            "into `.storage` via the coordinator's `Store`. That is the one "
+            "place those fields are not already redacted, and a non-JSON value "
+            "in `raw` can break `Store.async_save`.\n\n"
+            "**Approach:** persist an explicit scalar field list "
+            "(`message`, `received_at`, `key`, `device_name`, `site`, "
+            "`severity`); default `raw={}` in `from_dict`.\n\n"
+            "**Acceptance**\n"
+            "- [ ] `to_dict()` no longer serialises `raw`\n"
+            "- [ ] Restore path still rebuilds `last_alert` from the scalar fields\n"
+            "- [ ] Test asserts a non-JSON value in `raw` cannot break persistence\n"
+            "- [ ] CHANGELOG `[Unreleased]` updated (privacy)"
+        ),
+    ),
+    Issue(
+        title="Fix stale alert_received replay on reload",
+        milestone="v1.8.0",
+        labels=["fix", "size: S", "priority: high"],
+        body=(
+            "`UniFiAlertEventEntity._last_seen_count` resets to 0 in `__init__` "
+            "(`event.py`), so the first coordinator update after any options "
+            "save (which triggers a full reload) sees a restored non-zero "
+            "`alert_count` and re-fires `alert_received` for a stale alert into "
+            "users' automations.\n\n"
+            "**Approach:** seed `_last_seen_count` from the restored "
+            "`state.alert_count` in `async_added_to_hass`, before the first "
+            "`_handle_coordinator_update`.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Reload after an options change does not fire a fresh event\n"
+            "- [ ] A genuine new push still fires exactly once\n"
+            "- [ ] Regression test covers the reload sequence"
+        ),
+    ),
+    Issue(
+        title="Add a per-category webhook health signal",
+        milestone="v1.8.0",
+        labels=["feat", "size: M", "priority: high"],
+        body=(
+            "After pasting webhook URLs into Alarm Manager, a user has no way "
+            "to know setup worked until a real alert fires. This is the biggest "
+            "source of 'it does not work' reports for a push integration.\n\n"
+            "**Approach:** expose a per-category 'last webhook received' "
+            "timestamp (attribute and diagnostics) plus a healthy/stale "
+            "indicator. The webhook handler already timestamps receipt.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Last-received timestamp surfaced per category\n"
+            "- [ ] A never-received / stale category is visibly distinguishable\n"
+            "- [ ] Documented in the README setup section\n"
+            "- [ ] CHANGELOG `[Unreleased]` updated"
+        ),
+    ),
+    Issue(
+        title="Coalesce watermark persistence and surface failures",
+        milestone="v1.8.0",
+        labels=["fix", "size: S", "priority: high"],
+        body=(
+            "The per-push fire-and-forget `async_save` (`coordinator.py`) has a "
+            "lost-update hazard under bursts and no error path, so a failed "
+            "persist dies silently.\n\n"
+            "**Approach:** route writes through `Store.async_delay_save`, and "
+            "run background tasks through a shared helper whose done-callback "
+            "logs any non-`CancelledError` exception.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Bursted pushes coalesce to a single durable write\n"
+            "- [ ] A persist exception is logged, not swallowed\n"
+            "- [ ] Test covers the save-raises path"
+        ),
+    ),
+    # ----- v1.8.0: Medium value ---------------------------------------------
+    Issue(
+        title="Consolidate alert classification into a single seam",
+        milestone="v1.8.0",
+        labels=["size: M", "priority: medium"],
+        body=(
+            "Two parallel category resolvers exist: legacy prefix-match in "
+            "`unifi_client._classify`, and exact-key plus enum fallback in "
+            "`models.from_system_log_event`, each with its own unknown-key "
+            "warning path. The process-global `_unknown_system_log_keys` set is "
+            "shared mutable state.\n\n"
+            "**Approach:** collapse the taxonomy into one location so both "
+            "paths share resolution and warning dedup; remove the module-global "
+            "set in favour of instance/coordinator-scoped state.\n\n"
+            "**Acceptance**\n"
+            "- [ ] One classification entry point\n"
+            "- [ ] No process-global mutable warning set\n"
+            "- [ ] Existing classification tests still pass"
+        ),
+    ),
+    Issue(
+        title="Extract controller auth into a dedicated seam",
+        milestone="v1.8.0",
+        labels=["size: L", "priority: medium"],
+        body=(
+            "In `unifi_client.py`, auth-method autodetect, session state, "
+            "login, key verification, and header construction are interleaved "
+            "with transport, version probing, pagination, and parsing in one "
+            "class.\n\n"
+            "**Approach:** pull the auth concern into its own strategy so a "
+            "future third auth method or token refresh slots in cleanly and "
+            "auth becomes unit-testable in isolation. Large item; decompose if "
+            "needed.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Auth logic lives behind a single seam\n"
+            "- [ ] Auth is unit-testable without the full client\n"
+            "- [ ] Coordinator re-auth coupling still works"
+        ),
+    ),
+    Issue(
+        title="Add an end-to-end secret-rotation test",
+        milestone="v1.8.0",
+        labels=["tests", "size: M", "priority: medium"],
+        body=(
+            "Rotation is unit-tested in pieces but nothing proves the full "
+            "cycle, and rotation is a security boundary.\n\n"
+            "**Approach:** in `tests/integration/`, drive options finish -> "
+            "entry update -> reload -> webhook re-register; assert the old "
+            "token returns 401 and the new token returns 200 after reload.\n\n"
+            "**Acceptance**\n"
+            "- [ ] One integration test covers the whole rotation cycle\n"
+            "- [ ] Old token rejected, new token accepted post-reload"
+        ),
+    ),
+    Issue(
+        title="Catch InvalidAuthError on the re-auth retry",
+        milestone="v1.8.0",
+        labels=["fix", "size: S", "priority: medium"],
+        body=(
+            "After a 401 triggers re-authentication, the retried fetch "
+            "(`coordinator.py`) only catches `CannotConnectError`; a second "
+            "`InvalidAuthError` escapes `_async_update_data` as a generic error "
+            "instead of raising `ConfigEntryAuthFailed` to trigger HA "
+            "re-auth.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Retry that still 401s raises `ConfigEntryAuthFailed`\n"
+            "- [ ] Coordinator test covers 're-auth succeeds, retry still 401'"
+        ),
+    ),
+    Issue(
+        title="Harden _render_message_raw substitution",
+        milestone="v1.8.0",
+        labels=["security", "size: S", "priority: medium"],
+        body=(
+            "Sequential `str.replace` over controller-supplied `parameters` "
+            "(`models.py`) is order-dependent and lets a parameter value that "
+            "itself contains a `{TOKEN}` be re-substituted.\n\n"
+            "**Approach:** switch to single-pass substitution; add tests for "
+            "embedded-token, overlapping-prefix (`{IP}` vs `{IP_DST}`), and "
+            "non-string parameter values.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Substitution is single-pass and order-independent\n"
+            "- [ ] Tests cover the three hostile-input cases"
+        ),
+    ),
+    Issue(
+        title="Define the empty or malformed webhook contract",
+        milestone="v1.8.0",
+        labels=["fix", "size: S", "priority: medium"],
+        body=(
+            "An authenticated POST with an empty or unrecognisable body "
+            "currently flips the binary sensor to 'Problem' and fires an event "
+            "(`webhook_handler.py`, `coordinator.push_alert`).\n\n"
+            "**Approach (decide during implementation):** either skip "
+            "`push_callback` when no recognisable fields are present, or keep "
+            "the behaviour. Either way, lock the chosen contract in with a "
+            "test.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Contract decided and documented in the code\n"
+            "- [ ] Test asserts the behaviour for `{}` and a no-field body"
+        ),
+    ),
+    Issue(
+        title="Clarify retention and data handling",
+        milestone="v1.8.0",
+        labels=["documentation", "security", "size: M", "priority: medium", "v2.0-gate"],
+        body=(
+            "`clear()` advances the watermark but leaves `last_alert` (message, "
+            "device name) in state and on disk, so a 'cleared' category still "
+            "retains identifying content. There is no user-facing statement of "
+            "what is stored or for how long.\n\n"
+            "**Approach:** clear `last_alert` on `clear()` (or document that "
+            "clearing is acknowledgement, not deletion); add a README 'Data "
+            "handled and retention' section covering what is stored, where, and "
+            "how to purge it.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Clear semantics defined and implemented\n"
+            "- [ ] README documents stored fields, location, and purge path"
+        ),
+    ),
+    Issue(
+        title="Complete the Alarm Manager onboarding docs",
+        milestone="v1.8.0",
+        labels=["documentation", "size: S", "priority: medium", "v2.0-gate"],
+        body=(
+            "The hardest, most error-prone half of setup (configuring Alarm "
+            "Manager) has the thinnest docs, and the 'copy URLs before clicking "
+            "Submit' ordering is a footgun.\n\n"
+            "**Approach:** add a per-category trigger-mapping table and "
+            "annotated screenshots; remove the footgun by re-showing the URLs "
+            "after the entry is created (the options flow already supports "
+            "this).\n\n"
+            "**Acceptance**\n"
+            "- [ ] Per-category trigger table in the README\n"
+            "- [ ] URLs viewable after entry creation, not only before Submit"
+        ),
+    ),
+    # ----- v1.8.0: Low value / guardrails -----------------------------------
+    Issue(
+        title="Disable redirect-following on authenticated outbound calls",
+        milestone="v1.8.0",
+        labels=["security", "size: S", "priority: low"],
+        body=(
+            "Authenticated requests in `unifi_client.py` use aiohttp's default "
+            "`allow_redirects=True`, so the `X-API-Key` header and session "
+            "cookie can ride a controller-issued redirect to another host.\n\n"
+            "**Approach:** pass `allow_redirects=False` and treat a 3xx as an "
+            "error on the authenticated call sites.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Authed calls do not follow redirects\n"
+            "- [ ] A 3xx is surfaced as an error"
+        ),
+    ),
+    Issue(
+        title="Length-validate inbound key, severity, device_name",
+        milestone="v1.8.0",
+        labels=["security", "size: S", "priority: low"],
+        body=(
+            "`models.from_webhook_payload` truncates `message` but passes "
+            "`key`, `severity`, and `device_name` through untruncated, so a "
+            "token-bearing caller can push unbounded values into state and "
+            "logs.\n\n"
+            "**Acceptance**\n"
+            "- [ ] All three fields truncated like `message`\n"
+            "- [ ] Test covers oversized inputs"
+        ),
+    ),
+    Issue(
+        title="Document the diagnostics content exclusion",
+        milestone="v1.8.0",
+        labels=["documentation", "size: S", "priority: low"],
+        body=(
+            "Diagnostics deliberately excludes per-category alert content "
+            "(`message`, `device_name`, `raw`). Add a comment in "
+            "`diagnostics.py` recording that this must stay excluded; if alert "
+            "detail is ever added, route it through a field redactor.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Guardrail comment in place"
+        ),
+    ),
+    Issue(
+        title="Optional host guard on the controller URL",
+        milestone="v1.8.0",
+        labels=["security", "size: S", "priority: low"],
+        body=(
+            "URL validation in `config_flow.py` is scheme-only. Optionally "
+            "reject loopback and link-local hosts, or document that the URL is "
+            "fully trusted under the local-admin model. Low-priority "
+            "guardrail.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Decision made and either guard added or trust documented"
+        ),
+    ),
+    Issue(
+        title="Reconcile docs/REPO_LAYOUT.md with the file tree",
+        milestone="v1.8.0",
+        labels=["documentation", "size: S", "priority: low"],
+        body=(
+            "`docs/REPO_LAYOUT.md` (the per-file source of truth) omits "
+            "`services.py`, `services.yaml`, `scripts/run_lint.py`, and "
+            "`scripts/run_typecheck.py`.\n\n"
+            "**Approach:** add the missing rows; optionally add a "
+            "`scripts/validate_docs.py` check that every `*.py` under "
+            "`custom_components/` and `scripts/` appears at least once.\n\n"
+            "**Acceptance**\n"
+            "- [ ] All four files documented\n"
+            "- [ ] Optional drift check wired into validate_docs"
+        ),
+    ),
+    Issue(
+        title="Fix the Actions version comments in copilot-setup-steps.yml",
+        milestone="v1.8.0",
+        labels=["ci", "github-actions", "size: S", "priority: low"],
+        body=(
+            "The pinned SHAs in `.github/workflows/copilot-setup-steps.yml` "
+            "carry `# v4` and `# v5` comments but resolve to `# v6`, breaking "
+            "the human-readable pin contract Dependabot review relies on.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Comments match the resolved tags for the pinned SHAs"
+        ),
+    ),
+    # ----- v1.9.0: High value -----------------------------------------------
+    Issue(
+        title="Make category labels translatable",
+        milestone="v1.9.0",
+        labels=["feat", "size: M", "priority: high"],
+        body=(
+            "Entity name templates already use `_attr_translation_key`, but the "
+            "`{category}` placeholder is filled from the English-only "
+            "`CATEGORY_LABELS` dict (`const.py`), leaving entity names "
+            "half-translated for non-English Home Assistant.\n\n"
+            "**Approach:** give each category its own `translation_key` so the "
+            "label resolves through the translation layer.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Category names resolve via translations\n"
+            "- [ ] strings.json / translations drift check passes"
+        ),
+    ),
+    Issue(
+        title="Make the system-log key map self-healing",
+        milestone="v1.9.0",
+        labels=["feat", "size: S", "priority: high"],
+        body=(
+            "`SYSTEM_LOG_KEY_TO_CATEGORY` is intentionally incomplete and the "
+            "fallback enum keeps unmapped events roughly categorised, but there "
+            "is no user-visible signal when a key is unclassified, so the map "
+            "only improves via users who dig through DEBUG logs.\n\n"
+            "**Approach:** add an 'uncategorised' counter or a diagnostics "
+            "field listing recently seen unmapped keys so every install "
+            "passively surfaces the keys to add.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Unclassified keys are visible without DEBUG logging\n"
+            "- [ ] Documented how to report them"
+        ),
+    ),
+    # ----- v1.9.0: Medium value ---------------------------------------------
+    Issue(
+        title="Add severity filtering for noisy categories",
+        milestone="v1.9.0",
+        labels=["feat", "size: M", "priority: medium"],
+        body=(
+            "Noisy categories are blunt on/off toggles today. A min-severity "
+            "option (or a consistently surfaced severity attribute automations "
+            "can key off) makes them usable instead of muted on day one.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Severity is filterable at the integration level\n"
+            "- [ ] Documented; CHANGELOG `[Unreleased]` updated"
+        ),
+    ),
+    Issue(
+        title="Clamp the watermark fetch window",
+        milestone="v1.9.0",
+        labels=["fix", "size: M", "priority: medium"],
+        body=(
+            "`since = min(watermarks)` (`coordinator.py`) lets the fetch window "
+            "grow without bound when one category is rarely cleared, "
+            "re-paginating the full range every poll and risking recent alarms "
+            "being pushed past `MAX_SYSTEM_LOG_PAGES`.\n\n"
+            "**Approach:** clamp to `max(min(watermarks), now - lookback_cap)` "
+            "and log when the page cap is hit.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Fetch window is bounded under skewed clear-rates\n"
+            "- [ ] Page-cap hit is logged"
+        ),
+    ),
+    Issue(
+        title="Add probe backoff for the system-log endpoint",
+        milestone="v1.9.0",
+        labels=["fix", "size: S", "priority: medium"],
+        body=(
+            "A persistent non-404 failure makes "
+            "`unifi_client.probe_system_log_endpoint` re-probe on every poll "
+            "forever, doubling the request rate against a misbehaving "
+            "endpoint.\n\n"
+            "**Approach:** add a transient-failure counter that caches 'legacy' "
+            "after a threshold, with periodic re-probe.\n\n"
+            "**Acceptance**\n"
+            "- [ ] No permanent re-probe loop on persistent failure\n"
+            "- [ ] Capable controllers still detected"
+        ),
+    ),
+    Issue(
+        title="Localise the remaining inline strings",
+        milestone="v1.9.0",
+        labels=["enhancement", "size: S", "priority: medium"],
+        body=(
+            "`'No alerts yet'` (`sensor.py`) is returned in code with no "
+            "translation key, and some config descriptions carry meaning via "
+            "emoji and em-dashes.\n\n"
+            "**Approach:** move the state string to a translation key; replace "
+            "emoji/em-dash-carried meaning with plain-text prefixes so meaning "
+            "survives translation and screen readers.\n\n"
+            "**Acceptance**\n"
+            "- [ ] No user-facing English string hard-coded in platform files\n"
+            "- [ ] Meaning does not depend on an emoji glyph"
+        ),
+    ),
+    Issue(
+        title="Clarify the multi-controller setup in the docs",
+        milestone="v1.9.0",
+        labels=["documentation", "size: S", "priority: medium"],
+        body=(
+            "Multi-entry is supported and a `site` field exists, but the "
+            "multi-controller / multi-site story is undocumented and the `site` "
+            "field's role is unclear.\n\n"
+            "**Approach:** document the pattern and clarify the field. Defer "
+            "full per-category site config (parked, low value).\n\n"
+            "**Acceptance**\n"
+            "- [ ] README explains multi-controller setup and the site field"
+        ),
+    ),
+    # ----- v1.9.0: Low value ------------------------------------------------
+    Issue(
+        title="Add unicode and large-volume round-trip tests",
+        milestone="v1.9.0",
+        labels=["tests", "size: S", "priority: low"],
+        body=(
+            "Assert non-ASCII alert text (emoji, CJK, RTL) and 300-character "
+            "strings survive parse -> store -> restore and 255-character "
+            "truncation, and that a roughly 500-alert batch keeps counts and "
+            "watermark filtering deterministic.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Unicode round-trip test added\n"
+            "- [ ] Large-batch determinism test added"
+        ),
+    ),
+    Issue(
+        title="Add coverage measurement in CI",
+        milestone="v1.9.0",
+        labels=["ci", "size: S", "priority: low"],
+        body=(
+            "There is no `--cov` reporting, so thin-test regressions are "
+            "invisible until they bite. Add coverage reporting (not "
+            "necessarily a gate).\n\n"
+            "**Acceptance**\n"
+            "- [ ] Coverage reported in the test job"
+        ),
+    ),
+    Issue(
+        title="Pin dev dependencies for reproducible CI",
+        milestone="v1.9.0",
+        labels=["ci", "dependencies", "size: M", "priority: low"],
+        body=(
+            "`requirements-dev.txt` floats `homeassistant`, `ruff`, `mypy`, and "
+            "`pytest`, making CI and local `make check` non-reproducible.\n\n"
+            "**Approach (maintainer call):** decide whether a hashed "
+            "constraints file is warranted without enabling the pip Dependabot "
+            "ecosystem.\n\n"
+            "**Acceptance**\n"
+            "- [ ] Decision recorded; pinning added if adopted"
+        ),
+    ),
+    # ----- v2.0.0 -----------------------------------------------------------
+    Issue(
+        title="Submit the integration to the HACS default catalogue",
+        milestone="v2.0.0",
+        labels=["documentation", "size: M", "priority: high"],
+        body=(
+            "Umbrella issue for the HACS default submission. Gated on all "
+            "`v2.0-gate` issues (raw-payload persistence, retention statement, "
+            "Alarm Manager onboarding docs) and the localisation-maturity work "
+            "being complete.\n\n"
+            "**Acceptance**\n"
+            "- [ ] All `v2.0-gate` issues closed\n"
+            "- [ ] PR opened against https://github.com/hacs/default"
+        ),
+    ),
+]
+
+
+# --------------------------------------------------------------------------- #
+# gh plumbing
+# --------------------------------------------------------------------------- #
+
+
+def run_gh(args: list[str], *, dry_run: bool = False, capture: bool = False) -> str:
+    """Run a `gh` command. Returns stdout when capture=True, else ''."""
+    printable = "gh " + " ".join(args)
+    if dry_run and not capture:
+        print(f"  would run: {printable}")
+        return ""
+    result = subprocess.run(
+        ["gh", *args],
+        check=True,
+        text=True,
+        capture_output=capture,
+    )
+    return result.stdout if capture else ""
+
+
+def detect_repo() -> str:
+    """Return OWNER/NAME for the current repo via gh."""
+    out = run_gh(["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"], capture=True)
+    return out.strip()
+
+
+def existing_labels(repo: str) -> set[str]:
+    out = run_gh(["label", "list", "--repo", repo, "--limit", "300", "--json", "name"], capture=True)
+    return {item["name"] for item in json.loads(out or "[]")}
+
+
+def existing_milestones(repo: str) -> set[str]:
+    out = run_gh(["api", f"repos/{repo}/milestones", "--paginate", "--jq", ".[].title"], capture=True)
+    return {line for line in out.splitlines() if line}
+
+
+def existing_issue_titles(repo: str) -> set[str]:
+    out = run_gh(
+        ["issue", "list", "--repo", repo, "--state", "all", "--limit", "400", "--json", "title"],
+        capture=True,
+    )
+    return {item["title"] for item in json.loads(out or "[]")}
+
+
+def ensure_labels(repo: str, present: set[str], dry_run: bool) -> None:
+    print("Labels:")
+    for name, color, desc in LABELS:
+        if name in present:
+            print(f"  skip  {name}")
+            continue
+        run_gh(
+            ["label", "create", name, "--repo", repo, "--color", color, "--description", desc],
+            dry_run=dry_run,
+        )
+        print(f"  ok    {name}")
+
+
+def ensure_milestones(repo: str, present: set[str], dry_run: bool) -> None:
+    print("Milestones:")
+    for title, desc in MILESTONES:
+        if title in present:
+            print(f"  skip  {title}")
+            continue
+        run_gh(
+            ["api", f"repos/{repo}/milestones", "-f", f"title={title}", "-f", f"description={desc}"],
+            dry_run=dry_run,
+        )
+        print(f"  ok    {title}")
+
+
+def ensure_issues(repo: str, present: set[str], dry_run: bool) -> None:
+    print("Issues:")
+    for issue in ISSUES:
+        if issue.title in present:
+            print(f"  skip  {issue.title}")
+            continue
+        args = [
+            "issue", "create", "--repo", repo,
+            "--title", issue.title,
+            "--body", issue.body,
+            "--milestone", issue.milestone,
+        ]
+        for label in issue.labels:
+            args += ["--label", label]
+        run_gh(args, dry_run=dry_run)
+        print(f"  ok    [{issue.milestone}] {issue.title}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", help="OWNER/NAME (default: detect via gh)")
+    parser.add_argument("--dry-run", action="store_true", help="print the plan, change nothing")
+    parsed = parser.parse_args()
+
+    if subprocess.run(["gh", "--version"], capture_output=True).returncode != 0:
+        print("error: the `gh` CLI is required and must be authenticated.", file=sys.stderr)
+        return 1
+
+    repo = parsed.repo or detect_repo()
+    print(f"Repository: {repo}{'  (dry run)' if parsed.dry_run else ''}\n")
+
+    ensure_labels(repo, existing_labels(repo), parsed.dry_run)
+    print()
+    ensure_milestones(repo, existing_milestones(repo), parsed.dry_run)
+    print()
+    ensure_issues(repo, existing_issue_titles(repo), parsed.dry_run)
+    print("\nDone.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Moves the v1.8 / v1.9 / v2.0 backlog out of `docs/TODO.md` and into **GitHub Issues**, which become the source of truth for outstanding work. The backlog itself was distilled from a six-lens review of the codebase (security, quality, architecture, technical debt, product, responsible-engineering).

## Why

`docs/TODO.md` required manual "delete the line on ship" discipline and could not carry stable identifiers, priority, or size. Issues give us milestones, labels, and `Closes #NN` auto-close, and set us up to use the tracker in earnest from v1.9.

## Changes

- **`scripts/seed_issues.py`** (new): an **idempotent** `gh`-based seeder. Creates the `size: *` / `priority: *` / category / `v2.0-gate` labels, the `v1.8.0` / `v1.9.0` / `v2.0.0` milestones, and the ~30 backlog issues. Safe to re-run (matches issues by title); doubles as the way to bulk-add future items. `--dry-run` prints the plan.
- **`.github/ISSUE_TEMPLATE/task.yml`** (new): a generic Task template for engineering work that is neither a user-facing bug nor a feature (hardening, refactor, tests, docs, CI, tech debt).
- **`docs/TODO.md`**: converted from the backlog list to a **pointer** that documents the label/milestone taxonomy and the file/close workflow. The intentional `_device_info()` duplication note stays here (deliberately not an issue).
- **`docs/ROADMAP.md`**: themes retained; item-level detail now points at the milestones index instead of TODO.md.
- **`CLAUDE.md` / `AGENTS.md`**: rewired from "delete the TODO line" to "close the issue via a PR", including how to pick up work by milestone + priority and how to file new work.
- **`docs/UNIFI.md`**, **`feature_request.yml`**: re-pointed away from `docs/TODO.md` (one doubly-stale "v1.6.0 backlog" reference dropped).

## How the taxonomy maps

Milestone (`v1.8.0` / `v1.9.0` / `v2.0.0`) + category label (mirrors `.github/release.yml`) + `size: S|M|L` + `priority: high|medium|low`, with `v2.0-gate` flagging HACS-default prerequisites that live in earlier milestones.

## Action required (yours)

There is no MCP tool to create labels or milestones, so the actual population is run locally once:

```bash
python3 scripts/seed_issues.py --dry-run   # review the plan
python3 scripts/seed_issues.py             # create labels, milestones, issues
```

(Needs the `gh` CLI, authenticated against this repo.)

## Notes

- Doc/tooling-only change: `make doc-check` passes; CI lint/type-check scope is `custom_components/` + `tests/`, untouched here.
- Supersedes the interim "seed backlog into TODO.md" state from the first commit on this branch; the net result is the Issues migration.

https://claude.ai/code/session_01HjAaLCw5ahie4j6CTZx9Np