### PR TITLE
fix: coalesce watermark persistence and surface background failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - `make lint`, `make typecheck`, `make validate`, and the `.githooks/pre-push` hook no longer crash on Windows shells whose stdout codec defaults to `cp1252`. Previously, the `✅` success glyph printed by the scripts raised `UnicodeEncodeError` and exited the script non-zero even when the underlying tool (ruff, mypy, the validators) had succeeded. All five affected scripts (`run_lint.py`, `run_typecheck.py`, `validate_hacs.py`, `validate_docs.py`, `check_translations.py`) now reconfigure stdout and stderr to UTF-8 via a shared `scripts/_console.py` helper at startup. Windows contributors no longer need to export `PYTHONIOENCODING=utf-8` to use the standard development workflow. ([#148])
 - The v2 system-log probe no longer re-fires on every poll when the endpoint returns persistent non-404 errors. After 5 consecutive transient failures the probe caches the legacy path for 1 hour, then retries. A single blip still causes a re-probe on the next poll. ([#137])
+- Watermark/alert-count persistence triggered by a webhook push now coalesces a burst of pushes into a single debounced write via `Store.async_delay_save`, removing a lost-update race between overlapping fire-and-forget saves. Background-task failures (including a persist raised inside an auto-clear) are now logged via a shared done-callback instead of being silently swallowed. ([#118])
 
 ### Security
 
@@ -218,6 +219,7 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#67]: https://github.com/PHeonix25/unifi_alerts/pull/67
 [#68]: https://github.com/PHeonix25/unifi_alerts/pull/68
 [#116]: https://github.com/PHeonix25/unifi_alerts/issues/116
+[#118]: https://github.com/PHeonix25/unifi_alerts/issues/118
 [#147]: https://github.com/PHeonix25/unifi_alerts/pull/147
 [#148]: https://github.com/PHeonix25/unifi_alerts/issues/148
 [#PR]: https://github.com/PHeonix25/unifi_alerts/pull/PR

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Coroutine
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -31,6 +32,12 @@ from .unifi_client import CannotConnectError, InvalidAuthError, UniFiClient
 _LOGGER = logging.getLogger(__name__)
 
 _STORAGE_VERSION = 1
+
+# Debounce window for watermark persistence. push_alert is synchronous and can
+# fire in bursts; routing writes through Store.async_delay_save with this delay
+# coalesces a burst into a single durable write instead of one fire-and-forget
+# save per push.
+_PERSIST_DELAY_SECONDS = 1
 
 
 class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
@@ -344,9 +351,14 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
                     except (KeyError, TypeError, ValueError):
                         _LOGGER.warning("Ignoring invalid stored last_alert for %s", cat)
 
-    async def _async_persist_watermarks(self) -> None:
-        """Persist current category state (watermark, alert_count, last_alert) to storage."""
-        data: dict[str, dict[str, Any]] = {}
+    def _build_persist_data(self) -> dict[str, Any]:
+        """Build the JSON-serialisable snapshot of category state to persist.
+
+        Synchronous so it can be handed to ``Store.async_delay_save`` as the
+        data function, which calls it at write time to capture the latest
+        state after a burst of pushes has settled.
+        """
+        data: dict[str, Any] = {}
         for cat, state in self._category_states.items():
             entry: dict[str, Any] = {}
             if state.last_cleared_at is not None:
@@ -356,7 +368,11 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
                 state.last_alert.to_dict() if state.last_alert is not None else None
             )
             data[cat] = entry
-        await self._store.async_save(data)
+        return data
+
+    async def _async_persist_watermarks(self) -> None:
+        """Persist current category state immediately (awaited explicit-clear path)."""
+        await self._store.async_save(self._build_persist_data())
 
     # ── Clear entry points (called by buttons and services) ───────────────
 
@@ -391,27 +407,46 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
             existing.cancel()
 
         delay = self._clear_timeout_minutes * 60
-        coro = self._auto_clear(category, delay)
+        self._clear_tasks[category] = self._run_background(
+            self._auto_clear(category, delay),
+            name=f"unifi_alerts_auto_clear_{category}",
+        )
+
+    def _run_background(self, coro: Coroutine[Any, Any, None], *, name: str) -> asyncio.Task[None]:
+        """Create a background task and surface any exception it raises.
+
+        Centralises background-task creation so a failure in a fire-and-forget
+        coroutine (e.g. the persist awaited inside ``_auto_clear``) is logged
+        via the done-callback instead of being silently swallowed.
+        """
         create_bg = getattr(self.hass, "async_create_background_task", None)
+        task: asyncio.Task[None]
         if create_bg is not None:
-            task = create_bg(coro, name=f"unifi_alerts_auto_clear_{category}")
+            task = create_bg(coro, name=name)
         else:
             create_task = getattr(self.hass, "async_create_task", None)
             task = create_task(coro) if create_task is not None else asyncio.ensure_future(coro)
-        self._clear_tasks[category] = task
+        task.add_done_callback(self._on_background_task_done)
+        return task
+
+    @staticmethod
+    def _on_background_task_done(task: asyncio.Task[Any]) -> None:
+        """Log any non-cancellation exception raised by a background task."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            _LOGGER.error("Background task %s failed: %s", task.get_name(), exc, exc_info=exc)
 
     def _schedule_persist(self) -> None:
-        """Schedule a fire-and-forget persist so push_alert (sync) can trigger a save."""
-        coro = self._async_persist_watermarks()
-        create_bg = getattr(self.hass, "async_create_background_task", None)
-        if create_bg is not None:
-            create_bg(coro, name="unifi_alerts_persist_state")
-        else:
-            create_task = getattr(self.hass, "async_create_task", None)
-            if create_task is not None:
-                create_task(coro)
-            else:
-                asyncio.ensure_future(coro)
+        """Persist category state, coalescing bursts into one delayed write.
+
+        push_alert is synchronous and can fire rapidly. Routing through
+        ``Store.async_delay_save`` debounces a burst into a single durable
+        write (no lost-update race between overlapping fire-and-forget saves)
+        and lets HA's storage layer own the write and log any failure.
+        """
+        self._store.async_delay_save(self._build_persist_data, _PERSIST_DELAY_SECONDS)
 
     def cancel_clear(self, category: str) -> None:
         """Cancel any pending auto-clear task for the given category."""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ pytest
 pytest-asyncio
 pytest-cov
 pytest-homeassistant-custom-component
-ruff
+ruff==0.15.16  # pinned: an unpinned ruff silently picks up new lint rules and breaks CI on unrelated files

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,7 +17,10 @@ from custom_components.unifi_alerts.const import (
     CONF_ENABLED_CATEGORIES,
     CONF_POLL_INTERVAL,
 )
-from custom_components.unifi_alerts.coordinator import UniFiAlertsCoordinator
+from custom_components.unifi_alerts.coordinator import (
+    _PERSIST_DELAY_SECONDS,
+    UniFiAlertsCoordinator,
+)
 from custom_components.unifi_alerts.models import UniFiAlert
 
 
@@ -38,7 +43,15 @@ def make_coordinator(hass=None, enabled=None):
         CONF_POLL_INTERVAL: 60,
         CONF_CLEAR_TIMEOUT: 30,
     }
-    return UniFiAlertsCoordinator(hass, client, config)
+    coord = UniFiAlertsCoordinator(hass, client, config)
+    # Persistence is exercised in dedicated tests; default to a mock Store so
+    # push_alert's debounced async_delay_save is a harmless no-op here (the
+    # real Store needs a live event loop the MagicMock hass does not provide).
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=None)
+    coord._store.async_save = AsyncMock()
+    coord._store.async_delay_save = MagicMock()
+    return coord
 
 
 def make_alert(category: str, message: str = "test alert", key: str = "") -> UniFiAlert:
@@ -1484,17 +1497,90 @@ class TestCoordinatorUncoveredBranches:
         coord._schedule_clear(CATEGORY_NETWORK_WAN)
         assert coord._clear_tasks[CATEGORY_NETWORK_WAN] is created
 
-    def test_schedule_persist_uses_async_create_task_when_background_missing(self):
-        hass = MagicMock()
-        hass.async_create_background_task = None
-        called = {"create_task": 0}
+    def test_schedule_persist_delegates_to_delay_save(self):
+        """push persist must coalesce via Store.async_delay_save, not per-push tasks."""
+        coord = make_coordinator()
+        coord._store = MagicMock()
+        coord._store.async_delay_save = MagicMock()
 
-        def _create_task(coro):
-            called["create_task"] += 1
-            coro.close()
-            return MagicMock()
-
-        hass.async_create_task = _create_task
-        coord = make_coordinator(hass=hass)
         coord._schedule_persist()
-        assert called["create_task"] == 1
+
+        coord._store.async_delay_save.assert_called_once()
+        data_func, delay = coord._store.async_delay_save.call_args.args
+        assert callable(data_func)
+        assert delay == _PERSIST_DELAY_SECONDS
+        # The data function returns a live snapshot of every category, so the
+        # single coalesced write reflects state captured at write time.
+        snapshot = data_func()
+        assert set(snapshot) == set(ALL_CATEGORIES)
+
+    def test_schedule_persist_burst_coalesces_to_single_delay_save_per_call(self):
+        """A burst of pushes routes every persist through the same debounced sink.
+
+        Store.async_delay_save owns the debounce: repeated calls within the
+        delay window collapse to one durable write. We assert we always hand
+        off to it (never a fire-and-forget async_save), which is what removes
+        the lost-update race.
+        """
+        coord = make_coordinator()
+        coord._store = MagicMock()
+        coord._store.async_delay_save = MagicMock()
+        coord._store.async_save = AsyncMock()
+
+        for _ in range(5):
+            coord._schedule_persist()
+
+        assert coord._store.async_delay_save.call_count == 5
+        coord._store.async_save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_background_task_exception_is_logged(self, caplog):
+        """A background coroutine that raises must be logged, not swallowed."""
+        hass = MagicMock()
+        hass.async_create_background_task = lambda coro, name=None: asyncio.ensure_future(coro)
+        coord = make_coordinator(hass=hass)
+
+        async def _boom() -> None:
+            raise RuntimeError("kaboom")
+
+        task = coord._run_background(_boom(), name="unifi_alerts_test")
+        with caplog.at_level(logging.ERROR):
+            await asyncio.gather(task, return_exceptions=True)
+            await asyncio.sleep(0)  # let the done-callback run
+
+        assert "kaboom" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_background_persist_save_failure_is_logged(self, caplog):
+        """The save-raises path: a persist exception inside a bg task is logged."""
+        hass = MagicMock()
+        hass.async_create_background_task = lambda coro, name=None: asyncio.ensure_future(coro)
+        coord = make_coordinator(hass=hass)
+        coord._store = MagicMock()
+        coord._store.async_save = AsyncMock(side_effect=OSError("disk full"))
+
+        task = coord._run_background(coord._async_persist_watermarks(), name="persist")
+        with caplog.at_level(logging.ERROR):
+            await asyncio.gather(task, return_exceptions=True)
+            await asyncio.sleep(0)
+
+        assert "disk full" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_background_task_cancellation_is_not_logged(self, caplog):
+        """Cancelling a background task must not log an error."""
+        hass = MagicMock()
+        hass.async_create_background_task = lambda coro, name=None: asyncio.ensure_future(coro)
+        coord = make_coordinator(hass=hass)
+
+        async def _sleep_forever() -> None:
+            await asyncio.sleep(3600)
+
+        task = coord._run_background(_sleep_forever(), name="unifi_alerts_test")
+        await asyncio.sleep(0)
+        task.cancel()
+        with caplog.at_level(logging.ERROR):
+            await asyncio.gather(task, return_exceptions=True)
+            await asyncio.sleep(0)
+
+        assert "failed" not in caplog.text

--- a/tests/unit/test_unifi_client.py
+++ b/tests/unit/test_unifi_client.py
@@ -17,11 +17,10 @@ from custom_components.unifi_alerts.const import (
     CATEGORY_SECURITY_THREAT,
 )
 from custom_components.unifi_alerts.unifi_client import (
+    _PROBE_FAIL_LIMIT,
     CannotConnectError,
     InvalidAuthError,
     UniFiClient,
-    _PROBE_FAIL_LIMIT,
-    _PROBE_RETRY_AFTER,
 )
 
 
@@ -1074,7 +1073,6 @@ class TestProbeSystemLogEndpoint:
 
         assert captured_url, "Expected one POST call"
         assert "v2/api/site/mysite/system-log/count" in captured_url[0]
-
 
     @pytest.mark.asyncio
     async def test_probe_backoff_triggers_after_fail_limit(self):


### PR DESCRIPTION
## Summary

Resolves #118. The per-push watermark/alert-count persistence in `coordinator.py` was a synchronous-triggered, fire-and-forget `async_save` with no error path. Under a burst of webhook pushes, overlapping saves could race (lost update), and a failed write died silently.

- **Coalesce bursts**: push-triggered persistence now routes through `Store.async_delay_save`, HA's debounce primitive, which collapses a burst into a single durable write. The data builder is extracted into a synchronous `_build_persist_data()` so it can serve as the delay-save data function (called at write time, capturing the latest state).
- **Surface failures**: a shared `_run_background()` helper centralises background-task creation and attaches a done-callback that logs any non-`CancelledError` exception. `_schedule_clear` (whose `_auto_clear` awaits a persist) now routes through it, so a persist failure inside auto-clear is logged instead of swallowed.
- The awaited explicit-clear paths (`async_clear_category`, `async_clear_all`, `_auto_clear`) keep their immediate `await async_save` (durable on button press); `async_save` supersedes any pending delayed write, so there is no double-write or lost update between the two.

Maps to the issue's acceptance criteria:
- [x] Bursted pushes coalesce to a single durable write (via `async_delay_save`)
- [x] A persist exception is logged, not swallowed (via the `_run_background` done-callback)
- [x] Test covers the save-raises path (`test_background_persist_save_failure_is_logged`)

## Stacked on #159 — merge that first

This branch is based on `claude/fix-pin-ruff-dead-import` (#159), which pins `ruff` and clears a pre-existing lint failure. Without it `make check` / CI fails on an unrelated file. **Merge #159 first**; this PR's diff then reduces to just the #118 change. The first commit here (`ci: pin ruff…`) is #159's and will drop out once it lands.

## Test plan

- [x] `make check` green: ruff lint + format, mypy strict, HACS preflight, translation drift, **499 tests**, 98.02% coverage. `coordinator.py` new paths covered (delegation to `async_delay_save`, burst, logged background failure, logged save-raises, cancellation-not-logged).
- [x] CHANGELOG `[Unreleased]` updated with a `### Fixed` bullet and `[#118]` reference.

## Note on issue tracking

This environment cannot register the issue↔branch Development-panel link (`gh issue develop` needs the GitHub API, which is firewalled here and exposes no token). Per the workflow established in #158, the `landed-in-dev` label will be applied to #118 when this merges; the issue closes for real at the next `dev → main` release via `Closes #118`.

https://claude.ai/code/session_01PB8ifGMNshzif4i8DubbjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PB8ifGMNshzif4i8DubbjE)_