### PR TITLE
ci: add advanced CodeQL workflow so config-only PRs aren't blocked

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+name: CodeQL
+
+# Advanced CodeQL setup (replaces GitHub's default setup).
+#
+# Why this file exists: `CodeQL` is a required status check on `dev` and `main`.
+# Default setup runs diff-informed analysis and posts NO result for a PR whose
+# diff contains no analysed-language files. A config-only or docs-only PR (e.g.
+# one that only edits pyproject.toml) therefore left the required check stuck at
+# "waiting for results from CodeQL", blocking merge forever (see PR #249).
+#
+# This workflow runs on EVERY push and PR to dev/main with no `paths` filter, so
+# CodeQL always reports a result and the required check can always resolve, even
+# for PRs that touch no Python or workflow files.
+#
+# IMPORTANT: GitHub's CodeQL default setup must be DISABLED in repo Settings
+# (Settings > Code security > Code scanning) before this workflow takes effect.
+# Default setup and an advanced workflow cannot both be active; while default
+# setup is on, runs of this workflow fail with a configuration error.
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+  schedule:
+    # Weekly full scan, off the :00 mark to avoid the cron rush.
+    - cron: "27 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by CodeQL to read the Actions workflows it analyses.
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e  # v4.36.2
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

`CodeQL` is a **required** status check on `dev`/`main`, but the repo currently runs CodeQL via GitHub's **default setup**, which does diff-informed analysis and posts **no result** for a PR whose diff contains no analysed-language files. A config-only or docs-only PR therefore leaves the required check stuck at *"waiting for results from CodeQL"* and can never merge.

This is exactly what blocks **#249** (`ci: move pytest config into pyproject`): it only edits `pyproject.toml`/`pytest.ini`, so neither the `python` nor the `actions` analysis has a diff, CodeQL never reports, and merge is blocked despite an approval and 13 green checks.

## Change

- Add `.github/workflows/codeql.yml` (advanced CodeQL setup) that runs on **every** push and PR to `dev`/`main` with **no `paths` filter**, plus a weekly schedule. It analyses the `python` and `actions` languages (`build-mode: none`). Because it always runs, the required `CodeQL` check always reports a result, even for PRs that touch no code.
- All `uses:` are pinned to full 40-char commit SHAs with version comments, per repo policy (`actions/checkout@…  # v6`, `github/codeql-action@…  # v4.36.2`).
- Minimum-scope permissions (`security-events: write`, `actions: read`, `contents: read`).

## Required manual step (maintainer)

GitHub's **CodeQL default setup must be disabled** before this workflow takes effect: **Settings > Code security > Code scanning > CodeQL default setup > Disable**. Default setup and an advanced workflow cannot both be active; while default setup is on, runs of this workflow fail with a configuration error.

## Unblocking #249 after this lands

1. Merge this PR to `dev`.
2. Disable CodeQL default setup (step above).
3. Re-trigger #249 (close/reopen, or push) so the advanced workflow runs on it. It will analyse unconditionally, report, and the required check clears, making #249 mergeable. (Admin-merge of #249 remains available as a one-off shortcut if you prefer not to wait.)

## Verification

- `.github/workflows/codeql.yml` parses as valid YAML.
- This PR itself adds a workflow file (an `actions`-language change), so CodeQL reports on it and it is not self-blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdMtYaoxzrcrpCcfWYqU7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01TdMtYaoxzrcrpCcfWYqU7n)_