### PR TITLE
fix: reject unparseable webhook bodies with HTTP 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- Authenticated webhook POSTs whose body is not valid JSON or not valid UTF-8 now return HTTP 400 and are discarded rather than synthesizing an "Unknown alert" entity state update. A token-bearing sender could previously spam meaningless "Unknown alert" events via malformed bodies. ([#173])
 - `UniFiClearCategoryButton` and `UniFiClearAllButton` now override `_handle_coordinator_update()` to call `async_write_ha_state()`, so the `available` property is re-evaluated when coordinator state changes (e.g. after a category is disabled via the options flow without a full reload). Previously the button entities could remain stale between polls. ([#170])
 - A second 401 response from the controller after a successful re-authentication now raises `ConfigEntryAuthFailed` (triggering HA's re-auth repair flow) instead of propagating as an unhandled `InvalidAuthError`. Previously the coordinator only caught `CannotConnectError` on the retried fetch, so a persistent authentication failure after credential rotation silently broke polling. ([#122])
 - `make lint`, `make typecheck`, `make validate`, and the `.githooks/pre-push` hook no longer crash on Windows shells whose stdout codec defaults to `cp1252`. Previously, the `✅` success glyph printed by the scripts raised `UnicodeEncodeError` and exited the script non-zero even when the underlying tool (ruff, mypy, the validators) had succeeded. All five affected scripts (`run_lint.py`, `run_typecheck.py`, `validate_hacs.py`, `validate_docs.py`, `check_translations.py`) now reconfigure stdout and stderr to UTF-8 via a shared `scripts/_console.py` helper at startup. Windows contributors no longer need to export `PYTHONIOENCODING=utf-8` to use the standard development workflow. ([#148])
@@ -240,5 +241,6 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#139]: https://github.com/PHeonix25/unifi_alerts/issues/139
 [#163]: https://github.com/PHeonix25/unifi_alerts/issues/163
 [#170]: https://github.com/PHeonix25/unifi_alerts/issues/170
+[#173]: https://github.com/PHeonix25/unifi_alerts/issues/173
 [#175]: https://github.com/PHeonix25/unifi_alerts/issues/175
 [#PR]: https://github.com/PHeonix25/unifi_alerts/pull/PR

--- a/custom_components/unifi_alerts/webhook_handler.py
+++ b/custom_components/unifi_alerts/webhook_handler.py
@@ -147,9 +147,12 @@ class WebhookManager:
                     return Response(status=413)
                 payload = json.loads(raw.decode()) if raw else {}
             except (json.JSONDecodeError, UnicodeDecodeError, TypeError) as err:
-                # Decode failures previously fell through silently to an empty
-                # payload, hiding misconfigured controllers and truncated
-                # bodies. Log enough to diagnose without dumping the full body.
+                # Contract: bodies that fail JSON or UTF-8 decoding are rejected
+                # with HTTP 400 rather than falling through to an empty payload.
+                # Empty-but-valid bodies ({}) and bodies with no recognisable
+                # fields are accepted (400 is reserved for parse failures only).
+                # This prevents a token-bearing sender from spamming "Unknown
+                # alert" state via malformed bodies.
                 preview = raw[:80].decode("utf-8", errors="replace") if raw else ""
                 _LOGGER.warning(
                     "Malformed webhook body from controller for category %s (%s): %r",
@@ -157,7 +160,7 @@ class WebhookManager:
                     type(err).__name__,
                     preview,
                 )
-                payload = {}
+                return Response(status=400)
 
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 # Narrow the payload to known-safe fields before logging so

--- a/tests/unit/test_webhook_handler.py
+++ b/tests/unit/test_webhook_handler.py
@@ -247,17 +247,38 @@ class TestMakeHandler:
         push_cb.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_malformed_json_uses_empty_dict_fallback(self):
-        """If the body can't be parsed as JSON, push_callback is still called with empty payload."""
+    async def test_invalid_json_returns_400(self):
+        """A body that fails JSON parsing must be rejected with HTTP 400; push_callback not called."""
         manager, push_cb = make_manager(secret="tok")
         handler = manager._make_handler(CATEGORY_NETWORK_WAN, "tok")
         req = make_request(token="tok")
         req.content.read = AsyncMock(return_value=b"not valid json {{")
-        await handler(manager._hass, "wh-id", req)
+        response = await handler(manager._hass, "wh-id", req)
+        assert response is not None
+        assert response.status == 400
+        push_cb.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_utf8_returns_400(self):
+        """A body that fails UTF-8 decoding must be rejected with HTTP 400; push_callback not called."""
+        manager, push_cb = make_manager(secret="tok")
+        handler = manager._make_handler(CATEGORY_NETWORK_WAN, "tok")
+        req = make_request(token="tok")
+        req.content.read = AsyncMock(return_value=b"\xff\xfe invalid utf-8")
+        response = await handler(manager._hass, "wh-id", req)
+        assert response is not None
+        assert response.status == 400
+        push_cb.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_valid_json_accepted(self):
+        """A well-formed JSON body must be accepted (200/None) and push_callback called."""
+        manager, push_cb = make_manager(secret="tok")
+        handler = manager._make_handler(CATEGORY_NETWORK_WAN, "tok")
+        req = make_request(token="tok", json_body={"message": "WAN down"})
+        response = await handler(manager._hass, "wh-id", req)
+        assert response is None
         push_cb.assert_called_once()
-        # Alert should have fallback message
-        call_category, call_alert = push_cb.call_args[0]
-        assert call_alert.message == "Unknown alert"
 
     @pytest.mark.asyncio
     async def test_oversized_body_returns_413(self):
@@ -396,8 +417,8 @@ class TestDecodeErrorLogging:
         warning_args = mock_logger.warning.call_args[0][1:]
         assert "Malformed webhook body" in warning_msg
         assert "JSONDecodeError" in warning_args
-        # push_callback is still invoked with the empty-payload fallback
-        push_cb.assert_called_once()
+        # push_callback must NOT be called — we return 400 instead
+        push_cb.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_invalid_utf8_logs_warning(self):
@@ -409,7 +430,8 @@ class TestDecodeErrorLogging:
         with patch("custom_components.unifi_alerts.webhook_handler._LOGGER") as mock_logger:
             await handler(manager._hass, "wh-id", req)
         assert mock_logger.warning.called
-        push_cb.assert_called_once()
+        # push_callback must NOT be called — we return 400 instead
+        push_cb.assert_not_called()
 
 
 # ── DEBUG payload narrowing ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Authenticated webhook POSTs whose body fails JSON parsing or UTF-8 decoding previously fell through to an empty payload, synthesizing an "Unknown alert" entity state update. A token-bearing sender could spam meaningless events via malformed bodies.
- Now returns HTTP 400 and discards the body. Empty-but-valid bodies (`{}`) and bodies with no recognisable fields are still accepted (400 is reserved for parse failures only). The WARNING log is preserved as the misconfiguration diagnostic signal.
- A contract comment at the parse site documents which bodies are rejected (400) and which are accepted.
- Updates two existing tests in `TestDecodeErrorLogging` that asserted the old fallback behavior (`push_cb.assert_called_once()` → `push_cb.assert_not_called()`).

## Test plan

- [x] `test_invalid_json_returns_400`: invalid JSON body → 400, no `push_callback` call
- [x] `test_invalid_utf8_returns_400`: invalid UTF-8 body → 400, no `push_callback` call
- [x] `test_valid_json_accepted`: well-formed JSON → `None` (200), `push_callback` called
- [x] Existing oversized-body test (413) still passes
- [x] Full test suite: 516 passed, 98.19% coverage

Closes #173

https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj)_