### PR TITLE
ci: bump pytest-homeassistant-custom-component to 0.13.205; document advisory pip-audit rationale

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -10,9 +10,14 @@ name: Dependency audit
 # default setup (GitHub rejects the SARIF upload), so SAST lives there and this
 # workflow owns dependency auditing only.
 #
-# pip-audit is advisory only (continue-on-error on the audit step). A newly
-# published CVE in a transitive dependency must not block merges; the maintainer
-# reviews the job output and bumps requirements-dev.txt when warranted.
+# pip-audit is advisory only (continue-on-error on the audit step). As of
+# 2026-06, most findings are in transitive dependencies pinned by
+# pytest-homeassistant-custom-component (which sets homeassistant==2025.1.4).
+# The fix versions require homeassistant 2025.8+ or 2026.1, which are not
+# yet available on PyPI. When Dependabot bumps pytest-homeassistant-custom-
+# component to a version that pulls in a fixed homeassistant release, re-run
+# pip-audit locally, verify zero findings, then flip continue-on-error to
+# false on the audit step below to make the scan blocking.
 
 on:
   push:

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -97,11 +97,13 @@ Skip `make setup` for a doc-only branch on a fresh clone. The full setup install
 | `hacs` | Validates `hacs.json` and repository structure for HACS listing |
 | `lint` | `ruff check` + `ruff format --check` + `mypy` + `strings.json`/`translations/en.json` drift diff |
 | `test` | `pytest` against `tests/unit/` and `tests/integration/` |
-| `pip-audit` | Dependency vulnerability scan against `requirements-dev.txt`. Advisory only (`continue-on-error` on the audit step); it never blocks a merge |
+| `pip-audit` | Dependency vulnerability scan. Advisory only (`continue-on-error` on the audit step); currently non-blocking - see note below |
 
 Static security analysis (CodeQL SAST) for Python runs through GitHub's CodeQL **default setup**, configured in Settings > Code security and analysis, with findings in the repository Security tab. It is not a workflow in this repository: an advanced workflow-based CodeQL config cannot coexist with default setup (GitHub rejects the SARIF upload), so SAST lives in default setup and the workflow below owns dependency auditing only.
 
-`dependency-audit.yml` holds the `pip-audit` job. It runs on every push and pull request to `dev` and `main`, plus a weekly Monday 06:00 UTC schedule so newly disclosed vulnerabilities are caught even when the code has not changed. `pip-audit` is intentionally non-blocking: the maintainer reviews its output and bumps `requirements-dev.txt` when a finding warrants it. `continue-on-error` sits on the audit step (not the job) so a finding leaves the check green while the report still appears in the log.
+`dependency-audit.yml` holds the `pip-audit` job. It runs on every push and pull request to `dev` and `main`, plus a weekly Monday 06:00 UTC schedule so newly disclosed vulnerabilities are caught even when the code has not changed. `pip-audit` is currently advisory: `continue-on-error` sits on the audit step (not the job) so a finding leaves the check green while the report still appears in the log.
+
+**Why advisory and not blocking:** as of mid-2026, most findings are in transitive dependencies pinned by `pytest-homeassistant-custom-component` (which sets `homeassistant==2025.1.4`). The fix versions require `homeassistant 2025.8+` or `2026.1`, which are not yet on PyPI. When `pytest-homeassistant-custom-component` is bumped to a version that pulls in a fixed HA release, re-run `pip-audit` locally, verify zero findings, then flip `continue-on-error: true` to `false` on the audit step in `dependency-audit.yml` to make the scan blocking.
 
 `version-check.yml` enforces the version format per branch (`X.Y.Z` on `main`, `X.Y.Z-preN` on `dev`). `release.yml` triggers on tags and publishes via `gh release create --generate-notes`. All checks except `pip-audit` must pass before merging.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,5 +17,5 @@ mypy==2.1.0
 pytest==8.3.4
 pytest-asyncio==0.24.0
 pytest-cov==6.0.0
-pytest-homeassistant-custom-component==0.13.204
+pytest-homeassistant-custom-component==0.13.205
 ruff==0.15.16


### PR DESCRIPTION
## Summary

- Bumps `pytest-homeassistant-custom-component` from `0.13.204` to `0.13.205`, which pulls in `homeassistant==2025.1.4`
- Updates `dependency-audit.yml` header comment to explain the specific reason the scan is currently advisory (transitive CVEs blocked on HA 2025.8+/2026.1 releases not yet on PyPI)
- Updates `docs/DEVELOPING.md` to give the same explanation with the path to making the scan blocking

## Why not fully blocking?

Most CVEs in the scan are in transitive dependencies pinned by `pytest-homeassistant-custom-component`, which constrains `homeassistant` to `2025.1.4`. The fix versions require `homeassistant 2025.8+` or `2026.1`, neither of which is currently available on PyPI. `pytest` is also pinned to `8.3.4` by `hacc` (CVE-2025-71176 fix is 9.0.3, but `hacc 0.13.205` requires exactly `pytest==8.3.4`).

When `hacc` is bumped to a version that pulls in a patched HA release, run `pip-audit` locally, verify zero findings, then flip `continue-on-error: true` to `false` in `dependency-audit.yml`.

Note: `dependabot.yml` does not track the pip ecosystem - Python dependencies stay under manual review per the policy in `requirements-dev.txt`.

Partial fix for #180

## Test plan

- [x] `make check` passes (514 tests, 98% coverage) with `hacc==0.13.205`
- [x] Rebased cleanly on dev (conflict in `requirements-dev.txt` resolved: kept dev's full pinning from #142, bumped `hacc` to `0.13.205`)

https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj