### PR TITLE
feat: surface unrecognised event keys in diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Unclassified event keys seen during polling are now collected and exposed under `unrecognised_keys` in the integration diagnostics (Settings > Devices & Services > UniFi Alerts > Download diagnostics). This makes previously-invisible unmapped events visible without enabling DEBUG logging, so users can identify and report missing keys to the issue tracker. ([#134])
+
 ## [1.8.0] - 2026-06-19
 
 ### Added
@@ -257,6 +261,7 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#123]: https://github.com/PHeonix25/unifi_alerts/issues/123
 [#127]: https://github.com/PHeonix25/unifi_alerts/issues/127
 [#128]: https://github.com/PHeonix25/unifi_alerts/issues/128
+[#134]: https://github.com/PHeonix25/unifi_alerts/issues/134
 [#138]: https://github.com/PHeonix25/unifi_alerts/issues/138
 [#139]: https://github.com/PHeonix25/unifi_alerts/issues/139
 [#163]: https://github.com/PHeonix25/unifi_alerts/issues/163

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -100,6 +100,11 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         # controller from generating unbounded state updates and event fires.
         self._last_push_at: dict[tuple[str, str], float] = {}
 
+        # Accumulates event keys seen during polling that could not be mapped to
+        # any category. Exposed via diagnostics so users can report missing keys
+        # without needing DEBUG logging. Never reset; grows until the entry reloads.
+        self._unrecognised_keys: dict[str, int] = {}
+
     # ── DataUpdateCoordinator override ───────────────────────────────────
 
     async def _async_update_data(self) -> dict[str, CategoryState]:
@@ -202,7 +207,10 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
             has_v2 = False
 
         if not has_v2:
-            return await self._client.categorise_alarms(self._site)
+            result = await self._client.categorise_alarms(self._site)
+            for key, count in self._client.unrecognised_keys.items():
+                self._unrecognised_keys[key] = self._unrecognised_keys.get(key, 0) + count
+            return result
 
         # v2 path: compute the oldest watermark across enabled categories so we
         # fetch everything since the oldest unacknowledged window.
@@ -219,6 +227,15 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         for event in raw_events:
             alert = UniFiAlert.from_system_log_event(event, self._seen_unknown_keys)
             if not alert.category:
+                # Unknown key and no broad enum fallback — skip, same as legacy behaviour
+                key = event.get("key", "")
+                if key:
+                    self._unrecognised_keys[key] = self._unrecognised_keys.get(key, 0) + 1
+                    _LOGGER.debug(
+                        "Unclassified v2 system-log event key %r — consider reporting it at "
+                        "https://github.com/PHeonix25/unifi_alerts/issues",
+                        key,
+                    )
                 continue
             categorised.setdefault(alert.category, []).append(alert)
 
@@ -311,6 +328,15 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
     @property
     def rollup_open_count(self) -> int:
         return sum(s.open_count for s in self._category_states.values() if s.enabled)
+
+    @property
+    def unrecognised_keys(self) -> dict[str, int]:
+        """Event keys seen during polling that could not be mapped to any category.
+
+        Keys accumulate across all polls since the config entry was loaded. Exposed
+        via diagnostics so users can report missing keys without enabling DEBUG logging.
+        """
+        return self._unrecognised_keys
 
     @property
     def rollup_last_alert(self) -> UniFiAlert | None:

--- a/custom_components/unifi_alerts/diagnostics.py
+++ b/custom_components/unifi_alerts/diagnostics.py
@@ -57,6 +57,9 @@ async def async_get_config_entry_diagnostics(
             "rollup_alert_count": coordinator.rollup_alert_count,
             "rollup_open_count": coordinator.rollup_open_count,
             "categories": categories,
+            "unrecognised_keys": dict(
+                sorted(coordinator.unrecognised_keys.items(), key=lambda kv: kv[1], reverse=True)
+            ),
             # Per-category alert content (message, device_name, last_alert.raw) is
             # intentionally excluded. Those fields carry controller-supplied strings
             # that may contain client hostnames, MAC addresses, or IP addresses and

--- a/custom_components/unifi_alerts/unifi_client.py
+++ b/custom_components/unifi_alerts/unifi_client.py
@@ -92,6 +92,9 @@ class UniFiClient:
         self._probe_fail_count: int = 0
         # Set when _probe_fail_count reaches _PROBE_FAIL_LIMIT; clears on retry window expiry.
         self._probe_backoff_until: datetime | None = None
+        # Keys seen during the most recent categorise_alarms() call that could not
+        # be matched to any category. Reset each call; callers accumulate as needed.
+        self._unrecognised_keys: dict[str, int] = {}
 
     # ── Public interface ──────────────────────────────────────────────────
 
@@ -410,13 +413,22 @@ class UniFiClient:
 
         return results
 
+    @property
+    def unrecognised_keys(self) -> dict[str, int]:
+        """Keys seen in the most recent categorise_alarms() call with no category mapping."""
+        return self._unrecognised_keys
+
     async def categorise_alarms(self, site: str = "default") -> dict[str, list[UniFiAlert]]:
         """Fetch alarms and group them by category."""
         raw = await self.fetch_alarms(site)
+        self._unrecognised_keys = {}
         result: dict[str, list[UniFiAlert]] = {}
         for alarm in raw:
             category = self._classify(alarm)
             if category is None:
+                key = alarm.get("key", "")
+                if key:
+                    self._unrecognised_keys[key] = self._unrecognised_keys.get(key, 0) + 1
                 continue
             alert = UniFiAlert.from_api_alarm(category, alarm)
             result.setdefault(category, []).append(alert)

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -62,6 +62,8 @@ tests/integration/                # full HA lifecycle tests using the hass fixtu
 
 When a user reports an unrecognised alert key, add it to `UNIFI_KEY_TO_CATEGORY` in `const.py` and add a corresponding entry to `tests/unit/test_unifi_client.py::TestClassify::test_known_keys`. See `docs/UNIFI.md` for the key taxonomy.
 
+**How users find unrecognised keys without DEBUG logging:** the integration accumulates event keys that could not be matched to any category and exposes them in the HA diagnostics download (Settings > Devices & Services > UniFi Alerts > Download diagnostics, look for `coordinator.unrecognised_keys`). Ask users reporting missed alerts to share their diagnostics file and look for entries there first.
+
 ## Keeping strings.json and translations/en.json in sync
 
 HA requires `strings.json` and `translations/en.json` to match exactly. Edit both files together; the CI `lint` job and the pre-push hook diff the two files and fail on drift.

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1735,3 +1735,97 @@ class TestWatermarkPersistFailureRepair:
             coord._store.async_save = AsyncMock()
             await coord._async_persist_watermarks()
             assert mock_ir.async_delete_issue.call_count == 1
+
+
+class TestUnrecognisedKeys:
+    """Coordinator must accumulate unrecognised event keys from both polling paths."""
+
+    @pytest.mark.asyncio
+    async def test_v2_unrecognised_key_accumulates_in_coordinator(self):
+        """An unclassified v2 system-log key must be added to coordinator.unrecognised_keys."""
+        hass, client = _make_hass_and_client()
+        client.probe_system_log_endpoint = AsyncMock(return_value=True)
+        client.fetch_system_log_alarms = AsyncMock(
+            return_value=[
+                {
+                    "key": "TOTALLY_UNKNOWN_V2_KEY",
+                    "category": "AUDIT",  # not in SYSTEM_LOG_CATEGORY_FALLBACK
+                    "status": "NEW",
+                    "timestamp": 1778025612345,
+                    "message_raw": "Something happened.",
+                    "parameters": {},
+                    "severity": "LOW",
+                }
+            ]
+        )
+        coord = _make_full_coordinator(hass, client)
+
+        await coord._async_update_data()
+
+        assert "TOTALLY_UNKNOWN_V2_KEY" in coord.unrecognised_keys
+        assert coord.unrecognised_keys["TOTALLY_UNKNOWN_V2_KEY"] == 1
+
+    @pytest.mark.asyncio
+    async def test_v2_unrecognised_key_count_increments_across_polls(self):
+        """Repeated unclassified keys accumulate counts across multiple polls."""
+        hass, client = _make_hass_and_client()
+        client.probe_system_log_endpoint = AsyncMock(return_value=True)
+        event = {
+            "key": "REPEATING_UNKNOWN_KEY",
+            "category": "AUDIT",
+            "status": "NEW",
+            "timestamp": 1778025612345,
+            "message_raw": ".",
+            "parameters": {},
+            "severity": "LOW",
+        }
+        client.fetch_system_log_alarms = AsyncMock(return_value=[event])
+        coord = _make_full_coordinator(hass, client)
+
+        await coord._async_update_data()
+        await coord._async_update_data()
+
+        assert coord.unrecognised_keys["REPEATING_UNKNOWN_KEY"] == 2
+
+    @pytest.mark.asyncio
+    async def test_legacy_unrecognised_keys_merged_from_client(self):
+        """On the legacy path, unrecognised keys from client.unrecognised_keys are merged."""
+        hass, client = _make_hass_and_client()
+        client.probe_system_log_endpoint = AsyncMock(return_value=False)
+        client.categorise_alarms = AsyncMock(return_value={})
+        # Simulate the client having tracked one unrecognised key from its last call.
+        client.unrecognised_keys = {"EVT_MYSTERY_EVENT": 2}
+        coord = _make_full_coordinator(hass, client)
+
+        await coord._async_update_data()
+
+        assert "EVT_MYSTERY_EVENT" in coord.unrecognised_keys
+        assert coord.unrecognised_keys["EVT_MYSTERY_EVENT"] == 2
+
+    @pytest.mark.asyncio
+    async def test_unrecognised_keys_empty_when_all_classified(self):
+        """With no unclassified events, unrecognised_keys remains empty."""
+        from custom_components.unifi_alerts.const import CATEGORY_SECURITY_THREAT
+
+        hass, client = _make_hass_and_client()
+        client.probe_system_log_endpoint = AsyncMock(return_value=True)
+        client.fetch_system_log_alarms = AsyncMock(
+            return_value=[
+                {
+                    "key": "THREAT_BLOCKED_KNOWN_DESTINATION_CLIENT",
+                    "category": "SECURITY",
+                    "status": "NEW",
+                    "timestamp": 1778025612345,
+                    "message_raw": "Threat from {SRC_IP}.",
+                    "parameters": {"SRC_IP": {"name": "1.2.3.4"}},
+                    "severity": "HIGH",
+                }
+            ]
+        )
+        coord = _make_full_coordinator(hass, client)
+
+        await coord._async_update_data()
+
+        assert coord.unrecognised_keys == {}
+        state = coord.get_category_state(CATEGORY_SECURITY_THREAT)
+        assert state.open_count == 1

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -46,6 +46,7 @@ def _make_coordinator(
     rollup_alert_count: int = 0,
     rollup_open_count: int = 0,
     category_states: dict[str, CategoryState] | None = None,
+    unrecognised_keys: dict[str, int] | None = None,
 ) -> MagicMock:
     coordinator = MagicMock()
     coordinator.any_alerting = any_alerting
@@ -56,6 +57,7 @@ def _make_coordinator(
         if category_states is not None
         else {cat: CategoryState(category=cat) for cat in ALL_CATEGORIES}
     )
+    coordinator.unrecognised_keys = unrecognised_keys if unrecognised_keys is not None else {}
     return coordinator
 
 
@@ -169,6 +171,33 @@ class TestDiagnosticsContent:
             assert cat_entry["last_cleared_at"] is None
             assert cat_entry["last_webhook_at"] is None
             assert cat_entry["webhook_health"] == "never_received"
+
+    @pytest.mark.asyncio
+    async def test_includes_unrecognised_keys(self) -> None:
+        """unrecognised_keys in coordinator appear in diagnostics sorted by count descending."""
+        coordinator = _make_coordinator(
+            unrecognised_keys={"SOME_UNKNOWN_KEY": 3, "ANOTHER_WEIRD_KEY": 1, "FOO_BAR": 7}
+        )
+        entry = _make_entry_with_runtime(coordinator)
+        hass = MagicMock()
+
+        result = await async_get_config_entry_diagnostics(hass, entry)
+
+        unrecognised = result["coordinator"]["unrecognised_keys"]
+        assert unrecognised == {"FOO_BAR": 7, "SOME_UNKNOWN_KEY": 3, "ANOTHER_WEIRD_KEY": 1}
+        # Verify sort order (descending by count)
+        assert list(unrecognised.keys()) == ["FOO_BAR", "SOME_UNKNOWN_KEY", "ANOTHER_WEIRD_KEY"]
+
+    @pytest.mark.asyncio
+    async def test_unrecognised_keys_empty_when_all_classified(self) -> None:
+        """When no unrecognised keys have been seen, the field is an empty dict."""
+        coordinator = _make_coordinator(unrecognised_keys={})
+        entry = _make_entry_with_runtime(coordinator)
+        hass = MagicMock()
+
+        result = await async_get_config_entry_diagnostics(hass, entry)
+
+        assert result["coordinator"]["unrecognised_keys"] == {}
 
 
 class TestDiagnosticsEdgeCases:

--- a/tests/unit/test_unifi_client.py
+++ b/tests/unit/test_unifi_client.py
@@ -764,6 +764,76 @@ class TestCategoriseAlarms:
         result = await client.categorise_alarms()
         assert result == {}
 
+    @pytest.mark.asyncio
+    async def test_unrecognised_keys_tracked_on_unclassified_alarm(self):
+        """categorise_alarms() must record unclassified alarm keys in unrecognised_keys."""
+        client = make_client()
+        client._authenticated = True
+        body = {
+            "meta": {"rc": "ok"},
+            "data": [
+                {"key": "EVT_MYSTERY_DEVICE_FELL_OVER", "msg": "wat", "archived": False},
+                {"key": "EVT_MYSTERY_DEVICE_FELL_OVER", "msg": "again", "archived": False},
+                {"key": "EVT_ANOTHER_UNKNOWN", "msg": "hmm", "archived": False},
+            ],
+        }
+        ctx, _ = _make_json_response(200, body)
+        client._session.get = ctx
+
+        await client.categorise_alarms()
+
+        assert client.unrecognised_keys == {
+            "EVT_MYSTERY_DEVICE_FELL_OVER": 2,
+            "EVT_ANOTHER_UNKNOWN": 1,
+        }
+
+    @pytest.mark.asyncio
+    async def test_unrecognised_keys_reset_between_calls(self):
+        """unrecognised_keys reflects only the most recent categorise_alarms() call."""
+        client = make_client()
+        client._authenticated = True
+
+        # First call: unknown key
+        body1 = {
+            "meta": {"rc": "ok"},
+            "data": [{"key": "EVT_UNKNOWN_FIRST", "msg": ".", "archived": False}],
+        }
+        ctx1, _ = _make_json_response(200, body1)
+        client._session.get = ctx1
+        await client.categorise_alarms()
+        assert "EVT_UNKNOWN_FIRST" in client.unrecognised_keys
+
+        # Second call: different unknown key
+        body2 = {
+            "meta": {"rc": "ok"},
+            "data": [{"key": "EVT_UNKNOWN_SECOND", "msg": ".", "archived": False}],
+        }
+        ctx2, _ = _make_json_response(200, body2)
+        client._session.get = ctx2
+        await client.categorise_alarms()
+
+        # Only the second call's keys remain
+        assert "EVT_UNKNOWN_SECOND" in client.unrecognised_keys
+        assert "EVT_UNKNOWN_FIRST" not in client.unrecognised_keys
+
+    @pytest.mark.asyncio
+    async def test_unrecognised_keys_empty_when_all_classified(self):
+        """unrecognised_keys is empty when all alarms map to a category."""
+        client = make_client()
+        client._authenticated = True
+        body = {
+            "meta": {"rc": "ok"},
+            "data": [
+                {"key": "EVT_GW_WANTransition", "msg": "WAN down", "archived": False},
+            ],
+        }
+        ctx, _ = _make_json_response(200, body)
+        client._session.get = ctx
+
+        await client.categorise_alarms()
+
+        assert client.unrecognised_keys == {}
+
 
 class TestAuthenticate:
     """Tests for UniFiClient.authenticate — auth method selection and fallback."""


### PR DESCRIPTION
## Summary

- Unclassified event keys seen during polling now accumulate in the coordinator and appear under `coordinator.unrecognised_keys` in the HA diagnostics download (Settings > Devices & Services > UniFi Alerts > Download diagnostics)
- Keys are sorted by occurrence count descending, so the most frequently-missed events appear first
- Tracked from both the v2 system-log path and the legacy alarm path
- Documents how to find and report unrecognised keys in `docs/DEVELOPING.md`

## How it works

**Legacy path** (`categorise_alarms()`): the client resets `_unrecognised_keys` at the start of each call and records any alarm key where `_classify()` returns None. The coordinator merges the client's per-call keys into its own accumulator after each poll.

**v2 system-log path**: the coordinator tracks keys directly in `_fetch_categorised()` when an event has no matching category.

Both paths still emit a DEBUG log for unclassified keys (unchanged). The diagnostics field is the new user-visible surface.

Closes #134

## Test plan

- [ ] Verify `coordinator.unrecognised_keys` appears in the diagnostics download
- [ ] Trigger an event with an unknown key and confirm it appears in diagnostics
- [ ] Verify known keys do not appear in `unrecognised_keys`

https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj)_