### PR TITLE
ci: allow HISTORY.md changes on dev->main release merge in history-guard

### DIFF
--- a/.github/workflows/pr-guards.yml
+++ b/.github/workflows/pr-guards.yml
@@ -104,6 +104,13 @@ jobs:
             echo "Bump branch; HISTORY.md changes are allowed."
             exit 0
           fi
+          # Allow the stable release merge (dev -> main): HISTORY.md flows from
+          # the bump PR that already landed on dev; the guard has already run
+          # and passed on that bump PR.
+          if [ "$HEAD_REF" = "dev" ] && [ "$BASE_REF" = "main" ]; then
+            echo "Release merge (dev -> main); HISTORY.md changes are allowed."
+            exit 0
+          fi
           HISTORY_CHANGED=$(git diff --name-only "origin/${BASE_REF}..." \
             | grep "^docs/HISTORY\.md$" || true)
           if [ -n "$HISTORY_CHANGED" ]; then


### PR DESCRIPTION
## Summary

- The `history-guard` job in `pr-guards.yml` was blocking PR #244 (`dev → main`) because it only exempts `claude/bump-*` branches.
- The release merge carries HISTORY.md changes that already passed the guard when the bump PR landed on `dev`; the `dev → main` PR pattern should be exempt.
- Adds an early-exit when `HEAD_REF == dev && BASE_REF == main`.

Closes #244 (unblocks the release merge by fixing the guard itself)

## Test plan

- [ ] CI `history-guard` passes on this PR (no HISTORY.md changes here)
- [ ] After merge, PR #244 (`dev → main`) re-runs CI and `history-guard` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhFyV4gADPn6qXQgKZMAkd

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhFyV4gADPn6qXQgKZMAkd)_