### PR TITLE
ci: force UTF-8 on stdout/stderr in run_lint.py and run_typecheck.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `scripts/run_lint.py` and `scripts/run_typecheck.py` now force UTF-8 on stdout/stderr at startup, preventing `UnicodeEncodeError` crashes on Windows consoles with a cp1252 default codec when emoji success glyphs are printed. ([#148])
+
 ## [1.7.0] - 2026-05-29
 
 ### Security

--- a/scripts/run_lint.py
+++ b/scripts/run_lint.py
@@ -6,6 +6,12 @@ from __future__ import annotations
 import subprocess
 import sys
 
+# Force UTF-8 on Windows consoles whose default codec (cp1252) cannot encode
+# emoji glyphs used in success messages — raises UnicodeEncodeError otherwise.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 
 def _run_step(command: list[str], success_message: str) -> None:
     """Run a lint command and stop immediately if it fails."""

--- a/scripts/run_typecheck.py
+++ b/scripts/run_typecheck.py
@@ -6,6 +6,12 @@ from __future__ import annotations
 import subprocess
 import sys
 
+# Force UTF-8 on Windows consoles whose default codec (cp1252) cannot encode
+# emoji glyphs used in success messages — raises UnicodeEncodeError otherwise.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 
 def _run_step(command: list[str], success_message: str) -> None:
     """Run a typecheck command and stop immediately if it fails."""


### PR DESCRIPTION
Closing - this fix was already shipped in dev via PR #151 (`fix(ci): force scripts/* stdout to UTF-8`). My error: I hadn't fetched origin before starting and missed the `dev` branch entirely.