### PR TITLE
security: drop raw payload from persisted UniFiAlert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Security
+
+- `UniFiAlert.to_dict()` no longer persists the `raw` UniFi payload to `.storage`. That payload carried unredacted client MACs, IP addresses, and hostnames, and could contain non-JSON-safe values that would crash `Store.async_save`. Persistence now emits an explicit scalar field list (`category`, `message`, `received_at`, `key`, `device_name`, `site`, `severity`); `from_dict()` still defaults `raw` to `{}` on read so existing stored entries continue to load. Closes #115.
+
 ### Internal
 
 - Added test coverage reporting via Codecov: `pytest-cov` added to dev requirements, 95% floor enforced in CI and locally (`--cov-fail-under=95`), XML report uploaded to Codecov on every push, live badge added to README and info.md. `make coverage` generates an HTML report locally; `.coverage`, `coverage.xml`, and `htmlcov/` added to `.gitignore`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Security
 
-- `UniFiAlert.to_dict()` no longer persists the `raw` UniFi payload to `.storage`. That payload carried unredacted client MACs, IP addresses, and hostnames, and could contain non-JSON-safe values that would crash `Store.async_save`. Persistence now emits an explicit scalar field list (`category`, `message`, `received_at`, `key`, `device_name`, `site`, `severity`); `from_dict()` still defaults `raw` to `{}` on read so existing stored entries continue to load. Closes #115.
+- `UniFiAlert.to_dict()` no longer persists the `raw` UniFi payload to `.storage`. That payload carried unredacted client MACs, IP addresses, and hostnames, and could contain non-JSON-safe values that would crash `Store.async_save`. Persistence now emits an explicit scalar field list (`category`, `message`, `received_at`, `key`, `device_name`, `site`, `severity`); `from_dict()` still defaults `raw` to `{}` on read so existing stored entries continue to load. ([#147])
 
 ### Internal
 
@@ -205,4 +205,5 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#59]: https://github.com/PHeonix25/unifi_alerts/pull/59
 [#67]: https://github.com/PHeonix25/unifi_alerts/pull/67
 [#68]: https://github.com/PHeonix25/unifi_alerts/pull/68
+[#147]: https://github.com/PHeonix25/unifi_alerts/pull/147
 [#PR]: https://github.com/PHeonix25/unifi_alerts/pull/PR

--- a/custom_components/unifi_alerts/models.py
+++ b/custom_components/unifi_alerts/models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from contextlib import suppress
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, TypedDict
 
@@ -208,10 +208,22 @@ class UniFiAlert:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialise this alert to a JSON-safe dict for Store persistence."""
-        d = asdict(self)
-        d["received_at"] = self.received_at.isoformat()
-        return d
+        """Serialise this alert to a JSON-safe dict for Store persistence.
+
+        `raw` is intentionally excluded: it carries unredacted UniFi payload
+        fields (client MACs, IPs, hostnames) and arbitrary values that can
+        defeat Store.async_save's JSON encoder. The restore path only consumes
+        the scalar fields below; from_dict() defaults raw to {} on read.
+        """
+        return {
+            "category": self.category,
+            "message": self.message,
+            "received_at": self.received_at.isoformat(),
+            "key": self.key,
+            "device_name": self.device_name,
+            "site": self.site,
+            "severity": self.severity,
+        }
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> UniFiAlert:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -390,3 +390,59 @@ class TestAlertSerialization:
         )
         assert isinstance(restored.received_at, datetime)
         assert restored.received_at.tzinfo == UTC
+
+    def test_to_dict_omits_raw_payload(self):
+        """to_dict() must drop `raw` — it carries client MACs / IPs / hostnames that should not hit disk."""
+        alert = UniFiAlert.from_webhook_payload(
+            CATEGORY_NETWORK_WAN,
+            {
+                "message": "client connected",
+                "client_mac": "aa:bb:cc:dd:ee:ff",
+                "client_ip": "192.0.2.10",
+                "hostname": "my-laptop",
+            },
+        )
+        serialized = alert.to_dict()
+        assert "raw" not in serialized
+        # Scalar fields the restore path consumes must still be present.
+        for field_name in (
+            "category",
+            "message",
+            "received_at",
+            "key",
+            "device_name",
+            "site",
+            "severity",
+        ):
+            assert field_name in serialized
+
+    def test_to_dict_survives_non_json_value_in_raw(self):
+        """A non-JSON-safe value in raw must not be able to break Store.async_save."""
+        import json
+
+        alert = UniFiAlert.from_webhook_payload(CATEGORY_NETWORK_WAN, {"message": "test"})
+        # Inject a value stdlib json cannot serialise; if `raw` is still in to_dict() this raises.
+        alert.raw = {"weird": object()}
+        json.dumps(alert.to_dict())
+
+    def test_round_trip_resets_raw_to_empty_dict(self):
+        """from_dict(to_dict(alert)) preserves scalar fields and resets raw to {}."""
+        original = UniFiAlert(
+            category=CATEGORY_SECURITY_THREAT,
+            message="intrusion blocked",
+            received_at=datetime(2026, 6, 1, 12, 0, tzinfo=UTC),
+            raw={"client_mac": "aa:bb:cc:dd:ee:ff", "src_ip": "203.0.113.5"},
+            key="THREAT_BLOCKED",
+            device_name="UDM-Pro",
+            site="default",
+            severity="HIGH",
+        )
+        restored = UniFiAlert.from_dict(original.to_dict())
+        assert restored.category == original.category
+        assert restored.message == original.message
+        assert restored.received_at == original.received_at
+        assert restored.key == original.key
+        assert restored.device_name == original.device_name
+        assert restored.site == original.site
+        assert restored.severity == original.severity
+        assert restored.raw == {}


### PR DESCRIPTION
## Summary

`UniFiAlert.to_dict()` (used by the coordinator to persist `last_alert` to `.storage`) previously called `asdict(self)`, which serialised the full UniFi payload (`raw`) verbatim. That payload carries unredacted client MACs, IP addresses, and hostnames, and can contain non-JSON-safe values that crash `Store.async_save`.

Persistence now emits an explicit scalar field list: `category`, `message`, `received_at`, `key`, `device_name`, `site`, `severity`. `from_dict()` already defaults `raw` to `{}` on read, so existing stored entries continue to load unchanged — only the on-disk footprint shrinks and the privacy-sensitive fields no longer hit disk.

## Acceptance (from #115)

- [x] `to_dict()` no longer serialises `raw`
- [x] Restore path still rebuilds `last_alert` from the scalar fields (`from_dict()` unchanged — already used `data.get("raw", {})`)
- [x] Test asserts a non-JSON value in `raw` cannot break persistence (`test_to_dict_survives_non_json_value_in_raw`)
- [x] CHANGELOG `[Unreleased]` updated under `### Security`

## Test plan

- [x] New `TestAlertSerialization` cases:
  - `test_to_dict_omits_raw_payload` — `raw` key absent; scalar fields still present
  - `test_to_dict_survives_non_json_value_in_raw` — `alert.raw = {"weird": object()}`; `json.dumps(alert.to_dict())` no longer raises
  - `test_round_trip_resets_raw_to_empty_dict` — `from_dict(to_dict(alert))` preserves scalar fields and resets `raw` to `{}`
- [x] `make check` green locally (479 tests, 97.85% coverage)
- [x] CI green on this branch

Closes #115.