### PR TITLE
release: bump to v1.8.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-06-19
+
 ### Added
 
 - Per-category webhook health signal. Each category binary sensor now exposes a `webhook_health` attribute (`never_received`, `healthy`, or `stale`) and a `last_webhook_at` timestamp, so you can confirm the Alarm Manager wiring works without waiting for a real alert. `healthy` means a webhook arrived within the last 7 days; `stale` means the last one is older than that (expected for rarely-firing categories). Both fields also appear per category in the diagnostics download and survive a config-entry reload. ([#117])
@@ -215,7 +217,8 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 - UCG-Ultra OS detection: two-stage fallback probe added.
 - Config-flow API-key field guidance reworded to be firmware-version agnostic.
 
-[Unreleased]: https://github.com/PHeonix25/unifi_alerts/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/PHeonix25/unifi_alerts/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.8.0
 [1.7.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.7.0
 [1.6.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.6.0
 [1.5.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.5.0

--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": [],
-  "version": "1.8.0-pre3"
+  "version": "1.8.0"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -2,6 +2,13 @@
 
 Dated record of completed work. Newest first. Format per entry: category, short description, PR or commit reference, short why.
 
+## 2026-06-19
+
+- **release**: v1.8.0 stable. Promotes the "Trust and Hardening" cycle to main. All pre1-pre3 items shipped; one additional fix (#242) landed after pre3.
+- **fix**: schema v2-to-v3 migration now raises a HA Repair issue when `webhook_id_suffix` is backfilled, surfacing the URL change to users instead of silently breaking webhook delivery; migrated `_LOGGER.info` to `_LOGGER.debug` ([#242]). Closes #241.
+
+[#242]: https://github.com/PHeonix25/unifi_alerts/pull/242
+
 ## 2026-06-15
 
 - **release**: v1.8.0-pre3 tagged. Final checkpoint of the v1.8.0 "Trust and Hardening" cycle. Closes the last remaining structural item (#119): alert classification is now a single `classify_event_key()` entry point in `const.py` used by both polling and webhook paths. UniFiAuth extraction (#120) deferred to v1.9.0. v1.8.0 is feature-complete and ready for stable promotion.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,21 +2,11 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-06-15):** v1.8.0-pre3 tagged from `dev`. v1.8.0 is feature-complete: all planned items shipped across pre1-pre3; #120 (UniFiAuth extraction) deferred to v1.9.0. Ready for stable promotion. Path to v2.0.0: v1.8.0 (Trust and Hardening), v1.9.0 (Localisation and Scale), then v2.0.0 (HACS default catalogue). Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
+> **Status (2026-06-19):** v1.8.0 stable shipped. Path to v2.0.0: v1.9.0 (Localisation and Scale), then v2.0.0 (HACS default catalogue). Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
 
 > **Branching model:** see `CLAUDE.md § Branching strategy and versioning`.
 
 ---
-
-## v1.8.0: Trust and Hardening
-
-Correctness, privacy, security, and onboarding-confidence polish. Themes:
-
-- Privacy: clarify retention and data handling (raw-payload persistence shipped in pre1; in-memory raw drop and retention-semantics docs shipped in pre2).
-- Onboarding: complete the Alarm Manager setup docs (shipped in pre2: per-category trigger table, multi-controller/multi-site guide).
-- Structure: consolidate the two alert-classification paths (#119, shipped in pre3); extract controller auth into its own seam (#120, deferred to v1.9.0).
-
-Item-level detail: the `v1.8.0` [milestone](https://github.com/PHeonix25/unifi_alerts/milestones).
 
 ## v1.9.0: Localisation and Scale
 


### PR DESCRIPTION
Version bump: `1.8.0-pre3` -> `1.8.0`

## Changes

- `manifest.json`: version `1.8.0-pre3` -> `1.8.0`
- `CHANGELOG.md`: `[Unreleased]` renamed to `[1.8.0] - 2026-06-19`; fresh empty `[Unreleased]` added above; `[1.8.0]` link reference added at the bottom
- `docs/HISTORY.md`: new `## 2026-06-19` block covering the one post-pre3 PR (#242)
- `docs/ROADMAP.md`: v1.8.0 section removed (shipped); status blurb updated

## Merges since v1.8.0-pre3

- #242 fix: surface webhook URL change as Repair issue during schema v2->v3 migration

## After this merges to dev

Open a PR from `dev` -> `main` using **Create a merge commit** (never squash). After that merges, tag:

```bash
git checkout main && git pull origin main
git tag v1.8.0 && git push origin v1.8.0
```

GitHub Actions will create the stable release automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhFyV4gADPn6qXQgKZMAkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhFyV4gADPn6qXQgKZMAkd)_