### PR TITLE
feat: surface last_severity on category and rollup binary sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Category binary sensors now expose a `last_severity` attribute containing the severity string from the most recent alert (`"LOW"`, `"MEDIUM"`, `"HIGH"`, `"VERY_HIGH"` on v2 controllers; raw webhook severity on legacy controllers). The `any_alert` rollup sensor exposes the same attribute. Automations can condition on this to suppress or escalate alerts by severity without disabling the category. ([#135])
+
 ## [1.8.0] - 2026-06-19
 
 ### Added
@@ -257,6 +261,7 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#123]: https://github.com/PHeonix25/unifi_alerts/issues/123
 [#127]: https://github.com/PHeonix25/unifi_alerts/issues/127
 [#128]: https://github.com/PHeonix25/unifi_alerts/issues/128
+[#135]: https://github.com/PHeonix25/unifi_alerts/issues/135
 [#138]: https://github.com/PHeonix25/unifi_alerts/issues/138
 [#139]: https://github.com/PHeonix25/unifi_alerts/issues/139
 [#163]: https://github.com/PHeonix25/unifi_alerts/issues/163

--- a/custom_components/unifi_alerts/binary_sensor.py
+++ b/custom_components/unifi_alerts/binary_sensor.py
@@ -100,6 +100,7 @@ class UniFiCategoryBinarySensor(CoordinatorEntity[UniFiAlertsCoordinator], Binar
             attrs["last_alert_at"] = state.last_alert.received_at.isoformat()
             attrs["last_device"] = state.last_alert.device_name
             attrs["last_key"] = state.last_alert.key
+            attrs["last_severity"] = state.last_alert.severity
         if state.last_cleared_at:
             attrs["last_cleared_at"] = state.last_cleared_at.isoformat()
         return attrs
@@ -141,6 +142,7 @@ class UniFiRollupBinarySensor(CoordinatorEntity[UniFiAlertsCoordinator], BinaryS
             attrs["last_message"] = last.message
             attrs["last_alert_at"] = last.received_at.isoformat()
             attrs["last_category"] = last.category
+            attrs["last_severity"] = last.severity
         return attrs
 
 

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -140,6 +140,7 @@ class TestUniFiCategoryBinarySensor:
         assert attrs["last_message"] == "WAN offline"
         assert attrs["last_device"] == "UDM-Pro"
         assert attrs["last_key"] == "EVT_GW_WANTransition"
+        assert attrs["last_severity"] == "critical"
         assert "last_alert_at" in attrs
 
     def test_extra_attrs_without_alert(self):
@@ -223,6 +224,7 @@ class TestUniFiRollupBinarySensor:
         assert attrs["total_open_count"] == 2
         assert attrs["last_message"] == "WAN offline"
         assert attrs["last_category"] == CATEGORY_NETWORK_WAN
+        assert attrs["last_severity"] == "critical"
 
     def test_extra_attrs_without_last_alert(self):
         states = {CATEGORY_NETWORK_WAN: make_state()}


### PR DESCRIPTION
## Summary

- The `last_message` sensor already exposed `severity` as an attribute, but the binary sensor (which is what automations trigger on) did not
- Added `last_severity` to `UniFiCategoryBinarySensor.extra_state_attributes` and `UniFiRollupBinarySensor.extra_state_attributes`
- On v2 controllers the value is one of `LOW`, `MEDIUM`, `HIGH`, `VERY_HIGH`; on legacy webhook delivery it is whatever string the controller sends (empty string if the field is absent)
- Automations can now condition on severity without consulting a separate sensor entity

Example automation condition:
```yaml
condition:
  - condition: template
    value_template: >-
      {{ state_attr('binary_sensor.unifi_alerts_security_threat', 'last_severity') in ['HIGH', 'VERY_HIGH'] }}
```

Closes #135

## Test plan

- [ ] `make check` passes (514 tests, 98.08% coverage)
- [ ] `test_extra_attrs_with_alert` asserts `attrs["last_severity"] == "critical"`
- [ ] `test_extra_attrs_with_last_alert` (rollup) asserts `attrs["last_severity"] == "critical"`

https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj)_