### PR TITLE
ci: add Codecov coverage reporting with 95% minimum threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,5 +69,12 @@ jobs:
           python-version: "3.12"
       - name: Install test dependencies
         run: pip install -r requirements-dev.txt
-      - name: Run tests
-        run: pytest tests/ -v
+      - name: Run tests with coverage
+        run: pytest tests/ -v --cov-report=xml
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24  # v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ venv/
 dist/
 .env
 
+# Coverage artifacts
+.coverage
+coverage.xml
+
 # Claude Code auto-memory internal state
 .claude/auto-memory/
 .claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dist/
 # Coverage artifacts
 .coverage
 coverage.xml
+htmlcov/
 
 # Claude Code auto-memory internal state
 .claude/auto-memory/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Internal
 
-- Added test coverage reporting via Codecov: `pytest-cov` added to dev requirements, 95% floor enforced in CI (`--cov-fail-under=95`), XML report uploaded to Codecov on every run, and coverage badge added to README and info.md.
+- Added test coverage reporting via Codecov: `pytest-cov` added to dev requirements, 95% floor enforced in CI and locally (`--cov-fail-under=95`), XML report uploaded to Codecov on every push, live badge added to README and info.md. `make coverage` generates an HTML report locally; `.coverage`, `coverage.xml`, and `htmlcov/` added to `.gitignore`.
 
 ## [1.7.0] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Internal
+
+- Added test coverage reporting via Codecov: `pytest-cov` added to dev requirements, 95% floor enforced in CI (`--cov-fail-under=95`), XML report uploaded to Codecov on every run, and coverage badge added to README and info.md.
+
 ## [1.7.0] - 2026-05-29
 
 ### Security

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ help:
 	@echo "  make typecheck  - mypy"
 	@echo "  make validate   - HACS manifest preflight + docs prose linter"
 	@echo "  make test       - full pytest suite with coverage (fail below 95%)"
+	@echo "  make coverage   - open HTML coverage report in browser after running tests"
 
 setup:
 	$(PY312) -m venv .venv
@@ -37,6 +38,10 @@ setup-lint:
 
 test:
 	$(VENV)/pytest$(EXE) tests/ -v
+
+coverage:
+	$(VENV)/pytest$(EXE) tests/ -v --cov-report=html
+	$(VENV)/python$(EXE) -m webbrowser htmlcov/index.html
 
 lint:
 	$(VENV)/python$(EXE) scripts/run_lint.py

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help:
 	@echo "  make lint       - ruff check + format check"
 	@echo "  make typecheck  - mypy"
 	@echo "  make validate   - HACS manifest preflight + docs prose linter"
-	@echo "  make test       - full pytest suite"
+	@echo "  make test       - full pytest suite with coverage (fail below 95%)"
 
 setup:
 	$(PY312) -m venv .venv

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![HACS Custom](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://hacs.xyz)
 [![GitHub Release](https://img.shields.io/github/v/release/PHeonix25/unifi_alerts)](https://github.com/PHeonix25/unifi_alerts/releases)
+[![codecov](https://codecov.io/gh/PHeonix25/unifi_alerts/graph/badge.svg)](https://codecov.io/gh/PHeonix25/unifi_alerts)
 [![AI Ready](https://img.shields.io/badge/AI--Ready-yes-brightgreen?style=flat)](https://github.com/johnpapa/ai-ready)
 
 Aggregates **UniFi Network controller alerts** into Home Assistant sensors, binary sensors, and event entities. Real-time push via UniFi Alarm Manager webhooks, with REST polling as a backstop for open-count data and missed pushes.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 95%
+        threshold: 1%
+    patch:
+      default:
+        target: 90%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false

--- a/info.md
+++ b/info.md
@@ -1,5 +1,7 @@
 # UniFi Alerts for Home Assistant
 
+[![codecov](https://codecov.io/gh/PHeonix25/unifi_alerts/graph/badge.svg)](https://codecov.io/gh/PHeonix25/unifi_alerts)
+
 **Local network only: webhooks are not reachable over Nabu Casa remote access.**
 
 Aggregates **UniFi Network controller alerts** into Home Assistant sensors, binary sensors, event entities, and buttons. Alerts arrive in real time via UniFi Alarm Manager webhooks, with periodic REST polling as a backstop for open-count data and missed pushes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,14 @@ python_version = "3.12"
 strict = true
 ignore_missing_imports = true
 warn_unused_ignores = true
+
+[tool.coverage.run]
+source = ["custom_components/unifi_alerts"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ pythonpath = .
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
+addopts = --cov=custom_components/unifi_alerts --cov-report=term-missing --cov-fail-under=95
 filterwarnings =
     ignore::DeprecationWarning:josepy
     ignore::DeprecationWarning:acme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,6 @@ homeassistant
 mypy
 pytest
 pytest-asyncio
+pytest-cov
 pytest-homeassistant-custom-component
 ruff


### PR DESCRIPTION
## Summary

- Adds `pytest-cov` to `requirements-dev.txt` and configures branch coverage reporting end-to-end
- `pytest.ini` enforces `--cov-fail-under=95` so the 95% floor is applied identically locally and in CI; branch coverage tracked via `[tool.coverage.run] branch = true` in `pyproject.toml`
- CI `test` job now runs `pytest tests/ -v --cov-report=xml` and uploads `coverage.xml` to Codecov via `codecov/codecov-action@v5.4.3` (pinned to full SHA per project policy); upload uses `if: always()` so Codecov receives data even when the coverage gate trips
- `codecov.yml` declares project target of 95% (1% threshold) and patch target of 90%, mirroring the local gate
- Coverage build artifacts (`.coverage`, `coverage.xml`) added to `.gitignore`
- Live coverage badge added to `README.md` and `info.md`

Current coverage: **97.85%** (branch coverage included; was 99% line-only before branch tracking was enabled).

## Test plan

- [ ] CI `test` job passes with coverage output visible in the step log
- [ ] Codecov upload step succeeds (requires `CODECOV_TOKEN` secret — see setup note below)
- [ ] Badge renders in README once Codecov processes the first upload
- [ ] Verify locally: drop coverage below 95% and confirm `make test` fails with "Required test coverage of 95% not reached"

## Setup note

To activate the Codecov badge and status checks, add a `CODECOV_TOKEN` secret:
1. Sign in to [codecov.io](https://codecov.io) with GitHub and add the `PHeonix25/unifi_alerts` repo
2. Copy the upload token from Codecov repo settings
3. Add it as `CODECOV_TOKEN` in GitHub: Settings > Secrets and variables > Actions

https://claude.ai/code/session_01CubQxwd34E3otu6ZKM4fpS