### PR TITLE
ci: trigger pr-labeler on pull_request_target so fork PRs get labelled

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -15,8 +15,14 @@ name: PR Labeler
 # Other prefixes (chore, build, refactor, perf, style, etc.) intentionally fall
 # through to "Other Changes" in the release notes.
 
+# Uses pull_request_target (not pull_request) so the job runs in the base-repo
+# context and receives a write-capable GITHUB_TOKEN even for PRs from forks; a
+# plain pull_request trigger gets a read-only token on fork PRs and cannot apply
+# labels. Safe here because the workflow never checks out or runs PR code: it
+# only reads the PR title (via the PR_TITLE env var) and applies a label drawn
+# from a fixed case mapping, never from raw PR-controlled input.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened]
 
 permissions:

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -119,7 +119,7 @@ Three additional checks run on every pull request to `dev` or `main`:
 
 **Escaping the changelog guard:** apply the `skip-changelog` label if a code change genuinely has no user-visible effect (e.g. a coverage-only test change that incidentally touches a production file). The `ci`, `tests`, `documentation`, `dependencies`, and `github-actions` labels also bypass the guard automatically, since those categories of work rarely need a user-facing changelog entry.
 
-**Label timing:** `pr-labeler.yml` and `label-guard` run concurrently on PR open. If the auto-labeller wins first, both pass in a single round. If `label-guard` fires before the label is applied, it fails on the first run but re-runs on the `labeled` event and passes once the label is present. This is expected behaviour; the status check clears without any manual intervention.
+**Label timing:** `pr-labeler.yml` and `label-guard` run concurrently on PR open. If the auto-labeller wins first, both pass in a single round. If `label-guard` fires before the label is applied, it fails on the first run but re-runs on the `labeled` event and passes once the label is present. This is expected behaviour; the status check clears without any manual intervention. The self-heal flow depends on `pr-labeler.yml` having write access to apply the label, which is why that workflow uses the `pull_request_target` trigger: a plain `pull_request` trigger gets a read-only token on PRs from forks and cannot label them, leaving `label-guard` stuck red.
 
 ## Branching and PRs
 


### PR DESCRIPTION
## Summary

PRs opened from forks (e.g. #249) are blocked by two red checks:

- **Apply Conventional Commit label** (`pr-labeler.yml`) fails with `GraphQL: Resource not accessible by integration (addLabelsToLabelable)`.
- **PR has release-notes label** (`label-guard`) then fails because `PR_LABELS` is empty.

**Root cause:** `pull_request`-triggered workflows receive a **read-only `GITHUB_TOKEN` for PRs from forks** (the failing job log confirms `PullRequests: read`). `pr-labeler.yml` could not apply a label, so the `labeled` event never fired and `label-guard` never re-ran green. This silently breaks the self-heal flow documented in `docs/DEVELOPING.md`, which assumed the labeler always has write access (true only for same-repo PRs).

## Change

- Switch `pr-labeler.yml` from `pull_request` to `pull_request_target`. That runs the job in the base-repo context with a write-capable token even for fork PRs, so the labeler applies the label, fires a real `labeled` event, and `label-guard` self-heals to green.
- This is **safe**: the workflow never checks out or runs PR code. It only reads the PR title via the `PR_TITLE` env var (no shell injection) and applies a label drawn from a fixed `case` mapping, never raw PR-controlled input. The existing minimum-scope `permissions` block is unchanged.
- Documented the rationale in `docs/DEVELOPING.md` next to the existing label-timing note.

## Note on PR #249

This workflow edit does not retroactively re-run #249's checks. Since the `ci` label is already present on #249, **re-running its two failed jobs** (or closing/reopening it) clears both: the labeler hits its "already has a release-notes label" early-exit and `label-guard` sees `ci`. The contributor's branch lives on a fork, so this durable fix ships as a separate PR to `dev`.

## Verification

- `.github/workflows/pr-labeler.yml` parses as valid YAML; the only semantic change is the trigger event name.
- `make doc-check` passes.
- On this PR (same-repo), confirm `Apply Conventional Commit label` succeeds and `label-guard` ends green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdMtYaoxzrcrpCcfWYqU7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdMtYaoxzrcrpCcfWYqU7n)_