### PR TITLE
feat: add SSDP network discovery for UniFi OS consoles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- UniFi OS consoles (UDM, UDM Pro, UDM SE, UDM Pro Max) are now discovered automatically via SSDP. When one is found on the local network it appears in Settings > Integrations > Discovered, with the controller URL pre-filled. Credentials still need to be entered manually. ([#172])
+
 ## [1.8.0] - 2026-06-19
 
 ### Added
@@ -265,6 +269,7 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#167]: https://github.com/PHeonix25/unifi_alerts/issues/167
 [#168]: https://github.com/PHeonix25/unifi_alerts/issues/168
 [#170]: https://github.com/PHeonix25/unifi_alerts/issues/170
+[#172]: https://github.com/PHeonix25/unifi_alerts/issues/172
 [#173]: https://github.com/PHeonix25/unifi_alerts/issues/173
 [#175]: https://github.com/PHeonix25/unifi_alerts/issues/175
 [#233]: https://github.com/PHeonix25/unifi_alerts/issues/233

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import logging
 import secrets
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import voluptuous as vol
 from homeassistant.components.webhook import async_generate_url
+
+if TYPE_CHECKING:
+    from homeassistant.components import ssdp
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.core import callback
 from homeassistant.helpers import issue_registry as ir
@@ -142,9 +145,12 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
             )
         else:
+            # Use a pre-filled URL when arriving via SSDP discovery;
+            # fall back to the example placeholder for manual setup.
+            _url_default = self._controller_url or "https://192.168.1.1"
             schema = vol.Schema(
                 {
-                    vol.Required(CONF_CONTROLLER_URL, default="https://192.168.1.1"): str,
+                    vol.Required(CONF_CONTROLLER_URL, default=_url_default): str,
                     vol.Optional(CONF_USERNAME): str,
                     vol.Optional(CONF_PASSWORD): _password_selector,
                     vol.Optional(CONF_API_KEY): _api_key_selector,
@@ -157,6 +163,26 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
             description_placeholders={"docs_url": "https://github.com/PHeonix25/unifi_alerts"},
         )
+
+    async def async_step_ssdp(self, discovery_info: ssdp.SsdpServiceInfo) -> ConfigFlowResult:
+        """Handle a UniFi OS console discovered via SSDP on the local network.
+
+        Extracts the controller IP from the SSDP location URL, pre-fills the
+        controller URL field with https://{host}, and deduplicates against
+        existing entries. The user still needs to enter credentials.
+        """
+        from urllib.parse import urlparse
+
+        parsed = urlparse(discovery_info.ssdp_location or "")
+        host = parsed.hostname or ""
+        if not host:
+            return self.async_abort(reason="cannot_connect")
+
+        self._controller_url = f"https://{host}"
+        await self.async_set_unique_id(self._controller_url)
+        self._abort_if_unique_id_configured()
+        self.context["title_placeholders"] = {"name": host}
+        return await self.async_step_user()
 
     async def async_step_categories(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -10,5 +10,11 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": [],
+  "ssdp": [
+    {"manufacturer": "Ubiquiti Networks", "modelDescription": "UniFi Dream Machine"},
+    {"manufacturer": "Ubiquiti Networks", "modelDescription": "UniFi Dream Machine Pro"},
+    {"manufacturer": "Ubiquiti Networks", "modelDescription": "UniFi Dream Machine SE"},
+    {"manufacturer": "Ubiquiti Networks", "modelDescription": "UniFi Dream Machine Pro Max"}
+  ],
   "version": "1.8.0"
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@
 # - homeassistant uses >= with a minimum floor so the integration is validated
 #   against the minimum supported HA release rather than whatever pip resolves.
 aiohttp>=3.9.0
+async-upnp-client>=0.42.0
 homeassistant>=2025.1.3
 mypy==2.1.0
 pytest==8.3.4

--- a/tests/unit/config_flow/test_discovery.py
+++ b/tests/unit/config_flow/test_discovery.py
@@ -1,0 +1,114 @@
+"""Tests for SSDP discovery flow (async_step_ssdp)."""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.components import ssdp
+from homeassistant.data_entry_flow import AbortFlow
+
+from .conftest import make_flow
+
+
+def make_ssdp_info(host: str = "192.168.1.1") -> ssdp.SsdpServiceInfo:
+    """Build a minimal SsdpServiceInfo for a UDM Pro at the given host."""
+    return ssdp.SsdpServiceInfo(
+        ssdp_usn="uuid:abcd-1234-efgh-5678",
+        ssdp_st="urn:schemas-upnp-org:device:InternetGatewayDevice:1",
+        ssdp_location=f"http://{host}:1900/description.xml",
+        upnp={
+            ssdp.ATTR_UPNP_MANUFACTURER: "Ubiquiti Networks",
+            ssdp.ATTR_UPNP_MODEL_DESCRIPTION: "UniFi Dream Machine Pro",
+            ssdp.ATTR_UPNP_SERIAL: "aa:bb:cc:dd:ee:ff",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_ssdp_prefills_controller_url() -> None:
+    """async_step_ssdp pre-fills _controller_url from the discovered host."""
+    flow = make_flow()
+    flow.async_step_user = AsyncMock(return_value={"type": "form", "step_id": "user"})
+
+    await flow.async_step_ssdp(make_ssdp_info("10.0.0.1"))
+
+    assert flow._controller_url == "https://10.0.0.1"
+
+
+@pytest.mark.asyncio
+async def test_ssdp_sets_unique_id() -> None:
+    """async_step_ssdp must set the unique_id to the controller URL."""
+    flow = make_flow()
+    flow.async_step_user = AsyncMock(return_value={"type": "form"})
+
+    await flow.async_step_ssdp(make_ssdp_info("192.168.1.1"))
+
+    flow.async_set_unique_id.assert_called_once_with("https://192.168.1.1")
+
+
+@pytest.mark.asyncio
+async def test_ssdp_aborts_when_already_configured() -> None:
+    """async_step_ssdp must abort if the unique_id is already configured."""
+    flow = make_flow()
+    flow._abort_if_unique_id_configured = MagicMock(side_effect=AbortFlow("already_configured"))
+
+    with pytest.raises(AbortFlow) as exc_info:
+        await flow.async_step_ssdp(make_ssdp_info("192.168.1.1"))
+
+    assert exc_info.value.reason == "already_configured"
+
+
+@pytest.mark.asyncio
+async def test_ssdp_aborts_on_missing_host() -> None:
+    """async_step_ssdp aborts with cannot_connect when no host can be extracted."""
+    flow = make_flow()
+    flow.async_abort = MagicMock(return_value={"type": "abort", "reason": "cannot_connect"})
+
+    # Pass an SsdpServiceInfo with no ssdp_location
+    info = ssdp.SsdpServiceInfo(
+        ssdp_usn="uuid:abcd",
+        ssdp_st="urn:test",
+        ssdp_location=None,
+        upnp={},
+    )
+    result = await flow.async_step_ssdp(info)
+
+    flow.async_abort.assert_called_once_with(reason="cannot_connect")
+    assert result["reason"] == "cannot_connect"
+
+
+@pytest.mark.asyncio
+async def test_ssdp_sets_title_placeholder() -> None:
+    """async_step_ssdp populates context title_placeholders with the host."""
+    flow = make_flow()
+    flow.async_step_user = AsyncMock(return_value={"type": "form"})
+
+    await flow.async_step_ssdp(make_ssdp_info("192.168.50.1"))
+
+    assert flow.context.get("title_placeholders", {}).get("name") == "192.168.50.1"
+
+
+@pytest.mark.asyncio
+async def test_user_step_uses_ssdp_url_as_default() -> None:
+    """When _controller_url is pre-filled by SSDP, async_step_user uses it as the form default."""
+    import voluptuous as vol
+
+    from custom_components.unifi_alerts.const import CONF_CONTROLLER_URL
+
+    flow = make_flow()
+    flow._controller_url = "https://10.10.10.1"
+
+    result = await flow.async_step_user()
+
+    assert result["type"] == "form"
+    schema = result["data_schema"]
+    # Extract defaults from voluptuous key objects (default lives on the key, not the validator).
+    schema_defaults: dict[str, object] = {}
+    for key in schema.schema:
+        if hasattr(key, "default") and not isinstance(key.default, vol.Undefined.__class__):
+            with contextlib.suppress(Exception):
+                schema_defaults[key.schema] = key.default()
+
+    assert schema_defaults.get(CONF_CONTROLLER_URL) == "https://10.10.10.1"


### PR DESCRIPTION
## Summary

- Registers UDM, UDM Pro, UDM SE, and UDM Pro Max model descriptions in `manifest.json` so HA's SSDP scanner picks them up automatically
- `async_step_ssdp` extracts the host from the discovered SSDP location URL, sets the unique_id to `https://<host>` (consistent with manual-setup), aborts if already configured, and forwards to `async_step_user` with the controller URL pre-filled
- `async_step_user` uses the pre-filled `_controller_url` as the form default so users only need to enter credentials when discovered via SSDP
- 6 new tests in `tests/unit/config_flow/test_discovery.py` covering: URL pre-fill, unique_id set, abort-if-configured, abort-on-missing-host, title placeholder, and pre-filled default in the user form

Closes #172

## Test plan

- [ ] `make check` passes (520 tests, 98% coverage)
- [ ] New `tests/unit/config_flow/test_discovery.py` covers all six SSDP flow paths
- [ ] CI green

https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj)_