### PR TITLE
fix: catch InvalidAuthError on re-auth retry and raise ConfigEntryAuthFailed

### DIFF
--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -128,6 +128,10 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
                 ) from reauth_err
             try:
                 categorised = await self._fetch_categorised()
+            except InvalidAuthError as retry_err:
+                raise ConfigEntryAuthFailed(
+                    f"Credentials rejected after re-authentication: {retry_err}"
+                ) from retry_err
             except CannotConnectError as retry_err:
                 raise UpdateFailed(
                     f"Cannot reach UniFi controller after re-authentication: {retry_err}"

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -562,6 +562,36 @@ class TestPollingErrorPaths:
         assert "after re-authentication" in str(exc_info.value)
 
     @pytest.mark.asyncio
+    async def test_reauth_succeeds_but_retry_still_401_raises_config_entry_auth_failed(self):
+        """Re-auth succeeds but retried fetch still raises InvalidAuthError → ConfigEntryAuthFailed."""
+        from homeassistant.exceptions import ConfigEntryAuthFailed
+
+        from custom_components.unifi_alerts.unifi_client import InvalidAuthError
+
+        hass = MagicMock()
+
+        def _create_task(coro, **kwargs):
+            coro.close()
+            return MagicMock()
+
+        hass.async_create_task = _create_task
+        hass.async_create_background_task = _create_task
+        client = MagicMock()
+        client.categorise_alarms = AsyncMock(
+            side_effect=[InvalidAuthError("expired"), InvalidAuthError("still 401")]
+        )
+        client.authenticate = AsyncMock()  # re-auth appears to succeed
+
+        config = {
+            CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+            CONF_POLL_INTERVAL: 60,
+            CONF_CLEAR_TIMEOUT: 30,
+        }
+        coord = UniFiAlertsCoordinator(hass, client, config)
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coord._async_update_data()
+
+    @pytest.mark.asyncio
     async def test_cannot_connect_raises_update_failed(self):
         """CannotConnectError must be wrapped in UpdateFailed."""
         from homeassistant.helpers.update_coordinator import UpdateFailed


### PR DESCRIPTION
Closing as duplicate - PR #185 (same issue #122) was merged to dev at 2026-06-15T01:57:03Z.

https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj