### PR TITLE
ci: pin ruff and remove dead test import

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ pytest
 pytest-asyncio
 pytest-cov
 pytest-homeassistant-custom-component
-ruff
+ruff==0.15.16  # pinned: an unpinned ruff silently picks up new lint rules and breaks CI on unrelated files

--- a/tests/unit/test_unifi_client.py
+++ b/tests/unit/test_unifi_client.py
@@ -17,11 +17,10 @@ from custom_components.unifi_alerts.const import (
     CATEGORY_SECURITY_THREAT,
 )
 from custom_components.unifi_alerts.unifi_client import (
+    _PROBE_FAIL_LIMIT,
     CannotConnectError,
     InvalidAuthError,
     UniFiClient,
-    _PROBE_FAIL_LIMIT,
-    _PROBE_RETRY_AFTER,
 )
 
 
@@ -1074,7 +1073,6 @@ class TestProbeSystemLogEndpoint:
 
         assert captured_url, "Expected one POST call"
         assert "v2/api/site/mysite/system-log/count" in captured_url[0]
-
 
     @pytest.mark.asyncio
     async def test_probe_backoff_triggers_after_fail_limit(self):


### PR DESCRIPTION
## Summary

`requirements-dev.txt` left `ruff` unpinned, so a fresh `make setup` / CI install now pulls **ruff 0.15.16**, which flags three things in `tests/unit/test_unifi_client.py` that an older ruff accepted when #157 merged yesterday:

- an **unused import** (`_PROBE_RETRY_AFTER`) — a genuine dead import, never referenced;
- an **import ordering** change (underscore-prefixed names now sort first);
- a **stray double blank line**.

These block `make check` locally and would break **dev's own CI on its next clean install**, on a file unrelated to whatever change triggers that run.

## Changes

- **`requirements-dev.txt`**: pin `ruff==0.15.16` so lint is deterministic across CI and local installs. Dependabot can still propose controlled bumps. This is the root-cause fix for the drift.
- **`tests/unit/test_unifi_client.py`**: remove the dead import, fix the import order, drop the extra blank line (all via `ruff check --fix` + `ruff format`). `_PROBE_FAIL_LIMIT` is retained — it is used.

## Test plan

- [x] `make check` green: ruff lint + format, mypy, HACS preflight, translation drift, 495 tests, 97.90% coverage.

## Note

Found while picking up #118 (watermark persistence). #118 is implemented and stacked on this branch; its PR will follow once this lands so the lint baseline is clean. No production code changes here.

https://claude.ai/code/session_01PB8ifGMNshzif4i8DubbjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PB8ifGMNshzif4i8DubbjE)_