### PR TITLE
tests: adopt class-based grouping across unit test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - Added test coverage reporting via Codecov: `pytest-cov` added to dev requirements, 95% floor enforced in CI and locally (`--cov-fail-under=95`), XML report uploaded to Codecov on every push, live badge added to README and info.md. `make coverage` generates an HTML report locally; `.coverage`, `coverage.xml`, and `htmlcov/` added to `.gitignore`.
 - Added end-to-end integration tests for webhook secret rotation: confirms the old token is rejected (401) after reload and the new token is accepted (200), covering the full rotation cycle from entry-data update through webhook re-registration. ([#121])
 - `ci.yml` and `version-check.yml` now include a `concurrency` block so redundant runs for the same branch/PR are cancelled when a new commit is pushed. `release.yml` is intentionally excluded. ([#175])
+- Unit test files now use a consistent class-based layout: tests are grouped into `Test*` classes by flow step or functional area (`TestUserStep`, `TestCategoriesStep`, `TestDiagnosticsRedaction`, etc.) matching the `python_classes = Test*` convention already set in `pytest.ini`. `test_setup.py`, `test_diagnostics.py`, and `test_reauth.py` were converted from flat functions; `docs/TESTING.md` now documents the convention. ([#233])
 
 ## [1.7.0] - 2026-05-29
 
@@ -260,4 +261,5 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#170]: https://github.com/PHeonix25/unifi_alerts/issues/170
 [#173]: https://github.com/PHeonix25/unifi_alerts/issues/173
 [#175]: https://github.com/PHeonix25/unifi_alerts/issues/175
+[#233]: https://github.com/PHeonix25/unifi_alerts/issues/233
 [#PR]: https://github.com/PHeonix25/unifi_alerts/pull/PR

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -125,6 +125,7 @@ Key conventions:
 - `make_hass()` and `make_entry()` in `tests/unit/conftest.py` are helpers for setup/unload tests.
 - Use `pytest.mark.asyncio` (or the `asyncio_mode = auto` setting in `pytest.ini`) for async tests.
 - Mock `hass.async_create_task` AND `hass.async_create_background_task` together wherever the coordinator's `_schedule_clear` path is exercised.
+- Group tests into `Test` classes by the flow step or functional area they cover (e.g. `TestUserStep`, `TestCategoriesStep`, `TestDiagnosticsRedaction`). Each test method takes `self` and keeps its `@pytest.mark.asyncio` decorator. Integration tests stay as flat functions. The `python_classes = Test*` setting in `pytest.ini` picks up these classes automatically.
 
 ### What's tested
 

--- a/tests/unit/config_flow/test_reauth.py
+++ b/tests/unit/config_flow/test_reauth.py
@@ -15,11 +15,11 @@ from custom_components.unifi_alerts.const import (
 from .conftest import make_reauth_flow, make_session_mock
 
 
-class TestReauthFlow:
-    """Tests for the reauth flow steps."""
+class TestReauthStep:
+    """Tests for async_step_reauth and the auth-failure issue helper."""
 
     @pytest.mark.asyncio
-    async def test_async_step_reauth_routes_to_reauth_confirm(self) -> None:
+    async def test_routes_to_reauth_confirm(self) -> None:
         """async_step_reauth must store the entry and advance to reauth_confirm."""
         flow = UniFiAlertsConfigFlow()
         entry_id = "entry-reauth-1"
@@ -44,7 +44,7 @@ class TestReauthFlow:
         assert flow._reauth_entry is mock_entry
 
     @pytest.mark.asyncio
-    async def test_async_step_reauth_creates_issue(self) -> None:
+    async def test_creates_issue(self) -> None:
         """async_step_reauth must call _create_auth_failed_issue."""
         flow = UniFiAlertsConfigFlow()
         entry_id = "entry-issue-test"
@@ -67,8 +67,28 @@ class TestReauthFlow:
 
         mock_create.assert_called_once_with(hass, mock_entry)
 
+    def test_create_auth_failed_issue_calls_issue_registry(self) -> None:
+        from custom_components.unifi_alerts.config_flow import _create_auth_failed_issue
+
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+        entry.title = "Controller"
+
+        with patch(
+            "custom_components.unifi_alerts.config_flow.ir.async_create_issue"
+        ) as mock_create:
+            _create_auth_failed_issue(hass, entry)
+
+        mock_create.assert_called_once()
+        assert mock_create.call_args.args[2] == "auth_failed_entry-1"
+
+
+class TestReauthConfirmStep:
+    """Tests for async_step_reauth_confirm."""
+
     @pytest.mark.asyncio
-    async def test_reauth_confirm_no_input_shows_form(self) -> None:
+    async def test_no_input_shows_form(self) -> None:
         """With no user_input, reauth_confirm must show the credential form."""
         flow = make_reauth_flow()
         flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reauth_confirm"})
@@ -82,7 +102,7 @@ class TestReauthFlow:
         assert not call_kwargs["errors"]
 
     @pytest.mark.asyncio
-    async def test_reauth_confirm_valid_credentials_updates_entry_and_aborts(self) -> None:
+    async def test_valid_credentials_updates_entry_and_aborts(self) -> None:
         """Valid credentials must update entry.data and abort with reauth_successful."""
         flow = make_reauth_flow()
         flow.async_abort = MagicMock(return_value={"type": "abort", "reason": "reauth_successful"})
@@ -111,7 +131,7 @@ class TestReauthFlow:
         )
 
     @pytest.mark.asyncio
-    async def test_reauth_confirm_invalid_credentials_shows_error(self) -> None:
+    async def test_invalid_credentials_shows_error(self) -> None:
         """Invalid credentials must re-show the form with invalid_auth error."""
         from custom_components.unifi_alerts.unifi_client import InvalidAuthError
 
@@ -137,7 +157,7 @@ class TestReauthFlow:
         assert call_kwargs["errors"] == {"base": "invalid_auth"}
 
     @pytest.mark.asyncio
-    async def test_reauth_confirm_cannot_connect_shows_error(self) -> None:
+    async def test_cannot_connect_shows_error(self) -> None:
         """A connection error during reauth must show cannot_connect error."""
         from custom_components.unifi_alerts.unifi_client import CannotConnectError
 
@@ -163,7 +183,7 @@ class TestReauthFlow:
         assert call_kwargs["errors"] == {"base": "cannot_connect"}
 
     @pytest.mark.asyncio
-    async def test_reauth_confirm_ssl_cert_error_shows_invalid_ssl_cert(self) -> None:
+    async def test_ssl_cert_error_shows_invalid_ssl_cert(self) -> None:
         """SslCertificateError during reauth must show invalid_ssl_cert base error."""
         from custom_components.unifi_alerts.unifi_client import SslCertificateError
 
@@ -189,7 +209,7 @@ class TestReauthFlow:
         assert call_kwargs["errors"] == {"base": "invalid_ssl_cert"}
 
     @pytest.mark.asyncio
-    async def test_reauth_confirm_does_not_delete_issue_on_failure(self) -> None:
+    async def test_does_not_delete_issue_on_failure(self) -> None:
         """async_delete_issue must NOT be called when reauth fails."""
         from custom_components.unifi_alerts.unifi_client import InvalidAuthError
 
@@ -214,7 +234,7 @@ class TestReauthFlow:
         mock_del.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_reauth_confirm_unexpected_exception_shows_unknown(self) -> None:
+    async def test_unexpected_exception_shows_unknown(self) -> None:
         flow = make_reauth_flow()
         flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reauth_confirm"})
 
@@ -234,21 +254,9 @@ class TestReauthFlow:
         assert result["step_id"] == "reauth_confirm"
         assert flow.async_show_form.call_args.kwargs["errors"] == {"base": "unknown"}
 
-    def test_create_auth_failed_issue_calls_issue_registry(self) -> None:
-        from custom_components.unifi_alerts.config_flow import _create_auth_failed_issue
 
-        hass = MagicMock()
-        entry = MagicMock()
-        entry.entry_id = "entry-1"
-        entry.title = "Controller"
-
-        with patch(
-            "custom_components.unifi_alerts.config_flow.ir.async_create_issue"
-        ) as mock_create:
-            _create_auth_failed_issue(hass, entry)
-
-        mock_create.assert_called_once()
-        assert mock_create.call_args.args[2] == "auth_failed_entry-1"
+class TestConfigFlowHelpers:
+    """Tests for standalone config flow class methods and helpers."""
 
     def test_async_get_options_flow_returns_options_flow_instance(self) -> None:
         entry = MagicMock()

--- a/tests/unit/config_flow/test_setup.py
+++ b/tests/unit/config_flow/test_setup.py
@@ -24,507 +24,299 @@ from custom_components.unifi_alerts.const import (
 from .conftest import _VALID_INPUT, make_flow, make_session_mock
 
 
-@pytest.mark.asyncio
-async def test_duplicate_url_aborts() -> None:
-    """When the controller URL is already configured, the flow should abort."""
-    flow = make_flow()
-    flow._abort_if_unique_id_configured = MagicMock(side_effect=AbortFlow("already_configured"))
-
-    with pytest.raises(AbortFlow) as exc_info:
-        await flow.async_step_user(_VALID_INPUT)
-
-    assert exc_info.value.reason == "already_configured"
-
-
-@pytest.mark.asyncio
-async def test_unique_id_set_to_normalised_url() -> None:
-    """async_set_unique_id must be called with the URL with trailing slash stripped."""
-    flow = make_flow()
-    flow.async_step_categories = AsyncMock(return_value={"type": "form"})
-
-    with (
-        patch(
-            "custom_components.unifi_alerts.config_flow.async_get_clientsession",
-            return_value=make_session_mock(),
-        ),
-        patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
-    ):
-        instance = mock_cls.return_value
-        instance.authenticate = AsyncMock(return_value="userpass")
-        instance.fetch_alarms = AsyncMock(return_value=[])
-
-        await flow.async_step_user({**_VALID_INPUT, CONF_CONTROLLER_URL: "https://192.168.1.1/"})
-
-    flow.async_set_unique_id.assert_called_once_with("https://192.168.1.1")
-
-
-@pytest.mark.asyncio
-async def test_unique_id_checked_before_auth() -> None:
-    """_abort_if_unique_id_configured must be called before authentication.
-
-    Verifies fail-fast behaviour: we never hit the network if the entry
-    already exists.
-    """
-    flow = make_flow()
-    call_order: list[str] = []
-
-    async def _set_unique_id(url: str) -> None:
-        call_order.append("set_unique_id")
-
-    def _abort_if_configured() -> None:
-        call_order.append("abort_check")
-        raise AbortFlow("already_configured")
-
-    flow.async_set_unique_id = _set_unique_id  # type: ignore[assignment]
-    flow._abort_if_unique_id_configured = _abort_if_configured
-
-    with pytest.raises(AbortFlow):
-        await flow.async_step_user(_VALID_INPUT)
-
-    assert call_order == ["set_unique_id", "abort_check"]
-
-
-@pytest.mark.asyncio
-async def test_invalid_url_scheme_shows_error() -> None:
-    """A controller URL that is not http/https must show a field-level error."""
-    flow = make_flow()
-    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
-
-    result = await flow.async_step_user({**_VALID_INPUT, CONF_CONTROLLER_URL: "ftp://192.168.1.1"})
-
-    assert result["step_id"] == "user"
-    call_kwargs = flow.async_show_form.call_args.kwargs
-    assert call_kwargs["errors"].get("controller_url") == "invalid_url_scheme"
-    # unique-id check and network call must NOT have happened
-    flow.async_set_unique_id.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_no_duplicate_proceeds_to_categories() -> None:
-    """When there is no duplicate, the flow should proceed to the categories step."""
-    flow = make_flow()
-    categories_result = {"type": "form", "step_id": "categories"}
-    flow.async_step_categories = AsyncMock(return_value=categories_result)
-
-    with (
-        patch(
-            "custom_components.unifi_alerts.config_flow.async_get_clientsession",
-            return_value=make_session_mock(),
-        ),
-        patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
-    ):
-        instance = mock_cls.return_value
-        instance.authenticate = AsyncMock(return_value="userpass")
-        instance.fetch_alarms = AsyncMock(return_value=[])
-
-        result = await flow.async_step_user(_VALID_INPUT)
-
-    assert result == categories_result
-    flow.async_set_unique_id.assert_called_once()
-    flow._abort_if_unique_id_configured.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_categories_all_disabled_shows_error() -> None:
-    """Submitting categories with nothing selected must show an error, not proceed."""
-    flow = make_flow()
-    flow._controller_url = "https://192.168.1.1"
-    flow._detected_auth_method = "userpass"
-    flow._credentials = dict(_VALID_INPUT)
-    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
-
-    all_off = {f"cat_{cat}": False for cat in ALL_CATEGORIES}
-    result = await flow.async_step_categories(all_off)
-
-    assert result["step_id"] == "categories"
-    call_kwargs = flow.async_show_form.call_args.kwargs
-    assert call_kwargs["errors"] == {"base": "at_least_one_category"}
-
-
-@pytest.mark.asyncio
-async def test_categories_proceeds_to_finish() -> None:
-    """Submitting categories should proceed to the finish step, not create the entry."""
-    flow = make_flow()
-    flow._controller_url = "https://192.168.1.1"
-    flow._detected_auth_method = "userpass"
-    flow._credentials = dict(_VALID_INPUT)
-
-    finish_result = {"type": "form", "step_id": "finish"}
-    flow.async_step_finish = AsyncMock(return_value=finish_result)
-
-    cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
-    result = await flow.async_step_categories(cat_input)
-
-    assert result == finish_result
-    flow.async_step_finish.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_finish_shows_webhook_urls() -> None:
-    """async_step_finish with no input should show a form with webhook URL fields in data_schema."""
-    flow = make_flow()
-    flow._controller_url = "https://192.168.1.1"
-    fake_secret = "test-secret-token"
-    flow._entry_data = {CONF_ENABLED_CATEGORIES: ALL_CATEGORIES, CONF_WEBHOOK_SECRET: fake_secret}
-    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "finish"})
-
-    fake_url = "http://homeassistant.local:8123/api/webhook/unifi_alerts_network_device"
-    with patch(
-        "custom_components.unifi_alerts.config_flow.async_generate_url",
-        return_value=fake_url,
-    ):
-        result = await flow.async_step_finish(user_input=None)
-
-    assert result["step_id"] == "finish"
-    call_kwargs = flow.async_show_form.call_args.kwargs
-    schema = call_kwargs["data_schema"]
-    # Webhook URLs must be present as field defaults in the schema
-    schema_defaults = {str(k): k.default() for k in schema.schema}
-    assert any(f"?token={fake_secret}" in v for v in schema_defaults.values())
-    assert any(fake_url in v for v in schema_defaults.values())
-
-
-@pytest.mark.asyncio
-async def test_finish_submit_creates_entry() -> None:
-    """async_step_finish with empty input (form submitted) should create the config entry."""
-    flow = make_flow()
-    flow._controller_url = "https://192.168.1.1"
-    flow._entry_data = {
-        CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
-        **_VALID_INPUT,
-    }
-    flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
-
-    await flow.async_step_finish(user_input={})
-
-    flow.async_create_entry.assert_called_once()
-    call_kwargs = flow.async_create_entry.call_args.kwargs
-    assert call_kwargs["title"] == "UniFi Alerts (https://192.168.1.1)"
-    assert call_kwargs["data"] is flow._entry_data
-
-
-@pytest.mark.asyncio
-async def test_user_step_error_preserves_submitted_values() -> None:
-    """On a validation error, the form must re-populate with the user's submitted values.
-
-    If the user types a controller URL (and other fields) and auth fails, the
-    schema defaults for the re-shown form must reflect what was submitted, not
-    the original hardcoded defaults.
-    """
-    from custom_components.unifi_alerts.unifi_client import InvalidAuthError
-
-    submitted = {
-        CONF_CONTROLLER_URL: "https://10.0.0.1",
-        CONF_USERNAME: "myuser",
-        CONF_PASSWORD: "mypassword",
-        CONF_API_KEY: "",
-        CONF_VERIFY_SSL: False,
-    }
-
-    flow = make_flow()
-    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
-
-    with (
-        patch(
-            "custom_components.unifi_alerts.config_flow.async_get_clientsession",
-            return_value=make_session_mock(),
-        ),
-        patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
-    ):
-        instance = mock_cls.return_value
-        instance.authenticate = AsyncMock(side_effect=InvalidAuthError("bad creds"))
-
-        result = await flow.async_step_user(submitted)
-
-    assert result["step_id"] == "user"
-    call_kwargs = flow.async_show_form.call_args.kwargs
-    assert call_kwargs["errors"] == {"base": "invalid_auth"}
-
-    # Schema defaults must reflect submitted values, not hardcoded "https://192.168.1.1"
-    schema = call_kwargs["data_schema"]
-    schema_defaults = {str(k): k.default() for k in schema.schema if k.default is not vol.UNDEFINED}
-    assert schema_defaults.get(CONF_CONTROLLER_URL) == "https://10.0.0.1"
-    assert schema_defaults.get(CONF_USERNAME) == "myuser"
-    # Password and API key fields must NOT be pre-filled — they have no default
-    assert CONF_PASSWORD not in schema_defaults
-    assert CONF_API_KEY not in schema_defaults
-    assert schema_defaults.get(CONF_VERIFY_SSL) is False
-
-
-@pytest.mark.asyncio
-async def test_user_step_uses_ha_clientsession_with_user_verify_ssl() -> None:
-    """async_step_user must use HA's shared clientsession with the user's verify_ssl value.
-
-    Bare `aiohttp.ClientSession()` bypasses HA's proxy config, connection pool, and
-    the user's SSL setting. The fix is to call `async_get_clientsession(hass, verify_ssl=...)`
-    so HA returns the appropriately-configured shared session.
-    """
-    flow = make_flow()
-    flow.async_step_categories = AsyncMock(return_value={"type": "form"})
-
-    with (
-        patch(
-            "custom_components.unifi_alerts.config_flow.async_get_clientsession",
-            return_value=MagicMock(),
-        ) as mock_get_session,
-        patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
-    ):
-        instance = mock_cls.return_value
-        instance.authenticate = AsyncMock(return_value="userpass")
-        instance.fetch_alarms = AsyncMock(return_value=[])
-
-        await flow.async_step_user({**_VALID_INPUT, CONF_VERIFY_SSL: False})
-
-    mock_get_session.assert_called_once_with(flow.hass, verify_ssl=False)
-
-
-@pytest.mark.asyncio
-async def test_user_step_initial_load_uses_hardcoded_defaults() -> None:
-    """On initial load (no user_input), the form should show hardcoded defaults."""
-    flow = make_flow()
-    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
-
-    result = await flow.async_step_user(user_input=None)
-
-    assert result["step_id"] == "user"
-    call_kwargs = flow.async_show_form.call_args.kwargs
-    schema = call_kwargs["data_schema"]
-    # Only read defaults for keys that actually have one (some Optional fields don't).
-    schema_defaults = {}
-    for k in schema.schema:
-        if not isinstance(k.default, vol.Undefined.__class__) and k.default is not vol.UNDEFINED:
-            with contextlib.suppress(TypeError):
-                schema_defaults[str(k)] = k.default()
-    assert schema_defaults.get(CONF_CONTROLLER_URL) == "https://192.168.1.1"
-    assert schema_defaults.get(CONF_VERIFY_SSL) == DEFAULT_VERIFY_SSL
-
-
-@pytest.mark.asyncio
-async def test_categories_step_saves_poll_interval_and_clear_timeout() -> None:
-    """Submitted poll_interval and clear_timeout must be stored in _entry_data."""
-    from custom_components.unifi_alerts.const import CONF_CLEAR_TIMEOUT, CONF_POLL_INTERVAL
-
-    flow = make_flow()
-    flow._controller_url = "https://192.168.1.1"
-    flow._detected_auth_method = "userpass"
-    flow._credentials = {CONF_WEBHOOK_SECRET: "s"}
-    flow.async_step_finish = AsyncMock(return_value={"type": "form", "step_id": "finish"})
-
-    cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
-    cat_input[CONF_POLL_INTERVAL] = 120
-    cat_input[CONF_CLEAR_TIMEOUT] = 30
-
-    await flow.async_step_categories(cat_input)
-
-    assert flow._entry_data[CONF_POLL_INTERVAL] == 120
-    assert flow._entry_data[CONF_CLEAR_TIMEOUT] == 30
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("poll_interval", [10, 3600])
-async def test_categories_step_accepts_boundary_poll_intervals(poll_interval: int) -> None:
-    """poll_interval boundary values 10 and 3600 must be accepted without error."""
-    from custom_components.unifi_alerts.const import CONF_POLL_INTERVAL
-
-    flow = make_flow()
-    flow._controller_url = "https://192.168.1.1"
-    flow._detected_auth_method = "userpass"
-    flow._credentials = {CONF_WEBHOOK_SECRET: "s"}
-    flow.async_step_finish = AsyncMock(return_value={"type": "form", "step_id": "finish"})
-
-    cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
-    cat_input[CONF_POLL_INTERVAL] = poll_interval
-
-    result = await flow.async_step_categories(cat_input)
-
-    assert result["step_id"] == "finish"
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("clear_timeout", [1, 1440])
-async def test_categories_step_accepts_boundary_clear_timeouts(clear_timeout: int) -> None:
-    """clear_timeout boundary values 1 and 1440 must be accepted without error."""
-    from custom_components.unifi_alerts.const import CONF_CLEAR_TIMEOUT
-
-    flow = make_flow()
-    flow._controller_url = "https://192.168.1.1"
-    flow._detected_auth_method = "userpass"
-    flow._credentials = {CONF_WEBHOOK_SECRET: "s"}
-    flow.async_step_finish = AsyncMock(return_value={"type": "form", "step_id": "finish"})
-
-    cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
-    cat_input[CONF_CLEAR_TIMEOUT] = clear_timeout
-
-    result = await flow.async_step_categories(cat_input)
-
-    assert result["step_id"] == "finish"
-
-
-@pytest.mark.asyncio
-async def test_step_user_fetch_alarms_failure_shows_cannot_connect() -> None:
-    """If fetch_alarms() raises CannotConnectError after successful auth, show cannot_connect error."""
-    from custom_components.unifi_alerts.unifi_client import CannotConnectError
-
-    flow = make_flow()
-    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
-
-    with (
-        patch(
-            "custom_components.unifi_alerts.config_flow.async_get_clientsession",
-            return_value=make_session_mock(),
-        ),
-        patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
-    ):
-        instance = mock_cls.return_value
-        instance.authenticate = AsyncMock(return_value="userpass")
-        instance.fetch_alarms = AsyncMock(
-            side_effect=CannotConnectError("UniFi API error: api.err.InvalidObject")
-        )
-
-        result = await flow.async_step_user(_VALID_INPUT)
-
-    assert result["step_id"] == "user"
-    call_kwargs = flow.async_show_form.call_args.kwargs
-    assert call_kwargs["errors"] == {"base": "cannot_connect"}
-
-
-@pytest.mark.asyncio
-async def test_step_user_ssl_cert_error_on_authenticate_shows_invalid_ssl_cert() -> None:
-    """SslCertificateError from authenticate() must map to the invalid_ssl_cert field error."""
-    from custom_components.unifi_alerts.unifi_client import SslCertificateError
-
-    flow = make_flow()
-    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
-
-    with (
-        patch(
-            "custom_components.unifi_alerts.config_flow.async_get_clientsession",
-            return_value=make_session_mock(),
-        ),
-        patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
-    ):
-        instance = mock_cls.return_value
-        instance.authenticate = AsyncMock(side_effect=SslCertificateError("cert error"))
-
-        result = await flow.async_step_user(_VALID_INPUT)
-
-    assert result["step_id"] == "user"
-    call_kwargs = flow.async_show_form.call_args.kwargs
-    assert call_kwargs["errors"] == {CONF_CONTROLLER_URL: "invalid_ssl_cert"}
-
-
-@pytest.mark.asyncio
-async def test_step_user_ssl_cert_error_on_fetch_alarms_shows_invalid_ssl_cert() -> None:
-    """SslCertificateError from fetch_alarms() must map to the invalid_ssl_cert field error."""
-    from custom_components.unifi_alerts.unifi_client import SslCertificateError
-
-    flow = make_flow()
-    flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
-
-    with (
-        patch(
-            "custom_components.unifi_alerts.config_flow.async_get_clientsession",
-            return_value=make_session_mock(),
-        ),
-        patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
-    ):
-        instance = mock_cls.return_value
-        instance.authenticate = AsyncMock(return_value="userpass")
-        instance.fetch_alarms = AsyncMock(side_effect=SslCertificateError("cert error"))
-
-        result = await flow.async_step_user(_VALID_INPUT)
-
-    assert result["step_id"] == "user"
-    call_kwargs = flow.async_show_form.call_args.kwargs
-    assert call_kwargs["errors"] == {CONF_CONTROLLER_URL: "invalid_ssl_cert"}
-
-
-@pytest.mark.asyncio
-async def test_ssl_cert_error_is_subclass_of_cannot_connect() -> None:
-    """SslCertificateError must be a subclass of CannotConnectError."""
-    from custom_components.unifi_alerts.unifi_client import CannotConnectError, SslCertificateError
-
-    assert issubclass(SslCertificateError, CannotConnectError)
-
-
-@pytest.mark.asyncio
-async def test_async_migrate_entry_strips_conf_is_unifi_os() -> None:
-    """async_migrate_entry must remove is_unifi_os and ultimately reach version 3.
-
-    A v1 entry passes through v1->2 (strip is_unifi_os) and then v2->3
-    (backfill webhook_secret / webhook_id_suffix) in the same call.
-    """
-    from custom_components.unifi_alerts import async_migrate_entry
-
-    entry = MagicMock()
-    entry.entry_id = "test-entry-migrate"
-    entry.version = 1
-    entry.data = {
-        CONF_CONTROLLER_URL: "https://192.168.1.1",
-        CONF_USERNAME: "admin",
-        CONF_PASSWORD: "secret",
-        CONF_VERIFY_SSL: True,
-        "is_unifi_os": True,  # stale key from v1
-    }
-
-    # Simulate HA's async_update_entry: update version and data in-place
-    def _fake_update(entry, *, data=None, version=None, **kwargs):
-        if data is not None:
-            entry.data = data
-        if version is not None:
-            entry.version = version
-
-    hass = MagicMock()
-    hass.config_entries.async_update_entry = MagicMock(side_effect=_fake_update)
-
-    result = await async_migrate_entry(hass, entry)
-
-    assert result is True
-    # v1->2->3: the chained migration ends at version 3
-    assert entry.version == 3
-    assert "is_unifi_os" not in entry.data
-    # Remaining fields must be preserved
-    assert entry.data[CONF_CONTROLLER_URL] == "https://192.168.1.1"
-
-
-@pytest.mark.asyncio
-async def test_user_step_generates_webhook_id_suffix() -> None:
-    from custom_components.unifi_alerts.const import CONF_WEBHOOK_ID_SUFFIX
-
-    flow = make_flow()
-    flow.async_step_categories = AsyncMock(return_value={"type": "form"})
-
-    with (
-        patch(
-            "custom_components.unifi_alerts.config_flow.async_get_clientsession",
-            return_value=make_session_mock(),
-        ),
-        patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
-    ):
-        instance = mock_cls.return_value
-        instance.authenticate = AsyncMock(return_value="userpass")
-        instance.fetch_alarms = AsyncMock(return_value=[])
-        instance._is_unifi_os = False
-
-        await flow.async_step_user(_VALID_INPUT)
-
-    suffix = flow._credentials.get(CONF_WEBHOOK_ID_SUFFIX)
-    assert suffix is not None
-    assert len(suffix) == 8  # token_hex(4) → 8 hex chars
-    assert all(c in "0123456789abcdef" for c in suffix)
-
-
-@pytest.mark.asyncio
-async def test_two_distinct_setups_get_distinct_suffixes() -> None:
-    """Running two independent config flows must produce two distinct suffixes
-    (collisions would be vanishingly rare on 32 bits but the test guards
-    against accidentally hardcoding the value)."""
-    from custom_components.unifi_alerts.const import CONF_WEBHOOK_ID_SUFFIX
-
-    suffixes: list[str] = []
-    for _ in range(2):
+class TestUserStep:
+    """Tests for async_step_user."""
+
+    @pytest.mark.asyncio
+    async def test_duplicate_url_aborts(self) -> None:
+        """When the controller URL is already configured, the flow should abort."""
+        flow = make_flow()
+        flow._abort_if_unique_id_configured = MagicMock(side_effect=AbortFlow("already_configured"))
+
+        with pytest.raises(AbortFlow) as exc_info:
+            await flow.async_step_user(_VALID_INPUT)
+
+        assert exc_info.value.reason == "already_configured"
+
+    @pytest.mark.asyncio
+    async def test_unique_id_set_to_normalised_url(self) -> None:
+        """async_set_unique_id must be called with the URL with trailing slash stripped."""
         flow = make_flow()
         flow.async_step_categories = AsyncMock(return_value={"type": "form"})
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.fetch_alarms = AsyncMock(return_value=[])
+
+            await flow.async_step_user(
+                {**_VALID_INPUT, CONF_CONTROLLER_URL: "https://192.168.1.1/"}
+            )
+
+        flow.async_set_unique_id.assert_called_once_with("https://192.168.1.1")
+
+    @pytest.mark.asyncio
+    async def test_unique_id_checked_before_auth(self) -> None:
+        """_abort_if_unique_id_configured must be called before authentication.
+
+        Verifies fail-fast behaviour: we never hit the network if the entry
+        already exists.
+        """
+        flow = make_flow()
+        call_order: list[str] = []
+
+        async def _set_unique_id(url: str) -> None:
+            call_order.append("set_unique_id")
+
+        def _abort_if_configured() -> None:
+            call_order.append("abort_check")
+            raise AbortFlow("already_configured")
+
+        flow.async_set_unique_id = _set_unique_id  # type: ignore[assignment]
+        flow._abort_if_unique_id_configured = _abort_if_configured
+
+        with pytest.raises(AbortFlow):
+            await flow.async_step_user(_VALID_INPUT)
+
+        assert call_order == ["set_unique_id", "abort_check"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_url_scheme_shows_error(self) -> None:
+        """A controller URL that is not http/https must show a field-level error."""
+        flow = make_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
+
+        result = await flow.async_step_user(
+            {**_VALID_INPUT, CONF_CONTROLLER_URL: "ftp://192.168.1.1"}
+        )
+
+        assert result["step_id"] == "user"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"].get("controller_url") == "invalid_url_scheme"
+        # unique-id check and network call must NOT have happened
+        flow.async_set_unique_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_proceeds_to_categories(self) -> None:
+        """When there is no duplicate, the flow should proceed to the categories step."""
+        flow = make_flow()
+        categories_result = {"type": "form", "step_id": "categories"}
+        flow.async_step_categories = AsyncMock(return_value=categories_result)
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.fetch_alarms = AsyncMock(return_value=[])
+
+            result = await flow.async_step_user(_VALID_INPUT)
+
+        assert result == categories_result
+        flow.async_set_unique_id.assert_called_once()
+        flow._abort_if_unique_id_configured.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_error_preserves_submitted_values(self) -> None:
+        """On a validation error, the form must re-populate with the user's submitted values.
+
+        If the user types a controller URL (and other fields) and auth fails, the
+        schema defaults for the re-shown form must reflect what was submitted, not
+        the original hardcoded defaults.
+        """
+        from custom_components.unifi_alerts.unifi_client import InvalidAuthError
+
+        submitted = {
+            CONF_CONTROLLER_URL: "https://10.0.0.1",
+            CONF_USERNAME: "myuser",
+            CONF_PASSWORD: "mypassword",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: False,
+        }
+
+        flow = make_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(side_effect=InvalidAuthError("bad creds"))
+
+            result = await flow.async_step_user(submitted)
+
+        assert result["step_id"] == "user"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"] == {"base": "invalid_auth"}
+
+        # Schema defaults must reflect submitted values, not hardcoded "https://192.168.1.1"
+        schema = call_kwargs["data_schema"]
+        schema_defaults = {
+            str(k): k.default() for k in schema.schema if k.default is not vol.UNDEFINED
+        }
+        assert schema_defaults.get(CONF_CONTROLLER_URL) == "https://10.0.0.1"
+        assert schema_defaults.get(CONF_USERNAME) == "myuser"
+        # Password and API key fields must NOT be pre-filled — they have no default
+        assert CONF_PASSWORD not in schema_defaults
+        assert CONF_API_KEY not in schema_defaults
+        assert schema_defaults.get(CONF_VERIFY_SSL) is False
+
+    @pytest.mark.asyncio
+    async def test_uses_ha_clientsession_with_user_verify_ssl(self) -> None:
+        """async_step_user must use HA's shared clientsession with the user's verify_ssl value.
+
+        Bare `aiohttp.ClientSession()` bypasses HA's proxy config, connection pool, and
+        the user's SSL setting. The fix is to call `async_get_clientsession(hass, verify_ssl=...)`
+        so HA returns the appropriately-configured shared session.
+        """
+        flow = make_flow()
+        flow.async_step_categories = AsyncMock(return_value={"type": "form"})
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=MagicMock(),
+            ) as mock_get_session,
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.fetch_alarms = AsyncMock(return_value=[])
+
+            await flow.async_step_user({**_VALID_INPUT, CONF_VERIFY_SSL: False})
+
+        mock_get_session.assert_called_once_with(flow.hass, verify_ssl=False)
+
+    @pytest.mark.asyncio
+    async def test_initial_load_uses_hardcoded_defaults(self) -> None:
+        """On initial load (no user_input), the form should show hardcoded defaults."""
+        flow = make_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
+
+        result = await flow.async_step_user(user_input=None)
+
+        assert result["step_id"] == "user"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        schema = call_kwargs["data_schema"]
+        # Only read defaults for keys that actually have one (some Optional fields don't).
+        schema_defaults = {}
+        for k in schema.schema:
+            if (
+                not isinstance(k.default, vol.Undefined.__class__)
+                and k.default is not vol.UNDEFINED
+            ):
+                with contextlib.suppress(TypeError):
+                    schema_defaults[str(k)] = k.default()
+        assert schema_defaults.get(CONF_CONTROLLER_URL) == "https://192.168.1.1"
+        assert schema_defaults.get(CONF_VERIFY_SSL) == DEFAULT_VERIFY_SSL
+
+    @pytest.mark.asyncio
+    async def test_fetch_alarms_failure_shows_cannot_connect(self) -> None:
+        """If fetch_alarms() raises CannotConnectError after successful auth, show cannot_connect error."""
+        from custom_components.unifi_alerts.unifi_client import CannotConnectError
+
+        flow = make_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.fetch_alarms = AsyncMock(
+                side_effect=CannotConnectError("UniFi API error: api.err.InvalidObject")
+            )
+
+            result = await flow.async_step_user(_VALID_INPUT)
+
+        assert result["step_id"] == "user"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"] == {"base": "cannot_connect"}
+
+    @pytest.mark.asyncio
+    async def test_ssl_cert_error_on_authenticate_shows_invalid_ssl_cert(self) -> None:
+        """SslCertificateError from authenticate() must map to the invalid_ssl_cert field error."""
+        from custom_components.unifi_alerts.unifi_client import SslCertificateError
+
+        flow = make_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(side_effect=SslCertificateError("cert error"))
+
+            result = await flow.async_step_user(_VALID_INPUT)
+
+        assert result["step_id"] == "user"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"] == {CONF_CONTROLLER_URL: "invalid_ssl_cert"}
+
+    @pytest.mark.asyncio
+    async def test_ssl_cert_error_on_fetch_alarms_shows_invalid_ssl_cert(self) -> None:
+        """SslCertificateError from fetch_alarms() must map to the invalid_ssl_cert field error."""
+        from custom_components.unifi_alerts.unifi_client import SslCertificateError
+
+        flow = make_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.fetch_alarms = AsyncMock(side_effect=SslCertificateError("cert error"))
+
+            result = await flow.async_step_user(_VALID_INPUT)
+
+        assert result["step_id"] == "user"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"] == {CONF_CONTROLLER_URL: "invalid_ssl_cert"}
+
+    @pytest.mark.asyncio
+    async def test_ssl_cert_error_is_subclass_of_cannot_connect(self) -> None:
+        """SslCertificateError must be a subclass of CannotConnectError."""
+        from custom_components.unifi_alerts.unifi_client import (
+            CannotConnectError,
+            SslCertificateError,
+        )
+
+        assert issubclass(SslCertificateError, CannotConnectError)
+
+    @pytest.mark.asyncio
+    async def test_generates_webhook_id_suffix(self) -> None:
+        from custom_components.unifi_alerts.const import CONF_WEBHOOK_ID_SUFFIX
+
+        flow = make_flow()
+        flow.async_step_categories = AsyncMock(return_value={"type": "form"})
+
         with (
             patch(
                 "custom_components.unifi_alerts.config_flow.async_get_clientsession",
@@ -536,6 +328,223 @@ async def test_two_distinct_setups_get_distinct_suffixes() -> None:
             instance.authenticate = AsyncMock(return_value="userpass")
             instance.fetch_alarms = AsyncMock(return_value=[])
             instance._is_unifi_os = False
+
             await flow.async_step_user(_VALID_INPUT)
-        suffixes.append(flow._credentials[CONF_WEBHOOK_ID_SUFFIX])
-    assert suffixes[0] != suffixes[1]
+
+        suffix = flow._credentials.get(CONF_WEBHOOK_ID_SUFFIX)
+        assert suffix is not None
+        assert len(suffix) == 8  # token_hex(4) → 8 hex chars
+        assert all(c in "0123456789abcdef" for c in suffix)
+
+    @pytest.mark.asyncio
+    async def test_two_distinct_setups_get_distinct_suffixes(self) -> None:
+        """Running two independent config flows must produce two distinct suffixes
+        (collisions would be vanishingly rare on 32 bits but the test guards
+        against accidentally hardcoding the value)."""
+        from custom_components.unifi_alerts.const import CONF_WEBHOOK_ID_SUFFIX
+
+        suffixes: list[str] = []
+        for _ in range(2):
+            flow = make_flow()
+            flow.async_step_categories = AsyncMock(return_value={"type": "form"})
+            with (
+                patch(
+                    "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                    return_value=make_session_mock(),
+                ),
+                patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+            ):
+                instance = mock_cls.return_value
+                instance.authenticate = AsyncMock(return_value="userpass")
+                instance.fetch_alarms = AsyncMock(return_value=[])
+                instance._is_unifi_os = False
+                await flow.async_step_user(_VALID_INPUT)
+            suffixes.append(flow._credentials[CONF_WEBHOOK_ID_SUFFIX])
+        assert suffixes[0] != suffixes[1]
+
+
+class TestCategoriesStep:
+    """Tests for async_step_categories."""
+
+    @pytest.mark.asyncio
+    async def test_all_disabled_shows_error(self) -> None:
+        """Submitting categories with nothing selected must show an error, not proceed."""
+        flow = make_flow()
+        flow._controller_url = "https://192.168.1.1"
+        flow._detected_auth_method = "userpass"
+        flow._credentials = dict(_VALID_INPUT)
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
+
+        all_off = {f"cat_{cat}": False for cat in ALL_CATEGORIES}
+        result = await flow.async_step_categories(all_off)
+
+        assert result["step_id"] == "categories"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"] == {"base": "at_least_one_category"}
+
+    @pytest.mark.asyncio
+    async def test_proceeds_to_finish(self) -> None:
+        """Submitting categories should proceed to the finish step, not create the entry."""
+        flow = make_flow()
+        flow._controller_url = "https://192.168.1.1"
+        flow._detected_auth_method = "userpass"
+        flow._credentials = dict(_VALID_INPUT)
+
+        finish_result = {"type": "form", "step_id": "finish"}
+        flow.async_step_finish = AsyncMock(return_value=finish_result)
+
+        cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+        result = await flow.async_step_categories(cat_input)
+
+        assert result == finish_result
+        flow.async_step_finish.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_saves_poll_interval_and_clear_timeout(self) -> None:
+        """Submitted poll_interval and clear_timeout must be stored in _entry_data."""
+        from custom_components.unifi_alerts.const import CONF_CLEAR_TIMEOUT, CONF_POLL_INTERVAL
+
+        flow = make_flow()
+        flow._controller_url = "https://192.168.1.1"
+        flow._detected_auth_method = "userpass"
+        flow._credentials = {CONF_WEBHOOK_SECRET: "s"}
+        flow.async_step_finish = AsyncMock(return_value={"type": "form", "step_id": "finish"})
+
+        cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+        cat_input[CONF_POLL_INTERVAL] = 120
+        cat_input[CONF_CLEAR_TIMEOUT] = 30
+
+        await flow.async_step_categories(cat_input)
+
+        assert flow._entry_data[CONF_POLL_INTERVAL] == 120
+        assert flow._entry_data[CONF_CLEAR_TIMEOUT] == 30
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("poll_interval", [10, 3600])
+    async def test_accepts_boundary_poll_intervals(self, poll_interval: int) -> None:
+        """poll_interval boundary values 10 and 3600 must be accepted without error."""
+        from custom_components.unifi_alerts.const import CONF_POLL_INTERVAL
+
+        flow = make_flow()
+        flow._controller_url = "https://192.168.1.1"
+        flow._detected_auth_method = "userpass"
+        flow._credentials = {CONF_WEBHOOK_SECRET: "s"}
+        flow.async_step_finish = AsyncMock(return_value={"type": "form", "step_id": "finish"})
+
+        cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+        cat_input[CONF_POLL_INTERVAL] = poll_interval
+
+        result = await flow.async_step_categories(cat_input)
+
+        assert result["step_id"] == "finish"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("clear_timeout", [1, 1440])
+    async def test_accepts_boundary_clear_timeouts(self, clear_timeout: int) -> None:
+        """clear_timeout boundary values 1 and 1440 must be accepted without error."""
+        from custom_components.unifi_alerts.const import CONF_CLEAR_TIMEOUT
+
+        flow = make_flow()
+        flow._controller_url = "https://192.168.1.1"
+        flow._detected_auth_method = "userpass"
+        flow._credentials = {CONF_WEBHOOK_SECRET: "s"}
+        flow.async_step_finish = AsyncMock(return_value={"type": "form", "step_id": "finish"})
+
+        cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+        cat_input[CONF_CLEAR_TIMEOUT] = clear_timeout
+
+        result = await flow.async_step_categories(cat_input)
+
+        assert result["step_id"] == "finish"
+
+
+class TestFinishStep:
+    """Tests for async_step_finish."""
+
+    @pytest.mark.asyncio
+    async def test_shows_webhook_urls(self) -> None:
+        """async_step_finish with no input should show a form with webhook URL fields in data_schema."""
+        flow = make_flow()
+        flow._controller_url = "https://192.168.1.1"
+        fake_secret = "test-secret-token"
+        flow._entry_data = {
+            CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+            CONF_WEBHOOK_SECRET: fake_secret,
+        }
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "finish"})
+
+        fake_url = "http://homeassistant.local:8123/api/webhook/unifi_alerts_network_device"
+        with patch(
+            "custom_components.unifi_alerts.config_flow.async_generate_url",
+            return_value=fake_url,
+        ):
+            result = await flow.async_step_finish(user_input=None)
+
+        assert result["step_id"] == "finish"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        schema = call_kwargs["data_schema"]
+        # Webhook URLs must be present as field defaults in the schema
+        schema_defaults = {str(k): k.default() for k in schema.schema}
+        assert any(f"?token={fake_secret}" in v for v in schema_defaults.values())
+        assert any(fake_url in v for v in schema_defaults.values())
+
+    @pytest.mark.asyncio
+    async def test_submit_creates_entry(self) -> None:
+        """async_step_finish with empty input (form submitted) should create the config entry."""
+        flow = make_flow()
+        flow._controller_url = "https://192.168.1.1"
+        flow._entry_data = {
+            CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+            **_VALID_INPUT,
+        }
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+        await flow.async_step_finish(user_input={})
+
+        flow.async_create_entry.assert_called_once()
+        call_kwargs = flow.async_create_entry.call_args.kwargs
+        assert call_kwargs["title"] == "UniFi Alerts (https://192.168.1.1)"
+        assert call_kwargs["data"] is flow._entry_data
+
+
+class TestMigration:
+    """Tests for async_migrate_entry."""
+
+    @pytest.mark.asyncio
+    async def test_strips_conf_is_unifi_os(self) -> None:
+        """async_migrate_entry must remove is_unifi_os and ultimately reach version 3.
+
+        A v1 entry passes through v1->2 (strip is_unifi_os) and then v2->3
+        (backfill webhook_secret / webhook_id_suffix) in the same call.
+        """
+        from custom_components.unifi_alerts import async_migrate_entry
+
+        entry = MagicMock()
+        entry.entry_id = "test-entry-migrate"
+        entry.version = 1
+        entry.data = {
+            CONF_CONTROLLER_URL: "https://192.168.1.1",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "secret",
+            CONF_VERIFY_SSL: True,
+            "is_unifi_os": True,  # stale key from v1
+        }
+
+        # Simulate HA's async_update_entry: update version and data in-place
+        def _fake_update(entry, *, data=None, version=None, **kwargs):
+            if data is not None:
+                entry.data = data
+            if version is not None:
+                entry.version = version
+
+        hass = MagicMock()
+        hass.config_entries.async_update_entry = MagicMock(side_effect=_fake_update)
+
+        result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        # v1->2->3: the chained migration ends at version 3
+        assert entry.version == 3
+        assert "is_unifi_os" not in entry.data
+        # Remaining fields must be preserved
+        assert entry.data[CONF_CONTROLLER_URL] == "https://192.168.1.1"

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -59,124 +59,130 @@ def _make_coordinator(
     return coordinator
 
 
-@pytest.mark.asyncio
-async def test_diagnostics_redacts_password() -> None:
-    entry = _make_entry_with_runtime(_make_coordinator())
-    hass = MagicMock()
+class TestDiagnosticsRedaction:
+    """Tests that sensitive config fields are redacted and non-sensitive fields are preserved."""
 
-    result = await async_get_config_entry_diagnostics(hass, entry)
+    @pytest.mark.asyncio
+    async def test_redacts_password(self) -> None:
+        entry = _make_entry_with_runtime(_make_coordinator())
+        hass = MagicMock()
 
-    assert result["config_entry"][CONF_PASSWORD] == "**REDACTED**"
+        result = await async_get_config_entry_diagnostics(hass, entry)
 
+        assert result["config_entry"][CONF_PASSWORD] == "**REDACTED**"
 
-@pytest.mark.asyncio
-async def test_diagnostics_redacts_api_key() -> None:
-    entry = _make_entry_with_runtime(
-        _make_coordinator(), extra_data={CONF_API_KEY: "super-secret-key"}
-    )
-    hass = MagicMock()
+    @pytest.mark.asyncio
+    async def test_redacts_api_key(self) -> None:
+        entry = _make_entry_with_runtime(
+            _make_coordinator(), extra_data={CONF_API_KEY: "super-secret-key"}
+        )
+        hass = MagicMock()
 
-    result = await async_get_config_entry_diagnostics(hass, entry)
+        result = await async_get_config_entry_diagnostics(hass, entry)
 
-    assert result["config_entry"][CONF_API_KEY] == "**REDACTED**"
+        assert result["config_entry"][CONF_API_KEY] == "**REDACTED**"
 
+    @pytest.mark.asyncio
+    async def test_preserves_non_sensitive_config(self) -> None:
+        entry = _make_entry_with_runtime(_make_coordinator())
+        hass = MagicMock()
 
-@pytest.mark.asyncio
-async def test_diagnostics_exposes_all_webhook_urls() -> None:
-    entry = _make_entry_with_runtime(_make_coordinator())
-    hass = MagicMock()
+        result = await async_get_config_entry_diagnostics(hass, entry)
 
-    result = await async_get_config_entry_diagnostics(hass, entry)
-
-    assert result["webhook_urls"] == _SAMPLE_WEBHOOK_URLS
-    for cat in ALL_CATEGORIES:
-        assert cat in result["webhook_urls"]
-
-
-@pytest.mark.asyncio
-async def test_diagnostics_includes_coordinator_state() -> None:
-    coordinator = _make_coordinator(any_alerting=True, rollup_alert_count=3, rollup_open_count=5)
-    entry = _make_entry_with_runtime(coordinator)
-    hass = MagicMock()
-
-    result = await async_get_config_entry_diagnostics(hass, entry)
-
-    assert result["coordinator"]["any_alerting"] is True
-    assert result["coordinator"]["rollup_alert_count"] == 3
-    assert result["coordinator"]["rollup_open_count"] == 5
+        assert result["config_entry"]["controller_url"] == "https://192.168.1.1"
+        assert result["config_entry"]["username"] == "**REDACTED**"
 
 
-@pytest.mark.asyncio
-async def test_diagnostics_handles_missing_entry_data() -> None:
-    """Diagnostics should not raise if runtime_data is absent (e.g. during setup failure)."""
-    entry = _make_entry()
-    # Ensure runtime_data is not set (simulates a failed setup)
-    del entry.runtime_data
-    hass = MagicMock()
+class TestDiagnosticsContent:
+    """Tests that diagnostics expose the expected coordinator state and webhook URLs."""
 
-    result = await async_get_config_entry_diagnostics(hass, entry)
+    @pytest.mark.asyncio
+    async def test_exposes_all_webhook_urls(self) -> None:
+        entry = _make_entry_with_runtime(_make_coordinator())
+        hass = MagicMock()
 
-    assert result["webhook_urls"] == {}
-    assert result["coordinator"] == {}
+        result = await async_get_config_entry_diagnostics(hass, entry)
+
+        assert result["webhook_urls"] == _SAMPLE_WEBHOOK_URLS
+        for cat in ALL_CATEGORIES:
+            assert cat in result["webhook_urls"]
+
+    @pytest.mark.asyncio
+    async def test_includes_coordinator_state(self) -> None:
+        coordinator = _make_coordinator(
+            any_alerting=True, rollup_alert_count=3, rollup_open_count=5
+        )
+        entry = _make_entry_with_runtime(coordinator)
+        hass = MagicMock()
+
+        result = await async_get_config_entry_diagnostics(hass, entry)
+
+        assert result["coordinator"]["any_alerting"] is True
+        assert result["coordinator"]["rollup_alert_count"] == 3
+        assert result["coordinator"]["rollup_open_count"] == 5
+
+    @pytest.mark.asyncio
+    async def test_exposes_per_category_state(self) -> None:
+        cleared_at = datetime(2026, 4, 30, 12, 0, 0, tzinfo=UTC)
+        cat = ALL_CATEGORIES[0]
+        states = {c: CategoryState(category=c) for c in ALL_CATEGORIES}
+        # Use a current timestamp so webhook_health() reads "healthy" (within the
+        # 7-day window) deterministically regardless of when the suite runs.
+        webhook_at = datetime.now(UTC)
+        states[cat] = CategoryState(
+            category=cat,
+            enabled=True,
+            is_alerting=True,
+            alert_count=4,
+            open_count=2,
+            last_cleared_at=cleared_at,
+            last_webhook_at=webhook_at,
+        )
+        coordinator = _make_coordinator(category_states=states)
+        entry = _make_entry_with_runtime(coordinator)
+        hass = MagicMock()
+
+        result = await async_get_config_entry_diagnostics(hass, entry)
+
+        categories = result["coordinator"]["categories"]
+        assert set(categories.keys()) == set(ALL_CATEGORIES)
+        assert categories[cat] == {
+            "enabled": True,
+            "is_alerting": True,
+            "open_count": 2,
+            "alert_count": 4,
+            "last_cleared_at": cleared_at.isoformat(),
+            "last_webhook_at": webhook_at.isoformat(),
+            "webhook_health": "healthy",
+        }
+
+    @pytest.mark.asyncio
+    async def test_per_category_last_cleared_at_none_when_unset(self) -> None:
+        coordinator = _make_coordinator()
+        entry = _make_entry_with_runtime(coordinator)
+        hass = MagicMock()
+
+        result = await async_get_config_entry_diagnostics(hass, entry)
+
+        for cat in ALL_CATEGORIES:
+            cat_entry = result["coordinator"]["categories"][cat]
+            assert cat_entry["last_cleared_at"] is None
+            assert cat_entry["last_webhook_at"] is None
+            assert cat_entry["webhook_health"] == "never_received"
 
 
-@pytest.mark.asyncio
-async def test_diagnostics_preserves_non_sensitive_config() -> None:
-    entry = _make_entry_with_runtime(_make_coordinator())
-    hass = MagicMock()
+class TestDiagnosticsEdgeCases:
+    """Tests for diagnostics behaviour under unusual or incomplete entry state."""
 
-    result = await async_get_config_entry_diagnostics(hass, entry)
+    @pytest.mark.asyncio
+    async def test_handles_missing_entry_data(self) -> None:
+        """Diagnostics should not raise if runtime_data is absent (e.g. during setup failure)."""
+        entry = _make_entry()
+        # Ensure runtime_data is not set (simulates a failed setup)
+        del entry.runtime_data
+        hass = MagicMock()
 
-    assert result["config_entry"]["controller_url"] == "https://192.168.1.1"
-    assert result["config_entry"]["username"] == "**REDACTED**"
+        result = await async_get_config_entry_diagnostics(hass, entry)
 
-
-@pytest.mark.asyncio
-async def test_diagnostics_exposes_per_category_state() -> None:
-    cleared_at = datetime(2026, 4, 30, 12, 0, 0, tzinfo=UTC)
-    cat = ALL_CATEGORIES[0]
-    states = {c: CategoryState(category=c) for c in ALL_CATEGORIES}
-    # Use a current timestamp so webhook_health() reads "healthy" (within the
-    # 7-day window) deterministically regardless of when the suite runs.
-    webhook_at = datetime.now(UTC)
-    states[cat] = CategoryState(
-        category=cat,
-        enabled=True,
-        is_alerting=True,
-        alert_count=4,
-        open_count=2,
-        last_cleared_at=cleared_at,
-        last_webhook_at=webhook_at,
-    )
-    coordinator = _make_coordinator(category_states=states)
-    entry = _make_entry_with_runtime(coordinator)
-    hass = MagicMock()
-
-    result = await async_get_config_entry_diagnostics(hass, entry)
-
-    categories = result["coordinator"]["categories"]
-    assert set(categories.keys()) == set(ALL_CATEGORIES)
-    assert categories[cat] == {
-        "enabled": True,
-        "is_alerting": True,
-        "open_count": 2,
-        "alert_count": 4,
-        "last_cleared_at": cleared_at.isoformat(),
-        "last_webhook_at": webhook_at.isoformat(),
-        "webhook_health": "healthy",
-    }
-
-
-@pytest.mark.asyncio
-async def test_diagnostics_per_category_last_cleared_at_none_when_unset() -> None:
-    coordinator = _make_coordinator()
-    entry = _make_entry_with_runtime(coordinator)
-    hass = MagicMock()
-
-    result = await async_get_config_entry_diagnostics(hass, entry)
-
-    for cat in ALL_CATEGORIES:
-        entry = result["coordinator"]["categories"][cat]
-        assert entry["last_cleared_at"] is None
-        assert entry["last_webhook_at"] is None
-        assert entry["webhook_health"] == "never_received"
+        assert result["webhook_urls"] == {}
+        assert result["coordinator"] == {}


### PR DESCRIPTION
## Summary

Closes #233

Reorganises three flat unit test files into `Test*` classes grouped by flow step or functional area, matching the convention already used in `test_options.py` and required by `python_classes = Test*` in `pytest.ini`:

- `test_setup.py`: `TestUserStep` (14 tests), `TestCategoriesStep` (5), `TestFinishStep` (2), `TestMigration` (1)
- `test_diagnostics.py`: `TestDiagnosticsRedaction` (3), `TestDiagnosticsContent` (4), `TestDiagnosticsEdgeCases` (1)
- `test_reauth.py`: `TestReauthStep` (3), `TestReauthConfirmStep` (7), `TestConfigFlowHelpers` (1) — replaces the single monolithic `TestReauthFlow` class

Adds the class-grouping convention to `docs/TESTING.md` so future contributors know the expected pattern.

## Test plan

- [x] All 535 unit tests pass (`make test`)
- [x] Coverage holds at 96.9% (above the 95% threshold)
- [x] `ruff check` and `ruff format --check` pass on all changed files

https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj)_