### PR TITLE
security: length-validate key, severity, device_name in alert constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Security
 
+- `from_webhook_payload`, `from_api_alarm`, and `from_system_log_event` now truncate `key` to 64 characters, `device_name` to 255 characters, and `severity` to 32 characters. Previously only `message` was bounded, so a token-bearing caller could push unbounded strings into HA state and logs via the other fields. ([#128])
 - All authenticated outbound calls to the UniFi controller now pass `allow_redirects=False`. Any 3xx response raises `CannotConnectError` rather than silently resubmitting credentials to the redirect target. ([#127])
 - `UniFiAlert.to_dict()` no longer persists the `raw` UniFi payload to `.storage`. That payload carried unredacted client MACs, IP addresses, and hostnames, and could contain non-JSON-safe values that would crash `Store.async_save`. Persistence now emits an explicit scalar field list (`category`, `message`, `received_at`, `key`, `device_name`, `site`, `severity`); `from_dict()` still defaults `raw` to `{}` on read so existing stored entries continue to load. ([#147])
 
@@ -239,6 +240,8 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#147]: https://github.com/PHeonix25/unifi_alerts/pull/147
 [#148]: https://github.com/PHeonix25/unifi_alerts/issues/148
 [#122]: https://github.com/PHeonix25/unifi_alerts/issues/122
+[#127]: https://github.com/PHeonix25/unifi_alerts/issues/127
+[#128]: https://github.com/PHeonix25/unifi_alerts/issues/128
 [#138]: https://github.com/PHeonix25/unifi_alerts/issues/138
 [#139]: https://github.com/PHeonix25/unifi_alerts/issues/139
 [#163]: https://github.com/PHeonix25/unifi_alerts/issues/163

--- a/custom_components/unifi_alerts/models.py
+++ b/custom_components/unifi_alerts/models.py
@@ -96,13 +96,17 @@ class UniFiAlert:
             message=str(message)[:255],
             received_at=datetime.now(UTC),
             raw=payload,
-            key=payload.get("key", ""),
-            device_name=payload.get("device_name")
-            or payload.get("ap_name")
-            or payload.get("sw_name")
-            or "",
+            key=str(payload.get("key", ""))[:64],
+            device_name=(
+                payload.get("device_name")
+                or payload.get("ap_name")
+                or payload.get("sw_name")
+                or ""
+            )[:255],
             site=payload.get("site_name") or payload.get("site") or "",
-            severity=payload.get("severity") or payload.get("subsystem") or "",
+            severity=str(
+                payload.get("severity") or payload.get("subsystem") or ""
+            )[:32],
         )
 
     @classmethod
@@ -131,10 +135,10 @@ class UniFiAlert:
             message=str(message)[:255],
             received_at=received_at,
             raw=alarm,
-            key=alarm.get("key", ""),
-            device_name=alarm.get("device_name") or alarm.get("ap_name") or "",
+            key=str(alarm.get("key", ""))[:64],
+            device_name=(alarm.get("device_name") or alarm.get("ap_name") or "")[:255],
             site=alarm.get("site_name") or "",
-            severity=alarm.get("severity") or alarm.get("subsystem") or "",
+            severity=str(alarm.get("severity") or alarm.get("subsystem") or "")[:32],
         )
 
     @classmethod
@@ -201,10 +205,10 @@ class UniFiAlert:
             message=str(message)[:255],
             received_at=received_at,
             raw=payload,
-            key=key,
-            device_name=payload.get("device_name") or "",
+            key=key[:64],
+            device_name=(payload.get("device_name") or "")[:255],
             site=payload.get("site_name") or payload.get("site") or "",
-            severity=payload.get("severity") or "",
+            severity=str(payload.get("severity") or "")[:32],
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/custom_components/unifi_alerts/models.py
+++ b/custom_components/unifi_alerts/models.py
@@ -98,15 +98,10 @@ class UniFiAlert:
             raw=payload,
             key=str(payload.get("key", ""))[:64],
             device_name=(
-                payload.get("device_name")
-                or payload.get("ap_name")
-                or payload.get("sw_name")
-                or ""
+                payload.get("device_name") or payload.get("ap_name") or payload.get("sw_name") or ""
             )[:255],
             site=payload.get("site_name") or payload.get("site") or "",
-            severity=str(
-                payload.get("severity") or payload.get("subsystem") or ""
-            )[:32],
+            severity=str(payload.get("severity") or payload.get("subsystem") or "")[:32],
         )
 
     @classmethod

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -49,6 +49,21 @@ class TestUniFiAlert:
         alert = UniFiAlert.from_webhook_payload(CATEGORY_NETWORK_WAN, payload)
         assert len(alert.message) == 255
 
+    def test_key_truncated_at_64(self):
+        payload = {"message": "test", "key": "K" * 100}
+        alert = UniFiAlert.from_webhook_payload(CATEGORY_NETWORK_WAN, payload)
+        assert len(alert.key) == 64
+
+    def test_device_name_truncated_at_255(self):
+        payload = {"message": "test", "device_name": "D" * 300}
+        alert = UniFiAlert.from_webhook_payload(CATEGORY_NETWORK_WAN, payload)
+        assert len(alert.device_name) == 255
+
+    def test_severity_truncated_at_32(self):
+        payload = {"message": "test", "severity": "S" * 100}
+        alert = UniFiAlert.from_webhook_payload(CATEGORY_NETWORK_WAN, payload)
+        assert len(alert.severity) == 32
+
     def test_from_api_alarm(self):
         alarm = {
             "key": "EVT_IPS_ThreatDetected",


### PR DESCRIPTION
## Summary

Closes #128.

- `from_webhook_payload`, `from_api_alarm`, and `from_system_log_event` now truncate three previously unbounded fields:
  - `key`: clamped to 64 characters (event keys like `EVT_AP_Disconnected` are typically 20-35 chars)
  - `device_name`: clamped to 255 characters (consistent with `message`)
  - `severity`: clamped to 32 characters (values like `info`/`warning`/`critical` are short structured strings)
- A token-bearing caller could previously push arbitrary-length values into HA state and logs via these fields.

## Test plan

- [ ] `test_key_truncated_at_64` - 100-char key is clamped to 64
- [ ] `test_device_name_truncated_at_255` - 300-char device name is clamped to 255
- [ ] `test_severity_truncated_at_32` - 100-char severity is clamped to 32
- [ ] Full suite: `517 passed, 98.19% coverage`
- [ ] `mypy --strict`: no issues

https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj)_