### PR TITLE
fix: reformat over-long dict literal in test_models.py

### DIFF
--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -57,7 +57,11 @@ class TestUniFiAlert:
 
     def test_raw_not_retained_after_api_alarm_construction(self):
         """Raw alarm dict must not be retained in memory after building from a poll."""
-        alarm = {"msg": "threat", "key": "EVT_IPS_ThreatDetected", "client_mac": "aa:bb:cc:dd:ee:ff"}
+        alarm = {
+            "msg": "threat",
+            "key": "EVT_IPS_ThreatDetected",
+            "client_mac": "aa:bb:cc:dd:ee:ff",
+        }
         alert = UniFiAlert.from_api_alarm(CATEGORY_NETWORK_WAN, alarm)
         assert alert.raw == {}
 


### PR DESCRIPTION
Splits the 101-char dict literal in `test_raw_not_retained_after_api_alarm_construction` across multiple lines so `ruff format --check` passes. The pre-push hook caught this when running `git push origin v1.8.0-pre2` locally.

https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj)_