### PR TITLE
feat: surface watermark persist failures as a repair issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Per-category webhook health signal. Each category binary sensor now exposes a `webhook_health` attribute (`never_received`, `healthy`, or `stale`) and a `last_webhook_at` timestamp, so you can confirm the Alarm Manager wiring works without waiting for a real alert. `healthy` means a webhook arrived within the last 7 days; `stale` means the last one is older than that (expected for rarely-firing categories). Both fields also appear per category in the diagnostics download and survive a config-entry reload. ([#117])
+- A failed watermark save now raises a repair issue in Settings > Repairs warning that cleared alerts may reappear after a restart and to check disk space. The issue clears itself on the next successful save. ([#163])
 
 ### Changed
 
@@ -227,4 +228,5 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#118]: https://github.com/PHeonix25/unifi_alerts/issues/118
 [#147]: https://github.com/PHeonix25/unifi_alerts/pull/147
 [#148]: https://github.com/PHeonix25/unifi_alerts/issues/148
+[#163]: https://github.com/PHeonix25/unifi_alerts/issues/163
 [#PR]: https://github.com/PHeonix25/unifi_alerts/pull/PR

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -38,6 +39,10 @@ _STORAGE_VERSION = 1
 # coalesces a burst into a single durable write instead of one fire-and-forget
 # save per push.
 _PERSIST_DELAY_SECONDS = 1
+
+# Issue-registry id base for the repair surfaced when a watermark persist fails.
+# Suffixed with the config entry id so multi-entry installs report independently.
+_PERSIST_FAILED_ISSUE_BASE = "watermark_persist_failed"
 
 
 class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
@@ -71,6 +76,7 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         self._clear_timeout_minutes: int = config.get(CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT)
         self._enabled_categories: list[str] = config.get(CONF_ENABLED_CATEGORIES, ALL_CATEGORIES)
         self._site: str = config.get(CONF_SITE, DEFAULT_SITE)
+        self._entry_id: str = entry_id
         self._store: Store[dict[str, Any]] = Store(
             hass, _STORAGE_VERSION, f"{DOMAIN}_watermarks_{entry_id}"
         )
@@ -386,8 +392,43 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         return data
 
     async def _async_persist_watermarks(self) -> None:
-        """Persist current category state immediately (awaited explicit-clear path)."""
-        await self._store.async_save(self._build_persist_data())
+        """Persist current category state immediately (awaited explicit-clear path).
+
+        On failure (disk full, I/O error) the in-memory clear has already
+        succeeded, so the user sees the alert cleared but the watermark never
+        reaches disk. On the next HA restart open_count jumps back to the
+        pre-clear value. Surface this as a repair issue so the loss is visible
+        instead of buried in the log, then re-raise so the caller's error path
+        (including the background-task done-callback) still runs. A subsequent
+        successful persist deletes the issue, so it self-heals.
+        """
+        try:
+            await self._store.async_save(self._build_persist_data())
+        except Exception:
+            self._create_persist_failed_issue()
+            raise
+        else:
+            self._delete_persist_failed_issue()
+
+    @property
+    def _persist_failed_issue_id(self) -> str:
+        """Per-entry issue-registry id for the watermark-persist-failed repair."""
+        return f"{_PERSIST_FAILED_ISSUE_BASE}_{self._entry_id}"
+
+    def _create_persist_failed_issue(self) -> None:
+        """Raise a repair issue telling the user a watermark write failed."""
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            self._persist_failed_issue_id,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=_PERSIST_FAILED_ISSUE_BASE,
+        )
+
+    def _delete_persist_failed_issue(self) -> None:
+        """Clear the watermark-persist-failed repair once a write succeeds."""
+        ir.async_delete_issue(self.hass, DOMAIN, self._persist_failed_issue_id)
 
     # ── Clear entry points (called by buttons and services) ───────────────
 

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -74,6 +74,10 @@
           }
         }
       }
+    },
+    "watermark_persist_failed": {
+      "title": "UniFi Alerts: could not save cleared-alert state",
+      "description": "Home Assistant could not write the UniFi Alerts watermark to storage, so cleared alerts may reappear and Open Count may jump back to its previous value after a restart. This usually means the disk is full or there is a storage I/O error. Check available disk space and the Home Assistant logs. This message clears automatically once a save succeeds."
     }
   },
   "services": {

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -74,6 +74,10 @@
           }
         }
       }
+    },
+    "watermark_persist_failed": {
+      "title": "UniFi Alerts: could not save cleared-alert state",
+      "description": "Home Assistant could not write the UniFi Alerts watermark to storage, so cleared alerts may reappear and Open Count may jump back to its previous value after a restart. This usually means the disk is full or there is a storage I/O error. Check available disk space and the Home Assistant logs. This message clears automatically once a save succeeds."
     }
   },
   "services": {

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1633,3 +1633,73 @@ class TestCoordinatorUncoveredBranches:
             await asyncio.sleep(0)
 
         assert "failed" not in caplog.text
+
+
+class TestWatermarkPersistFailureRepair:
+    """A failed watermark persist must surface as a self-healing repair issue.
+
+    When Store.async_save raises (disk full, I/O error) the in-memory clear has
+    already happened, so the user sees the alert cleared but the watermark never
+    reaches disk. On the next restart open_count jumps back. The coordinator
+    raises an issue_registry repair so the loss is visible, then deletes it on
+    the next successful save so it self-heals.
+    """
+
+    def _make_coord(self):
+        coord = make_coordinator()
+        coord._entry_id = "abc123"
+        coord._store = MagicMock()
+        coord._store.async_save = AsyncMock()
+        return coord
+
+    @pytest.mark.asyncio
+    async def test_persist_failure_creates_repair_issue(self):
+        coord = self._make_coord()
+        coord._store.async_save = AsyncMock(side_effect=OSError("disk full"))
+
+        with (
+            patch("custom_components.unifi_alerts.coordinator.ir") as mock_ir,
+            pytest.raises(OSError),
+        ):
+            await coord._async_persist_watermarks()
+
+        mock_ir.async_create_issue.assert_called_once()
+        # Issue id is the constant base suffixed with the entry id.
+        _, kwargs = mock_ir.async_create_issue.call_args
+        args = mock_ir.async_create_issue.call_args.args
+        assert "watermark_persist_failed_abc123" in args
+        # is_fixable=False and severity WARNING per the issue spec.
+        assert kwargs["is_fixable"] is False
+        assert kwargs["severity"] is mock_ir.IssueSeverity.WARNING
+        assert kwargs["translation_key"] == "watermark_persist_failed"
+        # No deletion happened on the failure path.
+        mock_ir.async_delete_issue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_successful_persist_deletes_repair_issue(self):
+        coord = self._make_coord()
+
+        with patch("custom_components.unifi_alerts.coordinator.ir") as mock_ir:
+            await coord._async_persist_watermarks()
+
+        mock_ir.async_delete_issue.assert_called_once()
+        args = mock_ir.async_delete_issue.call_args.args
+        assert "watermark_persist_failed_abc123" in args
+        mock_ir.async_create_issue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_repair_issue_self_heals_on_next_success(self):
+        """Fail once (issue created), then succeed (issue deleted) - end to end."""
+        coord = self._make_coord()
+
+        with patch("custom_components.unifi_alerts.coordinator.ir") as mock_ir:
+            # First save raises - repair issue created.
+            coord._store.async_save = AsyncMock(side_effect=OSError("disk full"))
+            with pytest.raises(OSError):
+                await coord._async_persist_watermarks()
+            assert mock_ir.async_create_issue.call_count == 1
+
+            # Next save succeeds - repair issue deleted (self-heal).
+            coord._store.async_save = AsyncMock()
+            await coord._async_persist_watermarks()
+            assert mock_ir.async_delete_issue.call_count == 1


### PR DESCRIPTION
## Summary

When persisting watermark/clear state to the HA `Store` fails (disk full, I/O error), the in-memory clear has already succeeded, so the user sees the alert cleared but the watermark never reaches disk. On the next restart `open_count` jumps back to the pre-clear value. Previously this was only logged and invisible to the user.

This adds user-facing visibility via the HA repair-issue (`issue_registry`) mechanism:

- `coordinator._async_persist_watermarks()` now creates a repair issue (`watermark_persist_failed_<entry_id>`, severity `warning`, `is_fixable=False`) when `Store.async_save` raises, then re-raises so the existing background-task done-callback still logs it. This covers the awaited persist paths: manual Clear (`async_clear_category` / `async_clear_all`) and auto-clear (run through `_run_background`).
- A subsequent successful persist deletes the issue, so it self-heals.
- The delayed-save path (`_schedule_persist` via `Store.async_delay_save`) is owned by HA's storage layer and its failure is not directly observable to the integration, so the repair is wired to the observable awaited-save path as the issue allowed.
- New issue strings added to both `strings.json` and `translations/en.json`, kept byte-identical so the drift check passes.

## Acceptance criteria

- [x] A failing watermark persist creates a repair issue visible in HA Settings
- [x] The next successful persist removes the repair issue
- [x] strings.json / translations/en.json stay in sync (drift check passes)
- [x] Test covers the save-raises path and the self-heal path
- [x] CHANGELOG `[Unreleased]` updated

## Validation

`make check` passes locally: ruff lint + format, mypy strict, HACS preflight, strings/translations drift check, and the full pytest suite (514 passed, 98% coverage).

## Files touched

- `custom_components/unifi_alerts/coordinator.py`
- `custom_components/unifi_alerts/strings.json`
- `custom_components/unifi_alerts/translations/en.json`
- `tests/unit/test_coordinator.py`
- `CHANGELOG.md`

Closes #163

https://claude.ai/code/session_01FMdo6rMsAwzyXhGdCyXYkh

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMdo6rMsAwzyXhGdCyXYkh)_