### PR TITLE
fix: add transient-failure backoff to probe_system_log_endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - `make lint`, `make typecheck`, `make validate`, and the `.githooks/pre-push` hook no longer crash on Windows shells whose stdout codec defaults to `cp1252`. Previously, the `✅` success glyph printed by the scripts raised `UnicodeEncodeError` and exited the script non-zero even when the underlying tool (ruff, mypy, the validators) had succeeded. All five affected scripts (`run_lint.py`, `run_typecheck.py`, `validate_hacs.py`, `validate_docs.py`, `check_translations.py`) now reconfigure stdout and stderr to UTF-8 via a shared `scripts/_console.py` helper at startup. Windows contributors no longer need to export `PYTHONIOENCODING=utf-8` to use the standard development workflow. ([#148])
+- The v2 system-log probe no longer re-fires on every poll when the endpoint returns persistent non-404 errors. After 5 consecutive transient failures the probe caches the legacy path for 1 hour, then retries. A single blip still causes a re-probe on the next poll. ([#137])
 
 ### Security
 

--- a/custom_components/unifi_alerts/unifi_client.py
+++ b/custom_components/unifi_alerts/unifi_client.py
@@ -29,6 +29,13 @@ _LOGGER = logging.getLogger(__name__)
 # UniFi OS consoles (UDM, UCG, etc.) prefix all network API paths
 UNIFI_OS_NETWORK_PREFIX = "/proxy/network"
 
+# After this many consecutive transient probe failures, stop re-probing and
+# fall back to the legacy path. A single network blip should not pin the
+# client to legacy mode, so the threshold is intentionally > 1.
+_PROBE_FAIL_LIMIT = 5
+# How long to wait before attempting another probe after the threshold is hit.
+_PROBE_RETRY_AFTER = timedelta(hours=1)
+
 
 class CannotConnectError(Exception):
     """Raised when the controller is unreachable."""
@@ -72,6 +79,10 @@ class UniFiClient:
         # None = not yet probed. authenticate() detects v2 system-log availability
         # on first connect; fetch_alarms() falls back to legacy /list/alarm if False.
         self._has_system_log: bool | None = None
+        # Consecutive transient probe failures. Resets to 0 on any definitive result.
+        self._probe_fail_count: int = 0
+        # Set when _probe_fail_count reaches _PROBE_FAIL_LIMIT; clears on retry window expiry.
+        self._probe_backoff_until: datetime | None = None
 
     # ── Public interface ──────────────────────────────────────────────────
 
@@ -187,16 +198,29 @@ class UniFiClient:
         Calls POST /proxy/network/v2/api/site/{site}/system-log/count with an
         empty body. A 200 response indicates availability; 404 is the
         controller's definitive "endpoint not implemented" response. Any other
-        4xx/5xx or network error is treated as transient: the current poll
-        falls back to the legacy path, but the next poll re-probes.
+        4xx/5xx or network error is treated as transient.
 
-        Cache semantics: self._has_system_log is set to True or False only on
-        definitive responses (200 / 404). Transient failures leave the cache
-        as None so a capable controller is not pinned to legacy mode by a
-        single network blip.
+        Cache semantics:
+        - 200 sets _has_system_log=True (permanent until re-auth).
+        - 404 sets _has_system_log=False with no retry (_probe_backoff_until=None).
+        - A single transient failure leaves _has_system_log=None (re-probes next poll).
+        - After _PROBE_FAIL_LIMIT consecutive transient failures, _has_system_log is
+          set to False and _probe_backoff_until is set to now + _PROBE_RETRY_AFTER.
+          Once that window expires the probe resets to None and retries.
         """
         if self._has_system_log is not None:
-            return self._has_system_log
+            # For a backoff-triggered False, check whether the retry window has opened.
+            if self._has_system_log is False and self._probe_backoff_until is not None:
+                if datetime.now(UTC) >= self._probe_backoff_until:
+                    _LOGGER.debug("v2 system-log probe backoff expired; will retry")
+                    self._has_system_log = None
+                    self._probe_fail_count = 0
+                    self._probe_backoff_until = None
+                    # Fall through to probe below.
+                else:
+                    return False
+            else:
+                return self._has_system_log
 
         if not self._authenticated:
             await self.authenticate()
@@ -214,23 +238,56 @@ class UniFiClient:
                 if resp.status == 200:
                     _LOGGER.debug("v2 system-log endpoint available")
                     self._has_system_log = True
+                    self._probe_fail_count = 0
+                    self._probe_backoff_until = None
                     return True
                 if resp.status == 404:
                     _LOGGER.debug(
                         "v2 system-log endpoint not implemented (HTTP 404); using legacy path"
                     )
                     self._has_system_log = False
+                    self._probe_fail_count = 0
                     return False
-                _LOGGER.debug(
-                    "v2 system-log probe got HTTP %d (transient); legacy path this poll, will retry next",
-                    resp.status,
-                )
+                self._probe_fail_count += 1
+                if self._probe_fail_count >= _PROBE_FAIL_LIMIT:
+                    self._has_system_log = False
+                    self._probe_backoff_until = datetime.now(UTC) + _PROBE_RETRY_AFTER
+                    _LOGGER.debug(
+                        "v2 system-log probe failed %d consecutive times (HTTP %d); "
+                        "switching to legacy path for %s",
+                        _PROBE_FAIL_LIMIT,
+                        resp.status,
+                        _PROBE_RETRY_AFTER,
+                    )
+                else:
+                    _LOGGER.debug(
+                        "v2 system-log probe got HTTP %d (transient, %d/%d); "
+                        "legacy path this poll, will retry next",
+                        resp.status,
+                        self._probe_fail_count,
+                        _PROBE_FAIL_LIMIT,
+                    )
                 return False
         except aiohttp.ClientError as err:
-            _LOGGER.debug(
-                "v2 system-log probe failed with %s (transient); legacy path this poll, will retry next",
-                type(err).__name__,
-            )
+            self._probe_fail_count += 1
+            if self._probe_fail_count >= _PROBE_FAIL_LIMIT:
+                self._has_system_log = False
+                self._probe_backoff_until = datetime.now(UTC) + _PROBE_RETRY_AFTER
+                _LOGGER.debug(
+                    "v2 system-log probe failed %d consecutive times (%s); "
+                    "switching to legacy path for %s",
+                    _PROBE_FAIL_LIMIT,
+                    type(err).__name__,
+                    _PROBE_RETRY_AFTER,
+                )
+            else:
+                _LOGGER.debug(
+                    "v2 system-log probe failed with %s (transient, %d/%d); "
+                    "legacy path this poll, will retry next",
+                    type(err).__name__,
+                    self._probe_fail_count,
+                    _PROBE_FAIL_LIMIT,
+                )
             return False
 
     async def fetch_system_log_alarms(

--- a/tests/unit/test_unifi_client.py
+++ b/tests/unit/test_unifi_client.py
@@ -20,6 +20,8 @@ from custom_components.unifi_alerts.unifi_client import (
     CannotConnectError,
     InvalidAuthError,
     UniFiClient,
+    _PROBE_FAIL_LIMIT,
+    _PROBE_RETRY_AFTER,
 )
 
 
@@ -1072,6 +1074,115 @@ class TestProbeSystemLogEndpoint:
 
         assert captured_url, "Expected one POST call"
         assert "v2/api/site/mysite/system-log/count" in captured_url[0]
+
+
+    @pytest.mark.asyncio
+    async def test_probe_backoff_triggers_after_fail_limit(self):
+        """After _PROBE_FAIL_LIMIT consecutive transient failures the probe caches False
+        and sets a backoff deadline so subsequent polls skip the network entirely."""
+        client = make_client()
+        client._authenticated = True
+        ctx, _ = _make_post_json_response(503)
+
+        call_count = [0]
+
+        @asynccontextmanager
+        async def _always_503(*args, **kwargs):
+            call_count[0] += 1
+            resp = MagicMock()
+            resp.status = 503
+            resp.json = AsyncMock(return_value={})
+            yield resp
+
+        client._session.post = _always_503
+        for _ in range(_PROBE_FAIL_LIMIT):
+            result = await client.probe_system_log_endpoint()
+            assert result is False
+
+        # After the threshold the cache must be False and a backoff deadline set.
+        assert client._has_system_log is False
+        assert client._probe_backoff_until is not None
+        assert client._probe_fail_count == _PROBE_FAIL_LIMIT
+
+    @pytest.mark.asyncio
+    async def test_probe_during_backoff_skips_network(self):
+        """Once in backoff, probes must return False without making a network call."""
+        from datetime import UTC, datetime, timedelta
+
+        client = make_client()
+        client._authenticated = True
+        client._has_system_log = False
+        client._probe_backoff_until = datetime.now(UTC) + timedelta(hours=1)
+
+        call_count = [0]
+
+        @asynccontextmanager
+        async def _should_not_be_called(*args, **kwargs):
+            call_count[0] += 1
+            yield MagicMock()
+
+        client._session.post = _should_not_be_called
+        result = await client.probe_system_log_endpoint()
+        assert result is False
+        assert call_count[0] == 0, "Network must not be hit during backoff"
+
+    @pytest.mark.asyncio
+    async def test_probe_retries_after_backoff_expires(self):
+        """Once the backoff window expires, the next probe must hit the network
+        and, if successful, set cache=True and clear backoff state."""
+        from datetime import UTC, datetime, timedelta
+
+        client = make_client()
+        client._authenticated = True
+        # Simulate an expired backoff (deadline in the past).
+        client._has_system_log = False
+        client._probe_backoff_until = datetime.now(UTC) - timedelta(seconds=1)
+        client._probe_fail_count = _PROBE_FAIL_LIMIT
+
+        ctx, _ = _make_post_json_response(200, {})
+        client._session.post = ctx
+
+        result = await client.probe_system_log_endpoint()
+        assert result is True
+        assert client._has_system_log is True
+        assert client._probe_backoff_until is None
+        assert client._probe_fail_count == 0
+
+    @pytest.mark.asyncio
+    async def test_probe_404_does_not_set_backoff(self):
+        """A definitive 404 must set cache=False without a backoff deadline
+        (the endpoint will never appear on this controller)."""
+        client = make_client()
+        client._authenticated = True
+        ctx, _ = _make_post_json_response(404)
+        client._session.post = ctx
+
+        result = await client.probe_system_log_endpoint()
+        assert result is False
+        assert client._has_system_log is False
+        assert client._probe_backoff_until is None
+
+    @pytest.mark.asyncio
+    async def test_probe_backoff_via_network_error(self):
+        """Repeated aiohttp.ClientError failures must also trigger the backoff
+        after reaching _PROBE_FAIL_LIMIT."""
+        import aiohttp
+
+        client = make_client()
+        client._authenticated = True
+
+        @asynccontextmanager
+        async def _always_fail(*args, **kwargs):
+            raise aiohttp.ClientConnectionError("unreachable")
+            yield
+
+        client._session.post = _always_fail
+        for _ in range(_PROBE_FAIL_LIMIT):
+            result = await client.probe_system_log_endpoint()
+            assert result is False
+
+        assert client._has_system_log is False
+        assert client._probe_backoff_until is not None
 
 
 class TestFetchSystemLogAlarms:


### PR DESCRIPTION
## Summary

- `probe_system_log_endpoint` previously re-probed on every coordinator poll whenever the endpoint returned a persistent non-404 error (e.g. a misbehaving reverse proxy always returning 503). This doubled the request rate indefinitely against the controller.
- After `_PROBE_FAIL_LIMIT` (5) consecutive transient failures, the probe now caches the legacy path and sets a 1-hour retry window (`_PROBE_RETRY_AFTER`). Once the window expires, the probe resets and retries.
- A single transient failure still leaves the cache empty so one blip does not pin a capable controller to legacy mode.
- HTTP 404 remains a definitive "endpoint not implemented" result with no retry scheduled.
- Two new instance variables: `_probe_fail_count: int` (consecutive transient failures) and `_probe_backoff_until: datetime | None` (retry deadline).
- Five new tests covering threshold trigger, network-skip during backoff, retry after expiry, 404 not setting backoff, and network-error path through the threshold.

## Test plan

- [ ] All existing `TestProbeSystemLogEndpoint` tests pass
- [ ] New backoff tests pass
- [ ] `make check` green

Closes #137

https://claude.ai/code/session_01YNAtv86M1PomHg8wxCzvkg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNAtv86M1PomHg8wxCzvkg)_