### PR TITLE
fix: surface webhook URL change as Repair issue during schema v2->v3 migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+- Upgrading from a pre-v1.4.0 install no longer silently breaks webhook delivery. The schema v2-to-v3 migration now surfaces a Repair issue in Settings > Repairs when webhook URLs change due to the `webhook_id_suffix` being backfilled, giving a clear call to action to re-paste the new URLs into Alarm Manager. The previous INFO log was downgraded to DEBUG. ([#241])
 - Successful re-authentication now immediately clears the system-log probe backoff. Previously, if the probe had been forced onto the legacy path by consecutive transient failures (hit `_PROBE_FAIL_LIMIT`), re-auth would leave the backoff timer intact and the integration would stay on the legacy path for up to 1 hour even after the controller became reachable. The fix resets `_probe_backoff_until`, `_probe_fail_count`, and `_has_system_log` (to `None`, triggering a fresh probe on the next poll) inside `authenticate()` on every success path. ([#168])
 - Authenticated webhook POSTs whose body is not valid JSON or not valid UTF-8 now return HTTP 400 and are discarded rather than synthesizing an "Unknown alert" entity state update. A token-bearing sender could previously spam meaningless "Unknown alert" events via malformed bodies. ([#173])
 - `UniFiClearCategoryButton` and `UniFiClearAllButton` now override `_handle_coordinator_update()` to call `async_write_ha_state()`, so the `available` property is re-evaluated when coordinator state changes (e.g. after a category is disabled via the options flow without a full reload). Previously the button entities could remain stale between polls. ([#170])
@@ -264,4 +265,5 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#173]: https://github.com/PHeonix25/unifi_alerts/issues/173
 [#175]: https://github.com/PHeonix25/unifi_alerts/issues/175
 [#233]: https://github.com/PHeonix25/unifi_alerts/issues/233
+[#241]: https://github.com/PHeonix25/unifi_alerts/issues/241
 [#PR]: https://github.com/PHeonix25/unifi_alerts/pull/PR

--- a/custom_components/unifi_alerts/__init__.py
+++ b/custom_components/unifi_alerts/__init__.py
@@ -11,6 +11,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType
 
@@ -46,19 +47,31 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     if config_entry.version == 2:
         new_data = dict(config_entry.data)
         changed = False
+        suffix_backfilled = False
         if not new_data.get("webhook_secret"):
             new_data["webhook_secret"] = secrets.token_urlsafe(32)
             changed = True
         if not new_data.get("webhook_id_suffix"):
             new_data["webhook_id_suffix"] = secrets.token_hex(4)
             changed = True
+            suffix_backfilled = True
         if changed:
             hass.config_entries.async_update_entry(config_entry, data=new_data, version=3)
-            _LOGGER.info(
-                "Migrated config entry %s to version 3: backfilled webhook secret. "
+            _LOGGER.debug(
+                "Migrated config entry %s to version 3: backfilled webhook secret/suffix. "
                 "Re-paste webhook URLs from Settings > Devices & Services > UniFi Alerts > Configure.",
                 config_entry.entry_id,
             )
+            if suffix_backfilled:
+                ir.async_create_issue(
+                    hass,
+                    DOMAIN,
+                    f"webhook_urls_changed_{config_entry.entry_id}",
+                    is_fixable=False,
+                    severity=ir.IssueSeverity.WARNING,
+                    translation_key="webhook_urls_changed",
+                    translation_placeholders={"name": config_entry.title},
+                )
         else:
             hass.config_entries.async_update_entry(config_entry, version=3)
         return True

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -86,6 +86,10 @@
     "webhook_secret_rotated": {
       "title": "UniFi Alerts: webhook URLs have changed for {name}",
       "description": "The webhook secret was rotated. All previously configured URLs in UniFi Alarm Manager are now invalid.\n\nUpdate each category URL in UniFi Network: **Settings > Notifications > Alarm Manager**. The new URLs are shown in **Settings > Devices and Services > UniFi Alerts > Configure**.\n\nThis notice clears automatically when the first webhook is received after the update."
+    },
+    "webhook_urls_changed": {
+      "title": "UniFi Alerts: webhook URLs have changed for {name} — action required",
+      "description": "**Action required after upgrade.**\n\nThe integration was upgraded from a version that did not assign a unique suffix to webhook URLs. The webhook URLs for **{name}** have changed and the old URLs in UniFi Alarm Manager will no longer work.\n\nRe-paste all category webhook URLs: open **Settings > Devices and Services > UniFi Alerts > Configure** to see the new URLs, then update each one in **UniFi Network > Settings > Notifications > Alarm Manager**.\n\nWebhook event delivery will not resume until this is done."
     }
   },
   "services": {

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -86,6 +86,10 @@
     "webhook_secret_rotated": {
       "title": "UniFi Alerts: webhook URLs have changed for {name}",
       "description": "The webhook secret was rotated. All previously configured URLs in UniFi Alarm Manager are now invalid.\n\nUpdate each category URL in UniFi Network: **Settings > Notifications > Alarm Manager**. The new URLs are shown in **Settings > Devices and Services > UniFi Alerts > Configure**.\n\nThis notice clears automatically when the first webhook is received after the update."
+    },
+    "webhook_urls_changed": {
+      "title": "UniFi Alerts: webhook URLs have changed for {name} — action required",
+      "description": "**Action required after upgrade.**\n\nThe integration was upgraded from a version that did not assign a unique suffix to webhook URLs. The webhook URLs for **{name}** have changed and the old URLs in UniFi Alarm Manager will no longer work.\n\nRe-paste all category webhook URLs: open **Settings > Devices and Services > UniFi Alerts > Configure** to see the new URLs, then update each one in **UniFi Network > Settings > Notifications > Alarm Manager**.\n\nWebhook event delivery will not resume until this is done."
     }
   },
   "services": {

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -641,6 +641,113 @@ class TestAsyncMigrateEntry:
         assert second["data"][CONF_WEBHOOK_SECRET]  # non-empty
 
 
+class TestAsyncMigrateEntryRepairIssue:
+    """Repair issue is created when webhook_id_suffix is backfilled during v2->v3 migration."""
+
+    @pytest.mark.asyncio
+    async def test_repair_issue_created_when_suffix_backfilled(self):
+        """A v2 entry missing webhook_id_suffix must create a Repair issue after migration."""
+        from unittest.mock import patch
+
+        from custom_components.unifi_alerts import async_migrate_entry
+        from custom_components.unifi_alerts.const import DOMAIN
+
+        hass = make_hass()
+        entry = make_entry(
+            data={
+                CONF_CONTROLLER_URL: "https://192.168.1.1",
+                CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+            }
+        )
+        entry.version = 2
+
+        def capture_update(cfg_entry, **kwargs):
+            if "data" in kwargs:
+                cfg_entry.data = kwargs["data"]
+            if "version" in kwargs:
+                cfg_entry.version = kwargs["version"]
+
+        hass.config_entries.async_update_entry = capture_update
+
+        with patch("custom_components.unifi_alerts.ir.async_create_issue") as mock_create_issue:
+            result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        mock_create_issue.assert_called_once()
+        call_args = mock_create_issue.call_args
+        # hass, domain, issue_id are positional; the rest are keyword args
+        assert call_args.args[1] == DOMAIN
+        assert call_args.args[2].startswith("webhook_urls_changed_")
+        assert call_args.kwargs["translation_key"] == "webhook_urls_changed"
+        assert call_args.kwargs["is_fixable"] is False
+
+    @pytest.mark.asyncio
+    async def test_repair_issue_not_created_when_suffix_already_present(self):
+        """A v2 entry that already has webhook_id_suffix must NOT create a Repair issue."""
+        from unittest.mock import patch
+
+        from custom_components.unifi_alerts import async_migrate_entry
+
+        hass = make_hass()
+        entry = make_entry(
+            data={
+                CONF_CONTROLLER_URL: "https://192.168.1.1",
+                CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+                CONF_WEBHOOK_SECRET: "existing-secret",
+                CONF_WEBHOOK_ID_SUFFIX: "deadbeef",
+            }
+        )
+        entry.version = 2
+
+        def capture_update(cfg_entry, **kwargs):
+            if "version" in kwargs:
+                cfg_entry.version = kwargs["version"]
+
+        hass.config_entries.async_update_entry = capture_update
+
+        with patch("custom_components.unifi_alerts.ir.async_create_issue") as mock_create_issue:
+            result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        mock_create_issue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_repair_issue_not_created_when_only_secret_missing(self):
+        """A v2 entry missing only webhook_secret (suffix present) must NOT create a Repair issue.
+
+        The URL structure is unchanged when only the secret is backfilled; the suffix
+        determines the URL path, not the secret token.
+        """
+        from unittest.mock import patch
+
+        from custom_components.unifi_alerts import async_migrate_entry
+
+        hass = make_hass()
+        entry = make_entry(
+            data={
+                CONF_CONTROLLER_URL: "https://192.168.1.1",
+                CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
+                CONF_WEBHOOK_ID_SUFFIX: "deadbeef",
+                # No webhook_secret
+            }
+        )
+        entry.version = 2
+
+        def capture_update(cfg_entry, **kwargs):
+            if "data" in kwargs:
+                cfg_entry.data = kwargs["data"]
+            if "version" in kwargs:
+                cfg_entry.version = kwargs["version"]
+
+        hass.config_entries.async_update_entry = capture_update
+
+        with patch("custom_components.unifi_alerts.ir.async_create_issue") as mock_create_issue:
+            result = await async_migrate_entry(hass, entry)
+
+        assert result is True
+        mock_create_issue.assert_not_called()
+
+
 class TestRedactWebhookToken:
     """`?token=<secret>` must be stripped from URLs before they hit DEBUG logs."""
 


### PR DESCRIPTION
## Summary

- When a pre-v1.4.0 install upgrades to v1.8.0, the schema v2->v3 migration backfills `webhook_id_suffix`, silently changing every webhook URL from `unifi_alerts_{category}` to `unifi_alerts_{suffix}_{category}`. UniFi Alarm Manager keeps POSTing to the old 404 URLs and webhook delivery stops with no visible indication.
- Now calls `ir.async_create_issue` (severity WARNING, not fixable) when the suffix is backfilled, surfacing a persistent Repair card in HA Settings > Repairs with a clear call to action to re-paste the new URLs.
- Downgraded the previous `_LOGGER.info` to `_LOGGER.debug` — the Repair issue is the authoritative signal now.
- Added translation key `webhook_urls_changed` to `strings.json` and `translations/en.json` (matches the pattern of `webhook_secret_rotated`).
- Added three unit tests covering: suffix backfilled (issue created), suffix already present (no issue), only secret missing (no issue — URL path unchanged).

Closes #241

## Test plan

- [x] `make check` passes (560 tests, 98.33% coverage)
- [x] New tests in `TestAsyncMigrateEntryRepairIssue` all pass
- [x] Translation drift check clean (strings.json == en.json for the new key)
- [ ] Repair issue is visible in HA Settings > Repairs after upgrading a v2 entry without a suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhFyV4gADPn6qXQgKZMAkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhFyV4gADPn6qXQgKZMAkd)_