### PR TITLE
fix: seed event entity counter on add to prevent stale alert replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Event entities (`event.unifi_alerts_*`) no longer replay the most-recent persisted alert as a fresh `alert_received` event when the integration reloads (for example after an options-flow save). The per-entity counter is now seeded from the restored category state in `async_added_to_hass` instead of resetting to zero. ([#116])
+
 ### Security
 
 - `UniFiAlert.to_dict()` no longer persists the `raw` UniFi payload to `.storage`. That payload carried unredacted client MACs, IP addresses, and hostnames, and could contain non-JSON-safe values that would crash `Store.async_save`. Persistence now emits an explicit scalar field list (`category`, `message`, `received_at`, `key`, `device_name`, `site`, `severity`); `from_dict()` still defaults `raw` to `{}` on read so existing stored entries continue to load. ([#147])
@@ -205,5 +209,6 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#59]: https://github.com/PHeonix25/unifi_alerts/pull/59
 [#67]: https://github.com/PHeonix25/unifi_alerts/pull/67
 [#68]: https://github.com/PHeonix25/unifi_alerts/pull/68
+[#116]: https://github.com/PHeonix25/unifi_alerts/issues/116
 [#147]: https://github.com/PHeonix25/unifi_alerts/pull/147
 [#PR]: https://github.com/PHeonix25/unifi_alerts/pull/PR

--- a/custom_components/unifi_alerts/event.py
+++ b/custom_components/unifi_alerts/event.py
@@ -66,6 +66,14 @@ class UniFiAlertEventEntity(CoordinatorEntity[UniFiAlertsCoordinator], EventEnti
         # Track alert_count to detect new alerts on coordinator update
         self._last_seen_count: int = 0
 
+    async def async_added_to_hass(self) -> None:
+        # Seed from restored state so a reload (e.g. after options save) does
+        # not replay the last persisted alert as a fresh alert_received event.
+        state = self.coordinator.get_category_state(self._category)
+        if state is not None:
+            self._last_seen_count = state.alert_count
+        await super().async_added_to_hass()
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Called whenever the coordinator has new data.

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -452,6 +452,46 @@ class TestUniFiAlertEventEntity:
         ):
             assert key in payload
 
+    @pytest.mark.asyncio
+    async def test_reload_does_not_replay_restored_alert(self):
+        """Regression for #116: options save triggers a full reload; the
+        restored CategoryState carries a non-zero alert_count, and the first
+        coordinator update post-reload must NOT re-fire alert_received.
+        """
+        alert = make_alert()
+        state = make_state(is_alerting=True, alert_count=3, last_alert=alert)
+        entity = self._make(state)
+        # Simulate the reload boundary: __init__ has just set _last_seen_count
+        # to 0; async_added_to_hass must seed from the restored alert_count.
+        assert entity._last_seen_count == 0
+        await entity.async_added_to_hass()
+        assert entity._last_seen_count == 3
+        # First coordinator update after restore — same count, no new alert.
+        entity._handle_coordinator_update()
+        entity._trigger_event.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_new_alert_after_reload_still_fires_once(self):
+        """The seeding fix for #116 must not suppress genuinely new alerts."""
+        alert = make_alert()
+        state = make_state(is_alerting=True, alert_count=3, last_alert=alert)
+        entity = self._make(state)
+        await entity.async_added_to_hass()
+        # A fresh push arrives — coordinator bumps alert_count to 4.
+        state.alert_count = 4
+        entity._handle_coordinator_update()
+        entity._trigger_event.assert_called_once()
+        # And a second identical update (no new push) must not re-fire.
+        entity._handle_coordinator_update()
+        entity._trigger_event.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_added_to_hass_no_state_leaves_seed_zero(self):
+        """Fresh install / unknown category: no restored state → seed stays 0."""
+        entity = self._make(None)
+        await entity.async_added_to_hass()
+        assert entity._last_seen_count == 0
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # button


### PR DESCRIPTION
## Summary

- `UniFiAlertEventEntity._last_seen_count` was reset to `0` in `__init__`, so the first coordinator update after any options-flow save (which triggers a full reload) saw a restored non-zero `alert_count` and re-fired the most recent persisted alert as a fresh `alert_received` event into users automations.
- Fixed by overriding `async_added_to_hass` to seed `_last_seen_count` from the restored `CategoryState.alert_count` before chaining to `CoordinatorEntity.async_added_to_hass` (which registers the coordinator listener). Genuine new pushes (count strictly greater than the seeded value) continue to fire exactly once.
- Added three regression tests covering the issues acceptance criteria: reload does not replay, a fresh push after reload still fires exactly once, and fresh-install (no restored state) leaves the seed at zero.

Closes #116

## Test plan

- [x] `make check` (via pre-push hook): lint, mypy, HACS preflight, docs validation, 482 tests, 97.86% total coverage. `event.py` line + branch coverage is now 100%.
- [x] New regression test `test_reload_does_not_replay_restored_alert` fails on `main` / `dev` without the fix (manually verified: removing the `async_added_to_hass` override makes the assertion `entity._trigger_event.assert_not_called()` fail).
- [x] Existing 9 event-entity tests still pass unchanged.
- [x] CHANGELOG `[Unreleased]` updated with a `### Changed` bullet and `[#116]` reference link.