### PR TITLE
docs: align agent instructions with GitHub Issues ways of working

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,7 @@ make check   # lint + typecheck + validate + all tests
 
 ## Checklist
 
+- [ ] Linked the issue this PR resolves (`Closes #NN` in the description), if one exists
 - [ ] `make check` passes locally
 - [ ] `CHANGELOG.md` `[Unreleased]` updated (user-visible changes only; skip for internal/ci/docs)
 - [ ] PR title starts with a Conventional Commit prefix (`feat:`, `fix:`, `docs:`, `ci:`, `tests:`, `security:`, `chore:`, `refactor:`)

--- a/.github/agents/product-mgr.agent.md
+++ b/.github/agents/product-mgr.agent.md
@@ -165,6 +165,19 @@ For every feature request, create:
 2. **GitHub Issues** using the templates above
 3. **User Journey Map**: `docs/product/[feature-name]-journey.md`
 
+## Filing findings as GitHub Issues (this repo)
+
+Outstanding work here is tracked in **GitHub Issues**, not in `docs/TODO.md` (now a taxonomy pointer).
+
+**Repo-specific override:** ignore the generic `component` / `phase` / `team` label scheme in the templates above; this repo uses the taxonomy below. Likewise, the "every code change MUST have an issue" rule is softened here to a **confirm-first** gate.
+
+1. **Confirm before filing.** Frame the opportunity (named user, problem, measurable outcome) and ask the maintainer whether to raise an issue. Never open issues unprompted or in bulk.
+2. **Search existing issues first** to avoid duplicates.
+3. On approval, file with the **Task** template (or Feature where it fits) and apply one category label (`security`, `fix`, `feat`, `tests`, `ci`, `documentation`), one `size: S|M|L`, one `priority: high|medium|low`, and the target milestone (`v1.8.0`, `v1.9.0`, `v2.0.0`). Add `v2.0-gate` if it blocks the HACS default submission.
+4. Reference the issue from the resolving PR (`Closes #NN`).
+
+Taxonomy: `docs/TODO.md`. Bulk seeding: `scripts/seed_issues.py`.
+
 ## Anti-Patterns
 
 - Writing user stories with "the user" as the persona.

--- a/.github/agents/qe-lead.agent.md
+++ b/.github/agents/qe-lead.agent.md
@@ -1,7 +1,7 @@
 ---
 name: 'Quality Lead'
 description: 'Meticulous QA subagent for test planning, bug hunting, edge-case analysis, and implementation verification.'
-tools: ['vscode', 'execute', 'read', 'agent', 'edit', 'search', 'web', 'todo']
+tools: ['vscode', 'execute', 'read', 'agent', 'edit', 'search', 'web', 'todo', 'search_issues', 'create_issue']
 ---
 
 # Quality Lead
@@ -78,6 +78,18 @@ Verify implementations against requirements, hunt down defects before users find
 **Environment:** OS, browser, version, relevant config.
 **Evidence:** Error log, screenshot, or failing test.
 ```
+
+## Filing findings as GitHub Issues
+
+Outstanding work in this repo is tracked in **GitHub Issues**, not in `docs/TODO.md` (now a taxonomy pointer). When your review surfaces a confirmed defect or a coverage gap worth tracking:
+
+1. **Confirm before filing.** Summarise the finding (with repro steps) and ask the maintainer whether to raise an issue. Never open issues unprompted or in bulk.
+2. **Search existing issues first** to avoid duplicates.
+3. On approval, file with the **Task** template (or Bug where it fits) and apply one category label (`security`, `fix`, `feat`, `tests`, `ci`, `documentation`), one `size: S|M|L`, one `priority: high|medium|low`, and the target milestone. Add `v2.0-gate` if it blocks the HACS default submission.
+4. If you cannot file directly, hand the orchestrator a ready-to-file issue (title, body, labels, milestone).
+5. Reference the issue from the resolving PR (`Closes #NN`).
+
+Taxonomy: `docs/TODO.md`. Bulk seeding: `scripts/seed_issues.py`.
 
 ## Anti-Patterns
 

--- a/.github/agents/responsible-ai.agent.md
+++ b/.github/agents/responsible-ai.agent.md
@@ -1,7 +1,7 @@
 ---
 name: 'Responsible AI'
 description: 'Responsible AI specialist ensuring AI works for everyone through bias prevention, accessibility compliance, ethical development, and inclusive design'
-tools: ['codebase', 'edit/editFiles', 'search']
+tools: ['codebase', 'edit/editFiles', 'search', 'search_issues', 'create_issue']
 model: GPT-5
 ---
 
@@ -184,6 +184,18 @@ Create an RAI-ADR when the change touches:
 - Authentication that might exclude groups
 - Content moderation or filtering algorithms
 - Any feature handling protected characteristics
+
+## Filing findings as GitHub Issues
+
+Outstanding work in this repo is tracked in **GitHub Issues**, not in `docs/TODO.md` (now a taxonomy pointer). When your review surfaces an actionable privacy, accessibility, or explainability item worth tracking:
+
+1. **Confirm before filing.** Summarise the concern and who it affects, and ask the maintainer whether to raise an issue. Never open issues unprompted or in bulk.
+2. **Search existing issues first** to avoid duplicates.
+3. On approval, file with the **Task** template (or Bug / Feature where they fit) and apply one category label (`security`, `fix`, `feat`, `tests`, `ci`, `documentation`), one `size: S|M|L`, one `priority: high|medium|low`, and the target milestone. Add `v2.0-gate` if it blocks the HACS default submission.
+4. If you cannot file directly, hand the orchestrator a ready-to-file issue (title, body, labels, milestone).
+5. Reference the issue from the resolving PR (`Closes #NN`).
+
+Taxonomy: `docs/TODO.md`. Bulk seeding: `scripts/seed_issues.py`.
 
 ## Anti-Patterns
 

--- a/.github/agents/se-lead.agent.md
+++ b/.github/agents/se-lead.agent.md
@@ -64,6 +64,17 @@ Provide expert-level engineering guidance that lifts the design quality of every
 - [issue title and proposed labels, ready to file]
 ```
 
+## Filing findings as GitHub Issues
+
+Outstanding work in this repo is tracked in **GitHub Issues**, not in `docs/TODO.md` (now a taxonomy pointer). When you discover or incur technical debt, or surface a risk worth tracking:
+
+1. **Confirm before filing.** Summarise the item and ask the maintainer whether to raise an issue. Never open issues unprompted or in bulk.
+2. **Search existing issues first** to avoid duplicates.
+3. On approval, file with the **Task** template (or Bug / Feature where they fit) and apply one category label (`security`, `fix`, `feat`, `tests`, `ci`, `documentation`), one `size: S|M|L`, one `priority: high|medium|low`, and the target milestone. Add `v2.0-gate` if it blocks the HACS default submission.
+4. Reference the issue from the resolving PR (`Closes #NN`). This replaces the older "create_issue" guidance in the workflow above: same intent, with the confirm-first gate and this repo's taxonomy.
+
+Taxonomy: `docs/TODO.md`. Bulk seeding: `scripts/seed_issues.py`.
+
 ## Anti-Patterns
 
 - Drive-by nitpicks with no rationale.

--- a/.github/agents/security-lead.agent.md
+++ b/.github/agents/security-lead.agent.md
@@ -1,7 +1,7 @@
 ---
 name: 'Security Lead'
 description: 'Security-focused code review specialist with OWASP Top 10, Zero Trust, LLM security, and enterprise security standards'
-tools: ['codebase', 'edit/editFiles', 'search', 'problems']
+tools: ['codebase', 'edit/editFiles', 'search', 'problems', 'search_issues', 'create_issue']
 model: GPT-5
 ---
 
@@ -167,6 +167,18 @@ Save the review to `docs/code-review/[date]-[component]-review.md`:
 - Data classifications handled
 - Authentication and authorization assumptions
 ```
+
+## Filing findings as GitHub Issues
+
+Outstanding work in this repo is tracked in **GitHub Issues**, not in `docs/TODO.md` (now a taxonomy pointer). When your review surfaces an actionable item worth tracking:
+
+1. **Confirm before filing.** Summarise the finding and ask the maintainer whether to raise an issue. Never open issues unprompted or in bulk.
+2. **Search existing issues first** to avoid duplicates.
+3. On approval, file with the **Task** template (or Bug / Feature where they fit) and apply one category label (`security`, `fix`, `feat`, `tests`, `ci`, `documentation`), one `size: S|M|L`, one `priority: high|medium|low`, and the target milestone. Add `v2.0-gate` if it blocks the HACS default submission.
+4. If you cannot file directly, hand the orchestrator a ready-to-file issue (title, body, labels, milestone).
+5. Reference the issue from the resolving PR (`Closes #NN`).
+
+Taxonomy: `docs/TODO.md`. Bulk seeding: `scripts/seed_issues.py`.
 
 ## Anti-Patterns
 

--- a/.github/agents/tech-debt.agent.md
+++ b/.github/agents/tech-debt.agent.md
@@ -34,7 +34,7 @@ Generate comprehensive, actionable technical-debt remediation plans for code, te
 4. **Write the plan**
    - Summary table, then a detailed plan per the required sections.
 5. **File the work**
-   - Apply `/.github/ISSUE_TEMPLATE/chore_request.yml` for remediation tasks.
+   - File remediation tasks with the **Task** issue template (`.github/ISSUE_TEMPLATE/task.yml`), after confirming with the maintainer (see "Filing findings" below).
 
 ## Analysis Framework
 
@@ -94,6 +94,17 @@ Generate comprehensive, actionable technical-debt remediation plans for code, te
 ## Related Issues
 - #XX [existing tracking issue, if any]
 ```
+
+## Filing findings as GitHub Issues
+
+Outstanding work in this repo is tracked in **GitHub Issues**, not in `docs/TODO.md` (now a taxonomy pointer). When your remediation plan identifies debt worth tracking:
+
+1. **Confirm before filing.** Summarise the item (with your Ease / Impact / Risk scores) and ask the maintainer whether to raise an issue. Never open issues unprompted or in bulk.
+2. **Search existing issues first** to avoid duplicates (you already do this in Step 3).
+3. On approval, file with the **Task** template and apply one category label (`security`, `fix`, `feat`, `tests`, `ci`, `documentation`), one `size: S|M|L`, one `priority: high|medium|low`, and the target milestone. Add `v2.0-gate` if it blocks the HACS default submission.
+4. Reference the issue from the resolving PR (`Closes #NN`).
+
+Taxonomy: `docs/TODO.md`. Bulk seeding: `scripts/seed_issues.py`.
 
 ## Anti-Patterns
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # GitHub Copilot Instructions
 
 > Full project context, hard constraints, conventions, and working style live in [`CLAUDE.md`](../CLAUDE.md). Read it first.
-> Quick-reference links to architecture, HA patterns, UniFi API, testing, and TODO docs are in [`AGENTS.md`](../AGENTS.md).
+> Quick-reference links to architecture, HA patterns, UniFi API, testing, and outstanding work (GitHub Issues) are in [`AGENTS.md`](../AGENTS.md).
 
 ---
 
@@ -63,6 +63,11 @@ See [`CLAUDE.md`](../CLAUDE.md) for the complete list with rationale.
 - Claude cannot push tags; provide the user with the exact `git tag` + `git push origin <tag>` command after a version-bump PR merges.
 
 See [`CLAUDE.md`](../CLAUDE.md) for the full release workflow.
+
+## Ways of working: outstanding work and findings
+
+- **Work is tracked in GitHub Issues**, not in `docs/TODO.md` (now a taxonomy pointer). Pick work by milestone (`v1.8.0`, `v1.9.0`, `v2.0.0`), then `priority:`, then `size:`. Close items by referencing them in the PR (`Closes #NN`).
+- **When you spot something worth tracking** (a bug, a hardening gap, tech debt, a doc gap): confirm with the maintainer before opening an issue. Do not file issues unprompted or in bulk. On approval, use the **Task** issue template (or Bug / Feature where they fit) and apply one category label, one `size: S|M|L`, one `priority: high|medium|low`, and the target milestone. See `docs/TODO.md` for the taxonomy and `scripts/seed_issues.py` for bulk seeding.
 
 ## Maintenance matrix
 


### PR DESCRIPTION
## What

Follow-up to #114 (the `docs/TODO.md` → GitHub Issues migration). Aligns the remaining agentic instruction surfaces with the new ways of working: track work in Issues, and have the repo's review personas **file fresh issues for findings, but only after confirming with the maintainer.**

## Why

#114 rewired `CLAUDE.md` and `AGENTS.md`, but the Copilot instructions and the six `.github/agents/*` personas still pointed at the old TODO.md model (and one referenced a template that doesn't exist). This closes that gap so every agent surface tells the same story.

## Changes

- **`.github/copilot-instructions.md`**: new "Ways of working: outstanding work and findings" section (work tracked in Issues by milestone → `priority:` → `size:`; close via `Closes #NN`; confirm before filing). Dropped the stale "TODO docs" pointer.
- **All six `.github/agents/*.agent.md` personas**: added a consistent **"Filing findings as GitHub Issues"** section that requires:
  1. **Confirm with the maintainer before opening an issue** (no unprompted or bulk filing),
  2. search for duplicates first,
  3. on approval, file via the **Task** template with the repo taxonomy (one category + `size: S|M|L` + `priority: high|medium|low` + milestone, plus `v2.0-gate` where relevant),
  4. reference the issue from the resolving PR.
- Granted `search_issues` / `create_issue` tools to the three personas that lacked them (**security-lead**, **qe-lead**, **responsible-ai**) so the instruction is actionable.
- **tech-debt**: replaced the reference to the non-existent `chore_request.yml` with the real **Task** template.
- **product-mgr**: added a repo-specific override so it ignores its generic `component`/`phase`/`team` label scheme and uses this repo's taxonomy, softening its "every change must have an issue" rule to the confirm-first gate.
- **`PULL_REQUEST_TEMPLATE.md`**: added a "Closes #NN" checklist item.

## Notes

- Docs/config-only: `make doc-check` passes; no `custom_components/` or `tests/` changes.
- The persona `tools:` lists use the Copilot/VS Code agent vocabulary already present in those files (`create_issue`, `search_issues`), matching how `product-mgr` already declares issue tools.

https://claude.ai/code/session_01HjAaLCw5ahie4j6CTZx9Np

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjAaLCw5ahie4j6CTZx9Np)_