### PR TITLE
ci: add pip-audit dependency scanning (CodeQL via default setup)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,9 @@ jobs:
       contents: read
     # Advisory only: a freshly disclosed CVE must not block merges. The job
     # surfaces findings for the maintainer to triage and bump dependencies.
-    continue-on-error: true
+    # continue-on-error sits on the audit step itself (not the job) so the
+    # step failure is swallowed and the check reports green; a job-level flag
+    # only spares the overall run and still surfaces the job as failed.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
@@ -61,5 +63,6 @@ jobs:
           pip install -r requirements-dev.txt
           pip install pip-audit
 
-      - name: Run pip-audit
+      - name: Run pip-audit (advisory)
+        continue-on-error: true
         run: pip-audit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,65 @@
+name: Security scanning
+
+# Static security analysis (CodeQL SAST) plus dependency-vulnerability
+# scanning (pip-audit). Runs on every push and pull request to dev and main,
+# and on a weekly schedule so newly disclosed vulnerabilities are caught even
+# when the code has not changed.
+#
+# pip-audit is advisory only (continue-on-error: true). A newly published CVE
+# in a transitive dependency must not block merges; the maintainer reviews the
+# job output and bumps requirements-dev.txt when warranted. CodeQL findings are
+# surfaced in the repository Security tab, not as a hard merge gate here.
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    # Mondays 06:00 UTC, before the weekly Dependabot run (07:00 Brisbane).
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  codeql:
+    name: CodeQL analysis (python)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read  # CodeQL reads workflow run metadata on private/internal repos.
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+        with:
+          languages: python
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
+
+  pip-audit:
+    name: Dependency vulnerability scan (advisory, non-blocking)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Advisory only: a freshly disclosed CVE must not block merges. The job
+    # surfaces findings for the maintainer to triage and bump dependencies.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dev dependencies and pip-audit
+        run: |
+          pip install -r requirements-dev.txt
+          pip install pip-audit
+
+      - name: Run pip-audit
+        run: pip-audit

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,14 +1,18 @@
-name: Security scanning
+name: Dependency audit
 
-# Static security analysis (CodeQL SAST) plus dependency-vulnerability
-# scanning (pip-audit). Runs on every push and pull request to dev and main,
-# and on a weekly schedule so newly disclosed vulnerabilities are caught even
-# when the code has not changed.
+# Dependency-vulnerability scanning (pip-audit). Runs on every push and pull
+# request to dev and main, and on a weekly schedule so newly disclosed
+# vulnerabilities are caught even when the code has not changed.
 #
-# pip-audit is advisory only (continue-on-error: true). A newly published CVE
-# in a transitive dependency must not block merges; the maintainer reviews the
-# job output and bumps requirements-dev.txt when warranted. CodeQL findings are
-# surfaced in the repository Security tab, not as a hard merge gate here.
+# Static analysis (CodeQL SAST) is handled by GitHub's CodeQL default setup,
+# configured in Settings > Code security and analysis, not by a workflow in
+# this repository. An advanced workflow-based CodeQL config cannot coexist with
+# default setup (GitHub rejects the SARIF upload), so SAST lives there and this
+# workflow owns dependency auditing only.
+#
+# pip-audit is advisory only (continue-on-error on the audit step). A newly
+# published CVE in a transitive dependency must not block merges; the maintainer
+# reviews the job output and bumps requirements-dev.txt when warranted.
 
 on:
   push:
@@ -23,24 +27,6 @@ permissions:
   contents: read
 
 jobs:
-  codeql:
-    name: CodeQL analysis (python)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-      actions: read  # CodeQL reads workflow run metadata on private/internal repos.
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
-        with:
-          languages: python
-
-      - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357  # v3.36.2
-
   pip-audit:
     name: Dependency vulnerability scan (advisory, non-blocking)
     runs-on: ubuntu-latest

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -85,10 +85,11 @@ HA requires `strings.json` and `translations/en.json` to match exactly. Edit bot
 | `hacs` | Validates `hacs.json` and repository structure for HACS listing |
 | `lint` | `ruff check` + `ruff format --check` + `mypy` + `strings.json`/`translations/en.json` drift diff |
 | `test` | `pytest` against `tests/unit/` and `tests/integration/` |
-| `codeql` | CodeQL static security analysis (SAST) for Python. Findings appear in the repository Security tab |
-| `pip-audit` | Dependency vulnerability scan against `requirements-dev.txt`. Advisory only (`continue-on-error: true`); it never blocks a merge |
+| `pip-audit` | Dependency vulnerability scan against `requirements-dev.txt`. Advisory only (`continue-on-error` on the audit step); it never blocks a merge |
 
-`codeql.yml` holds the `codeql` and `pip-audit` jobs. Both run on every push and pull request to `dev` and `main`, plus a weekly Monday 06:00 UTC schedule so newly disclosed vulnerabilities are caught even when the code has not changed. `pip-audit` is intentionally non-blocking: the maintainer reviews its output and bumps `requirements-dev.txt` when a finding warrants it.
+Static security analysis (CodeQL SAST) for Python runs through GitHub's CodeQL **default setup**, configured in Settings > Code security and analysis, with findings in the repository Security tab. It is not a workflow in this repository: an advanced workflow-based CodeQL config cannot coexist with default setup (GitHub rejects the SARIF upload), so SAST lives in default setup and the workflow below owns dependency auditing only.
+
+`dependency-audit.yml` holds the `pip-audit` job. It runs on every push and pull request to `dev` and `main`, plus a weekly Monday 06:00 UTC schedule so newly disclosed vulnerabilities are caught even when the code has not changed. `pip-audit` is intentionally non-blocking: the maintainer reviews its output and bumps `requirements-dev.txt` when a finding warrants it. `continue-on-error` sits on the audit step (not the job) so a finding leaves the check green while the report still appears in the log.
 
 `version-check.yml` enforces the version format per branch (`X.Y.Z` on `main`, `X.Y.Z-preN` on `dev`). `release.yml` triggers on tags and publishes via `gh release create --generate-notes`. All checks except `pip-audit` must pass before merging.
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -85,8 +85,12 @@ HA requires `strings.json` and `translations/en.json` to match exactly. Edit bot
 | `hacs` | Validates `hacs.json` and repository structure for HACS listing |
 | `lint` | `ruff check` + `ruff format --check` + `mypy` + `strings.json`/`translations/en.json` drift diff |
 | `test` | `pytest` against `tests/unit/` and `tests/integration/` |
+| `codeql` | CodeQL static security analysis (SAST) for Python. Findings appear in the repository Security tab |
+| `pip-audit` | Dependency vulnerability scan against `requirements-dev.txt`. Advisory only (`continue-on-error: true`); it never blocks a merge |
 
-`version-check.yml` enforces the version format per branch (`X.Y.Z` on `main`, `X.Y.Z-preN` on `dev`). `release.yml` triggers on tags and publishes via `gh release create --generate-notes`. All checks must pass before merging.
+`codeql.yml` holds the `codeql` and `pip-audit` jobs. Both run on every push and pull request to `dev` and `main`, plus a weekly Monday 06:00 UTC schedule so newly disclosed vulnerabilities are caught even when the code has not changed. `pip-audit` is intentionally non-blocking: the maintainer reviews its output and bumps `requirements-dev.txt` when a finding warrants it.
+
+`version-check.yml` enforces the version format per branch (`X.Y.Z` on `main`, `X.Y.Z-preN` on `dev`). `release.yml` triggers on tags and publishes via `gh release create --generate-notes`. All checks except `pip-audit` must pass before merging.
 
 ## Branching and PRs
 


### PR DESCRIPTION
## Summary

Adds dependency-vulnerability scanning to CI, which previously had none. New `.github/workflows/dependency-audit.yml` carries a single `pip-audit` job:

- **`pip-audit`**: installs `requirements-dev.txt` and runs `pip-audit`. Advisory and **non-blocking** (`continue-on-error` on the audit step) so a freshly disclosed CVE in a transitive dependency cannot block merges; the maintainer reviews the output and bumps `requirements-dev.txt` when warranted. Least-privilege `permissions:` (`contents: read`). Runs on push and pull_request to `dev`/`main`, plus a weekly Monday 06:00 UTC `schedule`.

I used plain `pip-audit` (pip-installed) rather than a third-party action to avoid adding a new pinned dependency, keeping the action surface minimal.

### CodeQL note (changed from the original plan)

The original implementation added an advanced workflow-based CodeQL job. CI revealed the repo already has **CodeQL default setup** enabled, and GitHub rejects SARIF from an advanced config while default setup is on (`CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled`). Per maintainer decision, the CodeQL job was dropped: **static analysis continues via CodeQL default setup** (Settings > Code security and analysis, findings in the Security tab), and this workflow owns dependency auditing only. The file was renamed `codeql.yml` -> `dependency-audit.yml` to match.

## SHA pinning

Every `uses:` is pinned to a full 40-char commit SHA with a trailing tag comment, reusing the SHAs already present elsewhere in `.github/workflows/`:

- `actions/checkout` `de0fac2e4500dabe0009e67214ff5f5447ce83dd` # v6
- `actions/setup-python` `a309ff8b426b58ec0e2a45f0f869d46889d02405` # v6

## Dependabot

`.github/dependabot.yml` `github-actions` ecosystem uses `directory: "/"`, which scans the whole `.github/workflows/` directory. It picks up the renamed workflow automatically; no config change needed.

## Docs

Documented the `pip-audit` job and the CodeQL-default-setup arrangement in the CI overview in `docs/DEVELOPING.md`.

## Acceptance criteria

- [x] Dependency scanning runs on PRs and a weekly schedule
- [x] `pip-audit` job installs `requirements-dev.txt`, runs `pip-audit`, advisory/non-blocking, least-privilege permissions
- [x] Every `uses:` pinned to a full 40-char SHA with a tag comment; shared action SHAs reused
- [x] Dependabot coverage confirmed (directory-scoped, no edit required)
- [x] Documented in `docs/DEVELOPING.md`
- [x] YAML validity confirmed; `scripts/validate_docs.py` passes
- [x] CodeQL SAST retained via default setup (advanced workflow conflicts with it; dropped per maintainer call)

Closes #165

https://claude.ai/code/session_01FMdo6rMsAwzyXhGdCyXYkh

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMdo6rMsAwzyXhGdCyXYkh)_