### PR TITLE
fix: remove unused timedelta import in test file

### DIFF
--- a/tests/unit/test_unifi_client.py
+++ b/tests/unit/test_unifi_client.py
@@ -1341,8 +1341,6 @@ class TestProbeSystemLogEndpoint:
     async def test_reauth_does_not_reset_confirmed_true(self):
         """If _has_system_log is True (v2 endpoint confirmed), re-auth must not
         reset it to None - there's nothing to re-probe."""
-        from datetime import timedelta
-
         client = make_client()
         client._has_system_log = True
         client._probe_fail_count = 0


### PR DESCRIPTION
Removes the unused `from datetime import timedelta` import at line 1344 of `tests/unit/test_unifi_client.py` — left over from a draft of `test_reauth_does_not_reset_confirmed_true`. The pre-push hook's ruff lint step caught this when running `git push origin v1.8.0-pre2` locally.

https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj)_