### PR TITLE
feat: surface unmapped system-log keys in diagnostics (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Per-category webhook health signal. Each category binary sensor now exposes a `webhook_health` attribute (`never_received`, `healthy`, or `stale`) and a `last_webhook_at` timestamp, so you can confirm the Alarm Manager wiring works without waiting for a real alert. `healthy` means a webhook arrived within the last 7 days; `stale` means the last one is older than that (expected for rarely-firing categories). Both fields also appear per category in the diagnostics download and survive a config-entry reload. ([#117])
+- The diagnostics download now includes an `unmapped_system_log_keys` field listing any v2 system-log event keys seen since HA startup that are not yet in the integration's category map. A non-empty list means the map has gaps; copy the key names into a GitHub issue so they can be added to `const.py`. ([#134])
 - A failed watermark save now raises a repair issue in Settings > Repairs warning that cleared alerts may reappear after a restart and to check disk space. The issue clears itself on the next successful save. ([#163])
 
 ### Changed

--- a/custom_components/unifi_alerts/diagnostics.py
+++ b/custom_components/unifi_alerts/diagnostics.py
@@ -14,6 +14,7 @@ from .const import (
     CONF_USERNAME,
     CONF_WEBHOOK_SECRET,
 )
+from .models import get_unknown_system_log_keys
 
 _TO_REDACT: set[str] = {CONF_PASSWORD, CONF_API_KEY, CONF_USERNAME, CONF_WEBHOOK_SECRET}
 
@@ -61,9 +62,16 @@ async def async_get_config_entry_diagnostics(
     else:
         coordinator_info = {}
 
+    # v2 system-log keys seen since HA startup that are not in
+    # SYSTEM_LOG_KEY_TO_CATEGORY. Non-empty means the key map has gaps; report
+    # these keys at https://github.com/PHeonix25/unifi_alerts/issues so they
+    # can be added to const.py.
+    unknown_keys = sorted(get_unknown_system_log_keys())
+
     return {
         "config_entry": async_redact_data(dict(entry.data), _TO_REDACT),
         "options": async_redact_data(dict(entry.options), _TO_REDACT),
         "webhook_urls": webhook_urls,
         "coordinator": coordinator_info,
+        "unmapped_system_log_keys": unknown_keys,
     }

--- a/custom_components/unifi_alerts/models.py
+++ b/custom_components/unifi_alerts/models.py
@@ -15,6 +15,17 @@ _LOGGER = logging.getLogger(__name__)
 # "unrecognised key" warnings without instance state.
 _unknown_system_log_keys: set[str] = set()
 
+
+def get_unknown_system_log_keys() -> frozenset[str]:
+    """Return the set of v2 system-log keys seen since startup that have no entry
+    in SYSTEM_LOG_KEY_TO_CATEGORY.  Exposed for diagnostics; the caller should
+    sort the result for deterministic output.  Report unknown keys by opening an
+    issue at https://github.com/PHeonix25/unifi_alerts/issues/new and including
+    the key names and the category they belong to.
+    """
+    return frozenset(_unknown_system_log_keys)
+
+
 if TYPE_CHECKING:
     from .coordinator import UniFiAlertsCoordinator
     from .unifi_client import UniFiClient

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -180,3 +180,47 @@ async def test_diagnostics_per_category_last_cleared_at_none_when_unset() -> Non
         assert entry["last_cleared_at"] is None
         assert entry["last_webhook_at"] is None
         assert entry["webhook_health"] == "never_received"
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_exposes_unmapped_system_log_keys() -> None:
+    """unmapped_system_log_keys must appear in diagnostics and be sorted."""
+    import custom_components.unifi_alerts.models as models_module
+
+    original = set(models_module._unknown_system_log_keys)
+    try:
+        models_module._unknown_system_log_keys.clear()
+        models_module._unknown_system_log_keys.update({"EVT_UNKNOWN_Z", "EVT_UNKNOWN_A"})
+
+        coordinator = _make_coordinator()
+        entry = _make_entry_with_runtime(coordinator)
+        hass = MagicMock()
+
+        result = await async_get_config_entry_diagnostics(hass, entry)
+
+        assert "unmapped_system_log_keys" in result
+        assert result["unmapped_system_log_keys"] == ["EVT_UNKNOWN_A", "EVT_UNKNOWN_Z"]
+    finally:
+        models_module._unknown_system_log_keys.clear()
+        models_module._unknown_system_log_keys.update(original)
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_unmapped_system_log_keys_empty_when_all_mapped() -> None:
+    """unmapped_system_log_keys must be an empty list when no keys are unknown."""
+    import custom_components.unifi_alerts.models as models_module
+
+    original = set(models_module._unknown_system_log_keys)
+    try:
+        models_module._unknown_system_log_keys.clear()
+
+        coordinator = _make_coordinator()
+        entry = _make_entry_with_runtime(coordinator)
+        hass = MagicMock()
+
+        result = await async_get_config_entry_diagnostics(hass, entry)
+
+        assert result["unmapped_system_log_keys"] == []
+    finally:
+        models_module._unknown_system_log_keys.clear()
+        models_module._unknown_system_log_keys.update(original)


### PR DESCRIPTION
Closing as superseded by #207. That PR uses coordinator-level instance state (correct for multi-entry setups) rather than the module-level global set approach here. The `coordinator.unrecognised_keys` property is more robust since it's scoped per config entry.