### PR TITLE
ci(deps): bump actions/checkout to v6.0.3, hassfest and hacs/action to 2026-06-14 tips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,14 @@ jobs:
     name: Validate with hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - uses: home-assistant/actions/hassfest@868e6cb4607727d764341a158d98872cd63fa658  # master tip 2026-06-01
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: home-assistant/actions/hassfest@e91ad1948e57189485b9c1ad608af0c303946f89  # master tip 2026-06-14
 
   hacs-preflight:
     name: HACS manifest pre-flight (local rules)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
@@ -39,8 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: hacs-preflight
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - uses: hacs/action@dcb30e72781db3f207d5236b861172774ab0b485  # main
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa  # main tip 2026-06-14
         with:
           category: integration
 
@@ -48,7 +48,7 @@ jobs:
     name: Lint & type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
@@ -67,7 +67,7 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -14,7 +14,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -38,7 +38,7 @@ jobs:
     # step failure is swallowed and the check reports green; a job-level flag
     # only spares the overall run and still surfaces the job as failed.
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     name: Package and publish release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           # `gh release create --generate-notes` needs the full tag history to
           # compute the previous-tag boundary correctly.

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -26,7 +26,7 @@ jobs:
     name: Validate version format for branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
       - name: Extract version from manifest
         id: version


### PR DESCRIPTION
## Summary

Bumps three pinned GitHub Actions SHAs across all workflow files. All changes are comment-only on the functional SHA pins; no workflow logic changed.

| Action | Old SHA | New SHA | Comment |
|---|---|---|---|
| `actions/checkout` | `de0fac2e` | `df4cb1c0` | v6.0.3 |
| `home-assistant/actions/hassfest` | `868e6cb4` | `e91ad194` | master tip 2026-06-14 |
| `hacs/action` | `dcb30e72` | `1ebf01c4` | main tip 2026-06-14 |

Proposed by Dependabot as PRs #221, #222, #223 (all targeting `main`). Applied here targeting `dev` instead, per the two-branch model. Those three Dependabot PRs can be closed once this merges.

`actions/checkout` v6.0.3 includes a fix for SHA-256 repository checkout and a merge commit SHA regex expansion - safe to take.

## Test plan

- [x] No logic changed - SHA-only update
- [x] Comments match the resolved tag/branch tip for each pin

https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj)_