### PR TITLE
feat: localise remaining inline strings in sensor platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 
 - Event entities (`event.unifi_alerts_*`) no longer replay the most-recent persisted alert as a fresh `alert_received` event when the integration reloads (for example after an options-flow save). The per-entity counter is now seeded from the restored category state in `async_added_to_hass` instead of resetting to zero. ([#116])
+- The last-message sensor now returns `None` (HA "unknown") instead of the hardcoded English string "No alerts yet" when no alert has been received, eliminating the only remaining hard-coded user-facing string in the platform files. ([#138])
+- Entity display names for last-message, open-count, and event entities now use a colon separator instead of an em-dash (e.g. `{category}: Last Message`). ([#138])
+- The category configuration warning now reads "Warning:" instead of the `⚠️` emoji glyph so meaning is preserved for screen readers and translators. ([#138])
 
 ### Fixed
 

--- a/custom_components/unifi_alerts/sensor.py
+++ b/custom_components/unifi_alerts/sensor.py
@@ -61,10 +61,10 @@ class UniFiCategoryMessageSensor(CoordinatorEntity[UniFiAlertsCoordinator], Sens
         self._attr_device_info = _device_info(entry)
 
     @property
-    def native_value(self) -> str:
+    def native_value(self) -> str | None:
         state: CategoryState | None = self.coordinator.get_category_state(self._category)
         if not state or not state.last_alert:
-            return "No alerts yet"
+            return None
         return state.last_alert.message
 
     @property

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -14,7 +14,7 @@
       },
       "categories": {
         "title": "Configure Alert Categories",
-        "description": "Choose which alert types to monitor. Each enabled category gets its own sensors and a dedicated webhook URL (shown in the next step).\n\n⚠️ **Network: Client connect/disconnect** and **Network: Device offline/online** fire very frequently on active home networks. Leave these OFF unless you specifically need them.\n\n**Polling interval**: how often to fetch open-alarm counts from the controller as a backup to webhooks (lower = more accurate, higher = less load).\n**Auto-clear timeout**: minutes before an active sensor automatically resets to OFF if no further alert arrives.",
+        "description": "Choose which alert types to monitor. Each enabled category gets its own sensors and a dedicated webhook URL (shown in the next step).\n\nWarning: **Network: Client connect/disconnect** and **Network: Device offline/online** fire very frequently on active home networks. Leave these OFF unless you specifically need them.\n\n**Polling interval**: how often to fetch open-alarm counts from the controller as a backup to webhooks (lower = more accurate, higher = less load).\n**Auto-clear timeout**: minutes before an active sensor automatically resets to OFF if no further alert arrives.",
         "data": {
           "cat_network_device": "Network: Device offline/online",
           "cat_network_wan": "Network: WAN offline/latency",
@@ -108,12 +108,12 @@
       "any_alert": {"name": "Any Alert"}
     },
     "sensor": {
-      "last_message": {"name": "{category} — Last Message"},
-      "open_count": {"name": "{category} — Open Count"},
+      "last_message": {"name": "{category}: Last Message"},
+      "open_count": {"name": "{category}: Open Count"},
       "total_open": {"name": "Total Open Alerts"}
     },
     "event": {
-      "event": {"name": "{category} — Event"}
+      "event": {"name": "{category}: Event"}
     },
     "button": {
       "clear_category": {"name": "Clear {category}"},

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -14,7 +14,7 @@
       },
       "categories": {
         "title": "Configure Alert Categories",
-        "description": "Choose which alert types to monitor. Each enabled category gets its own sensors and a dedicated webhook URL (shown in the next step).\n\n⚠️ **Network: Client connect/disconnect** and **Network: Device offline/online** fire very frequently on active home networks. Leave these OFF unless you specifically need them.\n\n**Polling interval**: how often to fetch open-alarm counts from the controller as a backup to webhooks (lower = more accurate, higher = less load).\n**Auto-clear timeout**: minutes before an active sensor automatically resets to OFF if no further alert arrives.",
+        "description": "Choose which alert types to monitor. Each enabled category gets its own sensors and a dedicated webhook URL (shown in the next step).\n\nWarning: **Network: Client connect/disconnect** and **Network: Device offline/online** fire very frequently on active home networks. Leave these OFF unless you specifically need them.\n\n**Polling interval**: how often to fetch open-alarm counts from the controller as a backup to webhooks (lower = more accurate, higher = less load).\n**Auto-clear timeout**: minutes before an active sensor automatically resets to OFF if no further alert arrives.",
         "data": {
           "cat_network_device": "Network: Device offline/online",
           "cat_network_wan": "Network: WAN offline/latency",
@@ -108,12 +108,12 @@
       "any_alert": {"name": "Any Alert"}
     },
     "sensor": {
-      "last_message": {"name": "{category} — Last Message"},
-      "open_count": {"name": "{category} — Open Count"},
+      "last_message": {"name": "{category}: Last Message"},
+      "open_count": {"name": "{category}: Open Count"},
       "total_open": {"name": "Total Open Alerts"}
     },
     "event": {
-      "event": {"name": "{category} — Event"}
+      "event": {"name": "{category}: Event"}
     },
     "button": {
       "clear_category": {"name": "Clear {category}"},

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -239,11 +239,11 @@ class TestUniFiCategoryMessageSensor:
     def test_native_value_default_when_no_alert(self):
         state = make_state()
         entity = self._make(state)
-        assert entity.native_value == "No alerts yet"
+        assert entity.native_value is None
 
     def test_native_value_default_when_state_missing(self):
         entity = self._make(None)
-        assert entity.native_value == "No alerts yet"
+        assert entity.native_value is None
 
     def test_available_true_when_enabled(self):
         state = make_state(enabled=True)
@@ -665,7 +665,7 @@ class TestEntityCategories:
         coord = make_coordinator({CATEGORY_NETWORK_WAN: make_state()})
         entry = make_entry()
         entity = UniFiCategoryMessageSensor(coord, entry, CATEGORY_NETWORK_WAN)
-        assert entity.native_value == "No alerts yet"
+        assert entity.native_value is None
 
     def test_message_sensor_returns_message_when_alert_present(self):
         from custom_components.unifi_alerts.sensor import UniFiCategoryMessageSensor


### PR DESCRIPTION
## Summary

- `UniFiCategoryMessageSensor.native_value` now returns `None` instead of the hardcoded English string `"No alerts yet"` when no alert has been received. HA renders `None` as the built-in translated "Unknown" state, so no English string is hard-coded in the platform file.
- Entity display names replace em-dashes (`—`) with colons (`:`) per the project writing-style rule. `unique_id` values are unchanged so existing automations are unaffected.
- The `⚠️` warning glyph in the category-configuration step description is replaced with the plain-text prefix `Warning:` so meaning is preserved for screen readers and translators.
- Tests updated to assert `native_value is None` (previously `== "No alerts yet"`).

## Test plan

- [ ] `make check` passes (lint, typecheck, tests)
- [ ] Sensor shows "Unknown" in HA UI when no alerts have been received for a category
- [ ] Sensor shows the alert message when an alert is present
- [ ] Entity display names in HA use `:` separator (e.g. "WAN: Last Message")
- [ ] Config flow categories step shows "Warning:" instead of emoji

Closes #138

https://claude.ai/code/session_01YNAtv86M1PomHg8wxCzvkg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNAtv86M1PomHg8wxCzvkg)_