### PR TITLE
fix: clamp v2 system-log fetch window to prevent unbounded pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The v2 system-log fetch window is now clamped to `DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS` (24 hours). Previously, a rarely-cleared category could hold the oldest watermark to an arbitrarily old timestamp, causing every poll to paginate from that date forward and silently miss recent alarms once the 10-page cap was reached. The clamp ensures all categories are always within the paged window. A WARNING is now logged when the page cap is reached, indicating some events may have been missed. ([#136])
+
 ## [1.8.0] - 2026-06-19
 
 ### Added
@@ -257,6 +261,7 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#123]: https://github.com/PHeonix25/unifi_alerts/issues/123
 [#127]: https://github.com/PHeonix25/unifi_alerts/issues/127
 [#128]: https://github.com/PHeonix25/unifi_alerts/issues/128
+[#136]: https://github.com/PHeonix25/unifi_alerts/issues/136
 [#138]: https://github.com/PHeonix25/unifi_alerts/issues/138
 [#139]: https://github.com/PHeonix25/unifi_alerts/issues/139
 [#163]: https://github.com/PHeonix25/unifi_alerts/issues/163

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Coroutine
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from homeassistant.core import HomeAssistant
@@ -24,6 +24,7 @@ from .const import (
     DEFAULT_CLEAR_TIMEOUT,
     DEFAULT_POLL_INTERVAL,
     DEFAULT_SITE,
+    DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS,
     DOMAIN,
     WEBHOOK_DEDUP_WINDOW_SECONDS,
 )
@@ -205,13 +206,21 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
             return await self._client.categorise_alarms(self._site)
 
         # v2 path: compute the oldest watermark across enabled categories so we
-        # fetch everything since the oldest unacknowledged window.
+        # fetch everything since the oldest unacknowledged window. Clamp to
+        # DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS so a rarely-cleared category cannot
+        # grow the fetch window without bound and push recent events past
+        # MAX_SYSTEM_LOG_PAGES.
         watermarks = [
             state.last_cleared_at
             for state in self._category_states.values()
             if state.enabled and state.last_cleared_at is not None
         ]
-        since: datetime | None = min(watermarks) if watermarks else None
+        since: datetime | None
+        if watermarks:
+            lookback_floor = datetime.now(UTC) - timedelta(hours=DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS)
+            since = max(min(watermarks), lookback_floor)
+        else:
+            since = None
 
         raw_events = await self._client.fetch_system_log_alarms(self._site, since=since)
 

--- a/custom_components/unifi_alerts/unifi_client.py
+++ b/custom_components/unifi_alerts/unifi_client.py
@@ -407,6 +407,16 @@ class UniFiClient:
             )
             if page + 1 >= total_pages or not page_data:
                 break
+        else:
+            # for-loop exhausted range(MAX_SYSTEM_LOG_PAGES) without breaking:
+            # the page cap was reached before all events were fetched.
+            _LOGGER.warning(
+                "v2 system-log page cap reached (%d pages / %d events); "
+                "some recent alarms may have been missed. "
+                "Clear categories more frequently or reduce the polling window.",
+                MAX_SYSTEM_LOG_PAGES,
+                len(results),
+            )
 
         return results
 

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1470,18 +1470,22 @@ class TestCoordinatorV2Dispatch:
             assert state.open_count == 0
 
     @pytest.mark.asyncio
-    async def test_v2_watermark_passed_as_since_to_fetch(self):
-        """The oldest watermark across enabled categories must be passed as since=."""
-        from datetime import UTC, datetime
+    async def test_v2_watermark_within_window_passed_as_since(self):
+        """When the oldest watermark is within DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS,
+        it is passed as-is to fetch_system_log_alarms (no clamping needed)."""
+        from datetime import UTC, datetime, timedelta
+
+        from custom_components.unifi_alerts.const import DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS
 
         hass, client = _make_hass_and_client()
         client.probe_system_log_endpoint = AsyncMock(return_value=True)
         client.fetch_system_log_alarms = AsyncMock(return_value=[])
         coord = _make_full_coordinator(hass, client)
 
-        # Set distinct watermarks; the oldest should be passed as since
-        older_wm = datetime(2026, 5, 1, 10, 0, 0, tzinfo=UTC)
-        newer_wm = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+        # Place both watermarks within the lookback window
+        now = datetime.now(UTC)
+        older_wm = now - timedelta(hours=DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS - 1)
+        newer_wm = now - timedelta(hours=1)
         coord.get_category_state(CATEGORY_NETWORK_WAN).last_cleared_at = older_wm
         coord.get_category_state(CATEGORY_SECURITY_THREAT).last_cleared_at = newer_wm
 
@@ -1489,7 +1493,36 @@ class TestCoordinatorV2Dispatch:
 
         client.fetch_system_log_alarms.assert_awaited_once()
         _, kwargs = client.fetch_system_log_alarms.call_args
+        # since must equal the older watermark (not clamped)
         assert kwargs.get("since") == older_wm
+
+    @pytest.mark.asyncio
+    async def test_v2_watermark_older_than_lookback_clamped(self):
+        """When the oldest watermark is beyond DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS,
+        since= is clamped to now - DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS."""
+        from datetime import UTC, datetime, timedelta
+
+        from custom_components.unifi_alerts.const import DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS
+
+        hass, client = _make_hass_and_client()
+        client.probe_system_log_endpoint = AsyncMock(return_value=True)
+        client.fetch_system_log_alarms = AsyncMock(return_value=[])
+        coord = _make_full_coordinator(hass, client)
+
+        # Watermark far in the past (30 days ago) — well beyond the 24h cap
+        stale_wm = datetime.now(UTC) - timedelta(days=30)
+        coord.get_category_state(CATEGORY_NETWORK_WAN).last_cleared_at = stale_wm
+
+        await coord._async_update_data()
+
+        client.fetch_system_log_alarms.assert_awaited_once()
+        _, kwargs = client.fetch_system_log_alarms.call_args
+        since = kwargs.get("since")
+        assert since is not None
+        # since must NOT be the stale watermark; it must be approximately now - 24h
+        expected_floor = datetime.now(UTC) - timedelta(hours=DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS)
+        # Allow 5-second tolerance for test execution time
+        assert abs((since - expected_floor).total_seconds()) < 5
 
     @pytest.mark.asyncio
     async def test_v2_no_watermark_passes_none_as_since(self):


### PR DESCRIPTION
## Summary

- In `_fetch_categorised` (coordinator): the `since=` timestamp passed to `fetch_system_log_alarms` is now clamped to `max(min(watermarks), now - DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS)`. Previously a rarely-cleared category could anchor the fetch window to an arbitrarily old timestamp, causing every poll to paginate from that old date and silently miss recent alarms once the 10-page cap was hit.
- In `fetch_system_log_alarms` (unifi_client): added a `for...else` warning when the loop exhausts `MAX_SYSTEM_LOG_PAGES` without reaching the last page — this tells the operator that events were missed and suggests clearing categories more frequently.

Closes #136

## Test plan

- [x] `test_v2_watermark_within_window_passed_as_since` — watermark inside 24h window is passed unchanged
- [x] `test_v2_watermark_older_than_lookback_clamped` — 30-day-old watermark is clamped to approximately `now - 24h` (5s tolerance for test execution)
- [x] `test_v2_no_watermark_passes_none_as_since` — no watermarks still passes `None`
- [x] Existing `test_stops_at_max_pages_cap` covers the for-else warning path
- [x] Full suite: 515 tests pass, 98.08% coverage
- [x] `make check` passes

https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj)_