### PR TITLE
release: bump to v1.8.0-pre3

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": [],
-  "version": "1.8.0-pre2"
+  "version": "1.8.0-pre3"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -4,6 +4,13 @@ Dated record of completed work. Newest first. Format per entry: category, short 
 
 ## 2026-06-15
 
+- **release**: v1.8.0-pre3 tagged. Final checkpoint of the v1.8.0 "Trust and Hardening" cycle. Closes the last remaining structural item (#119): alert classification is now a single `classify_event_key()` entry point in `const.py` used by both polling and webhook paths. UniFiAuth extraction (#120) deferred to v1.9.0. v1.8.0 is feature-complete and ready for stable promotion.
+- **refactor**: consolidate alert classification into a single `classify_event_key()` function in `const.py`; remove the `_unknown_system_log_keys` module-global from `models.py` and scope warn-dedup to the coordinator instance via a `seen_keys` parameter, so warnings dedup per coordinator instance rather than per process (fixes test isolation) ([#217]). Closes #119.
+- **tests**: reorganise three flat unit test files into `Test*` classes grouped by flow step or functional area (`TestUserStep`, `TestCategoriesStep`, `TestDiagnosticsRedaction`, etc.); document the convention in `docs/TESTING.md` ([#235]). Closes #233.
+- **chore**: add `scripts/seed_issues.py` to bulk-seed GitHub Issues from the backlog; run idempotently to populate v1.8.0 and v1.9.0 milestones ([#234]).
+
+## 2026-06-15
+
 - **release**: v1.8.0-pre2 tagged. Second checkpoint of the v1.8.0 "Trust and Hardening" cycle. Headline: security hardening of the alert construction and authentication paths (redirect-blocking, raw-payload drop from in-memory state, bounded field lengths, single-pass template substitution), operational reliability fixes (probe-backoff reset after re-auth, button availability propagation, unparseable webhook rejection, post-reauth retry error handling), two user-visible features (SSL cert failure surfaces a dedicated config-flow error; webhook secret rotation creates a HA repair issue), and CI/docs infrastructure (pr-guards workflow, concurrency groups, pinned dev dependencies, pip Dependabot, per-category Alarm Manager trigger table). The two remaining v1.8.0 structural items (classify-consolidation #119 and UniFiAuth extraction #120) carry forward to pre3.
 - **feat**: rotating the webhook secret in the options flow now creates a HA repair issue until the first authenticated webhook is received after the update ([#200]). Closes #167.
 - **feat**: SSL certificate verification failures in the config flow now surface a dedicated, actionable error; `verify_ssl` field carries an inline MITM-risk warning ([#199]). Closes #166.
@@ -341,7 +348,10 @@ Dated record of completed work. Newest first. Format per entry: category, short 
 [#213]: https://github.com/PHeonix25/unifi_alerts/pull/213
 [#214]: https://github.com/PHeonix25/unifi_alerts/pull/214
 [#215]: https://github.com/PHeonix25/unifi_alerts/pull/215
+[#217]: https://github.com/PHeonix25/unifi_alerts/pull/217
 [#224]: https://github.com/PHeonix25/unifi_alerts/pull/224
+[#234]: https://github.com/PHeonix25/unifi_alerts/pull/234
+[#235]: https://github.com/PHeonix25/unifi_alerts/pull/235
 
 [0d951b3]: https://github.com/PHeonix25/unifi_alerts/commit/0d951b3
 [0f17afb]: https://github.com/PHeonix25/unifi_alerts/commit/0f17afb

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-06-15):** v1.8.0-pre2 tagged from `dev`. Security hardening, reliability fixes, and two user-visible features shipped; two structural items (classify-consolidation #119, UniFiAuth extraction #120) remain for pre3. Path to v2.0.0: v1.8.0 (Trust and Hardening), v1.9.0 (Localisation and Scale), then v2.0.0 (HACS default catalogue). Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
+> **Status (2026-06-15):** v1.8.0-pre3 tagged from `dev`. v1.8.0 is feature-complete: all planned items shipped across pre1-pre3; #120 (UniFiAuth extraction) deferred to v1.9.0. Ready for stable promotion. Path to v2.0.0: v1.8.0 (Trust and Hardening), v1.9.0 (Localisation and Scale), then v2.0.0 (HACS default catalogue). Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
 
 > **Branching model:** see `CLAUDE.md § Branching strategy and versioning`.
 
@@ -14,7 +14,7 @@ Correctness, privacy, security, and onboarding-confidence polish. Themes:
 
 - Privacy: clarify retention and data handling (raw-payload persistence shipped in pre1; in-memory raw drop and retention-semantics docs shipped in pre2).
 - Onboarding: complete the Alarm Manager setup docs (shipped in pre2: per-category trigger table, multi-controller/multi-site guide).
-- Structure: consolidate the two alert-classification paths (#119); extract controller auth into its own seam (#120). Remaining for pre3.
+- Structure: consolidate the two alert-classification paths (#119, shipped in pre3); extract controller auth into its own seam (#120, deferred to v1.9.0).
 
 Item-level detail: the `v1.8.0` [milestone](https://github.com/PHeonix25/unifi_alerts/milestones).
 


### PR DESCRIPTION
## Summary

Version bump from `1.8.0-pre2` to `1.8.0-pre3`. Final pre-release checkpoint for v1.8.0 "Trust and Hardening".

**Changes since v1.8.0-pre2:**
- #217 — `classify_event_key()` consolidation (#119, last planned v1.8.0 structural item)
- #235 — unit test class-based layout (#233)
- #234 — `scripts/seed_issues.py` for backlog seeding

**v1.8.0 is now feature-complete.** #120 (UniFiAuth extraction) has been deferred to v1.9.0.

## Files changed

- `custom_components/unifi_alerts/manifest.json` — version bumped to `1.8.0-pre3`
- `docs/HISTORY.md` — new `## 2026-06-15` block covering the three PRs since pre2
- `docs/ROADMAP.md` — status line updated; v1.8.0 Structure item updated to reflect #119 shipped, #120 deferred

## After merge

Once this PR merges to `dev`, tag the release:

```bash
git checkout dev && git pull origin dev
git tag v1.8.0-pre3 && git push origin v1.8.0-pre3
```

GitHub Actions will create the pre-release automatically.

https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WM5YGLnjZKL4J2rYCnnpzj)_