### PR TITLE
fix(ci): force scripts/* stdout to UTF-8 so cp1252 Windows consoles do not crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `make lint`, `make typecheck`, `make validate`, and the `.githooks/pre-push` hook no longer crash on Windows shells whose stdout codec defaults to `cp1252`. Previously, the `✅` success glyph printed by the scripts raised `UnicodeEncodeError` and exited the script non-zero even when the underlying tool (ruff, mypy, the validators) had succeeded. All five affected scripts (`run_lint.py`, `run_typecheck.py`, `validate_hacs.py`, `validate_docs.py`, `check_translations.py`) now reconfigure stdout and stderr to UTF-8 via a shared `scripts/_console.py` helper at startup. Windows contributors no longer need to export `PYTHONIOENCODING=utf-8` to use the standard development workflow. ([#148])
+
 ### Security
 
 - `UniFiAlert.to_dict()` no longer persists the `raw` UniFi payload to `.storage`. That payload carried unredacted client MACs, IP addresses, and hostnames, and could contain non-JSON-safe values that would crash `Store.async_save`. Persistence now emits an explicit scalar field list (`category`, `message`, `received_at`, `key`, `device_name`, `site`, `severity`); `from_dict()` still defaults `raw` to `{}` on read so existing stored entries continue to load. ([#147])
@@ -206,4 +210,5 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#67]: https://github.com/PHeonix25/unifi_alerts/pull/67
 [#68]: https://github.com/PHeonix25/unifi_alerts/pull/68
 [#147]: https://github.com/PHeonix25/unifi_alerts/pull/147
+[#148]: https://github.com/PHeonix25/unifi_alerts/issues/148
 [#PR]: https://github.com/PHeonix25/unifi_alerts/pull/PR

--- a/scripts/_console.py
+++ b/scripts/_console.py
@@ -1,0 +1,38 @@
+"""Console-encoding helper for the standalone `scripts/*.py` entry points.
+
+Several scripts print status lines that contain non-ASCII glyphs (e.g. the
+U+2705 ✅ check mark used as a success marker). On Windows, when stdout is
+attached to a console whose default codec is `cp1252` (the default on most
+non-internationalised Windows installs), `print("✅ …")` raises
+`UnicodeEncodeError` and the script exits non-zero — even though the
+underlying tool (ruff, mypy, etc.) succeeded.
+
+`use_utf8_console()` forces stdout and stderr to UTF-8 before any prints
+happen, so the scripts behave identically on Linux, macOS, and Windows
+without requiring contributors to set `PYTHONIOENCODING=utf-8` in their
+shell. `errors="replace"` ensures even an exotic console that still cannot
+encode the bytes degrades gracefully (printing `?`) rather than crashing.
+
+The helper lives in `scripts/` (not the integration package) because it
+must be importable from standalone scripts that are invoked as
+`python scripts/<name>.py`. In that mode Python adds the script's
+directory to `sys.path[0]`, so `from _console import use_utf8_console`
+works without any `sys.path` manipulation.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def use_utf8_console() -> None:
+    """Reconfigure sys.stdout and sys.stderr to UTF-8 if possible.
+
+    `TextIOWrapper.reconfigure` is available on Python 3.7+; this project
+    floors at 3.12 so the `hasattr` guard is purely defensive (covers
+    streams that have already been replaced with non-TextIOWrapper
+    objects, e.g. by a test harness or a CI runner).
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")

--- a/scripts/check_translations.py
+++ b/scripts/check_translations.py
@@ -13,6 +13,10 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+from _console import use_utf8_console
+
+use_utf8_console()
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 STRINGS = REPO_ROOT / "custom_components" / "unifi_alerts" / "strings.json"
 EN = REPO_ROOT / "custom_components" / "unifi_alerts" / "translations" / "en.json"

--- a/scripts/run_lint.py
+++ b/scripts/run_lint.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 import subprocess
 import sys
 
+from _console import use_utf8_console
+
+use_utf8_console()
+
 
 def _run_step(command: list[str], success_message: str) -> None:
     """Run a lint command and stop immediately if it fails."""

--- a/scripts/run_typecheck.py
+++ b/scripts/run_typecheck.py
@@ -6,6 +6,10 @@ from __future__ import annotations
 import subprocess
 import sys
 
+from _console import use_utf8_console
+
+use_utf8_console()
+
 
 def _run_step(command: list[str], success_message: str) -> None:
     """Run a typecheck command and stop immediately if it fails."""

--- a/scripts/validate_docs.py
+++ b/scripts/validate_docs.py
@@ -23,6 +23,10 @@ import re
 import sys
 from pathlib import Path
 
+from _console import use_utf8_console
+
+use_utf8_console()
+
 REPO = Path(__file__).resolve().parent.parent
 
 # Every markdown file in the repo is in scope, recursively, so the same rules

--- a/scripts/validate_hacs.py
+++ b/scripts/validate_hacs.py
@@ -20,6 +20,10 @@ import re
 import sys
 from pathlib import Path
 
+from _console import use_utf8_console
+
+use_utf8_console()
+
 # HA core built-in integrations. HACS rejects these in `dependencies` because
 # they ship with HA and cannot be installed separately. Add entries here
 # whenever the HACS action rejects a new one.

--- a/tests/unit/test_console_helper.py
+++ b/tests/unit/test_console_helper.py
@@ -62,9 +62,7 @@ class TestUseUtf8Console:
         fake_stdout.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")
         fake_stderr.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")
 
-    def test_is_noop_when_reconfigure_unavailable(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_is_noop_when_reconfigure_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Streams that don't expose `reconfigure` (e.g. swapped by a test
         harness) must be skipped silently, not crash."""
 

--- a/tests/unit/test_console_helper.py
+++ b/tests/unit/test_console_helper.py
@@ -1,0 +1,119 @@
+"""Regression tests for `scripts/_console.py`.
+
+Issue #148: on Windows shells whose stdout codec is `cp1252` (the default
+on most non-internationalised Windows installs), `print("✅ …")` raises
+`UnicodeEncodeError` and crashes the standalone scripts in `scripts/`.
+
+`use_utf8_console()` forces stdout/stderr to UTF-8 so the scripts behave
+identically on Linux, macOS, and Windows without contributors needing to
+export `PYTHONIOENCODING=utf-8`. These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CONSOLE_PATH = REPO_ROOT / "scripts" / "_console.py"
+AFFECTED_SCRIPTS = (
+    "run_lint.py",
+    "run_typecheck.py",
+    "validate_hacs.py",
+    "validate_docs.py",
+    "check_translations.py",
+)
+
+
+def _load_console() -> ModuleType:
+    """Import `scripts/_console.py` by file path.
+
+    `scripts/` has no `__init__.py` (it is a flat directory of standalone
+    entry points), so a normal `from scripts._console import …` does not
+    resolve. We replicate Python's invocation behaviour: when a script is
+    run as `python scripts/run_lint.py`, its directory is added to
+    `sys.path[0]` and the helper is importable as `_console`.
+    """
+    spec = importlib.util.spec_from_file_location("_console", CONSOLE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestUseUtf8Console:
+    def test_reconfigures_both_streams_to_utf8_replace(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both stdout and stderr are reconfigured with errors='replace'."""
+        fake_stdout = MagicMock()
+        fake_stderr = MagicMock()
+        monkeypatch.setattr(sys, "stdout", fake_stdout)
+        monkeypatch.setattr(sys, "stderr", fake_stderr)
+
+        _load_console().use_utf8_console()
+
+        fake_stdout.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")
+        fake_stderr.reconfigure.assert_called_once_with(encoding="utf-8", errors="replace")
+
+    def test_is_noop_when_reconfigure_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Streams that don't expose `reconfigure` (e.g. swapped by a test
+        harness) must be skipped silently, not crash."""
+
+        class _NoReconfigure:
+            pass
+
+        monkeypatch.setattr(sys, "stdout", _NoReconfigure())
+        monkeypatch.setattr(sys, "stderr", _NoReconfigure())
+
+        # Must not raise.
+        _load_console().use_utf8_console()
+
+    def test_emoji_print_does_not_crash_after_reconfigure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end: a TextIOWrapper around a cp1252 buffer crashes on
+        emoji before `use_utf8_console()` runs, and succeeds after."""
+        raw = io.BytesIO()
+        stream = io.TextIOWrapper(raw, encoding="cp1252", write_through=True)
+        monkeypatch.setattr(sys, "stdout", stream)
+        monkeypatch.setattr(sys, "stderr", stream)
+
+        # Sanity check: cp1252 cannot encode U+2705, baseline must crash.
+        with pytest.raises(UnicodeEncodeError):
+            print("✅ baseline")
+
+        _load_console().use_utf8_console()
+
+        # After reconfigure, the same print succeeds and the UTF-8 bytes
+        # for U+2705 (E2 9C 85) appear in the underlying buffer.
+        print("✅ after fix")
+        stream.flush()
+        assert b"\xe2\x9c\x85" in raw.getvalue()
+
+
+class TestAffectedScriptsWireTheHelper:
+    """Each of the 5 scripts named in #148 must import and call the helper.
+
+    A purely textual check is brittle, but it catches the common
+    regression: someone adds a 6th unicode-emitting script (or refactors
+    one of the 5) and forgets the two-line wiring.
+    """
+
+    @pytest.mark.parametrize("script", AFFECTED_SCRIPTS)
+    def test_script_imports_and_invokes_helper(self, script: str) -> None:
+        source = (REPO_ROOT / "scripts" / script).read_text(encoding="utf-8")
+        assert "from _console import use_utf8_console" in source, (
+            f"scripts/{script} is missing the _console import — see #148"
+        )
+        assert "use_utf8_console()" in source, (
+            f"scripts/{script} imports the helper but never calls it — see #148"
+        )


### PR DESCRIPTION
## Summary

- `scripts/run_lint.py`, `run_typecheck.py`, `validate_hacs.py`, `validate_docs.py`, and `check_translations.py` print status lines prefixed with the U+2705 check mark. On Windows shells whose stdout codec defaults to `cp1252` (the default on most non-internationalised Windows installs), `print()` of those bytes raises `UnicodeEncodeError` and exits the script non-zero — even though the underlying tool (ruff, mypy, the validators) succeeded. The result was that `make lint`, `make typecheck`, `make check`, and the `.githooks/pre-push` hook all failed on Windows unless the contributor exported `PYTHONIOENCODING=utf-8` for every invocation.
- Added `scripts/_console.use_utf8_console()` that reconfigures `sys.stdout`/`sys.stderr` to UTF-8 with `errors="replace"` (graceful degradation on truly exotic consoles). Wired it into all five affected scripts. Idempotent and silently no-ops on streams that do not expose `reconfigure`.
- The issue listed only `run_lint.py` and `run_typecheck.py` as in-scope, but the three remaining scripts have the same bug — they just had not crashed yet because `make check` stopped at the first failure. Fixing all five prevents the next iteration of the same regression from a different entry point.

Closes #148

## Test plan

- [x] **End-to-end verification on Windows**: `git push` triggered the pre-push hook (`make check`) **without** `PYTHONIOENCODING=utf-8` set. All five scripts ran to completion and printed their `✅` success lines cleanly. Pre-fix, the first script (`run_lint.py`) crashes at the first `print("✅ …")`.
- [x] **Reproduction verified**: `PYTHONIOENCODING=cp1252 python scripts/validate_docs.py` exits 0 and prints `✅ Docs validation passed.` correctly with the fix in place.
- [x] **Unit tests** (`tests/unit/test_console_helper.py`, 8 tests):
  - `use_utf8_console()` calls `reconfigure(encoding="utf-8", errors="replace")` on both streams.
  - Silently no-ops when the stream does not expose `reconfigure`.
  - **End-to-end**: a `TextIOWrapper` around a cp1252 `BytesIO` crashes on `print("✅ …")` before the helper runs, succeeds after, and writes the correct UTF-8 bytes (`E2 9C 85`) to the underlying buffer.
  - Parametrised over all five scripts: each must import the helper and call it (catches the "added a 6th unicode-emitting script and forgot the wiring" regression).
- [x] **Full `make check`**: 487 tests pass (479 prior + 8 new), 97.85% total coverage. No regression on `coordinator.py`, `webhook_handler.py`, or any other path.
- [x] **No new dependencies**. The helper is 4 lines of stdlib.
- [x] **CHANGELOG**: `[Unreleased]` updated with a `### Fixed` bullet and `[#148]` reference link.

## Notes for reviewers

- `scripts/_console.py` has a leading underscore to mark it as a private helper (not a standalone entry point you would invoke as `python scripts/_console.py`).
- The `hasattr(stream, "reconfigure")` guard is defensive: `TextIOWrapper.reconfigure` exists on Python 3.7+, and this project floors at 3.12, so the only realistic miss is a test harness or CI runner that swapped the stream for a non-`TextIOWrapper` object.
- The textual "scripts wire the helper" check (`TestAffectedScriptsWireTheHelper`) is intentionally brittle — that is the point. If someone adds a sixth unicode-emitting script, the parametrise list reminds them to add the two-line wiring.