### PR TITLE
release: bump version to 1.9.0-pre2

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -11,10 +11,22 @@
   "issue_tracker": "https://github.com/PHeonix25/unifi_alerts/issues",
   "requirements": [],
   "ssdp": [
-    {"manufacturer": "Ubiquiti Networks", "modelDescription": "UniFi Dream Machine"},
-    {"manufacturer": "Ubiquiti Networks", "modelDescription": "UniFi Dream Machine Pro"},
-    {"manufacturer": "Ubiquiti Networks", "modelDescription": "UniFi Dream Machine SE"},
-    {"manufacturer": "Ubiquiti Networks", "modelDescription": "UniFi Dream Machine Pro Max"}
+    {
+      "manufacturer": "Ubiquiti Networks",
+      "modelDescription": "UniFi Dream Machine"
+    },
+    {
+      "manufacturer": "Ubiquiti Networks",
+      "modelDescription": "UniFi Dream Machine Pro"
+    },
+    {
+      "manufacturer": "Ubiquiti Networks",
+      "modelDescription": "UniFi Dream Machine SE"
+    },
+    {
+      "manufacturer": "Ubiquiti Networks",
+      "modelDescription": "UniFi Dream Machine Pro Max"
+    }
   ],
-  "version": "1.9.0-pre1"
+  "version": "1.9.0-pre2"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -2,6 +2,29 @@
 
 Dated record of completed work. Newest first. Format per entry: category, short description, PR or commit reference, short why.
 
+## 2026-07-03
+
+- **release**: v1.9.0-pre2 tagged. Second checkpoint of the v1.9.0 "Localisation and Scale" cycle. Headline: site validation against the controller (#205), unrecognised event keys surfaced in diagnostics (#207), severity exposed on binary sensors (#210), SSDP discovery for UniFi OS consoles (#212), plus a `UniFiAuth` extraction (#218), narrowed exception handling with a `ConfigEntryAuthFailed` reauth-repair fix (#257), and test-infrastructure hardening (#258, #260) alongside an options-flow refactor (#259). Closes the five PRs carried forward from pre1.
+- **feat**: non-default site names are now validated against the controller in both the config and options flow; a failed lookup shows an `invalid_site` field error instead of creating a broken entry; the default site skips the extra round-trip ([#205]). Closes #171.
+- **feat**: unclassified event keys seen during polling now accumulate and appear under `coordinator.unrecognised_keys` in the HA diagnostics download, sorted by occurrence count, from both the v2 system-log and legacy alarm paths ([#207]). Closes #134.
+- **feat**: `last_severity` is now exposed as an attribute on `UniFiCategoryBinarySensor` and `UniFiRollupBinarySensor`, not just the message sensor, so automations can condition on severity directly from the entity that triggers them ([#210]). Closes #135.
+- **feat**: SSDP discovery for UDM, UDM Pro, UDM SE, and UDM Pro Max consoles; `async_step_ssdp` pre-fills the controller URL and forwards to the credentials step ([#212]). Closes #172.
+- **refactor**: extract `UniFiAuth` from `UniFiClient` into its own module (`unifi_auth.py`) with no passthrough properties; production call sites import auth exceptions from `.unifi_auth` directly ([#218]). Closes #120.
+- **fix**: `coordinator.async_config_entry_first_refresh()` no longer wraps HA core's call in a blanket `except Exception`, which was silently misclassifying `ConfigEntryAuthFailed` as `ConfigEntryNotReady` and suppressing HA's reauth-repair flow; every other blind `except Exception` (BLE001) across the integration narrowed to the specific exceptions each call site can raise ([#257]). Closes #237.
+- **tests**: `test_unifi_client.py` now drives a real `aiohttp.ClientSession` through `aioresponses` instead of hand-built `MagicMock` response doubles, so tests assert on actual outbound HTTP rather than a fabricated aiohttp surface ([#258]). Closes #229.
+- **refactor**: `UniFiAlertsOptionsFlow.async_step_credentials` split from a ~135-line method into a thin orchestrator over standalone helpers (form parsing, duplicate-entry detection, staged-dict builders, credential validation); no behaviour change ([#259]). Closes #238.
+- **tests**: collapsed near-duplicate test-body clusters in `test_coordinator.py` and `test_entities.py` into `@pytest.mark.parametrize` cases with readable `ids`; test-item counts unchanged (90 and 84 respectively) ([#260]). Closes #231.
+
+[#205]: https://github.com/PHeonix25/unifi_alerts/pull/205
+[#207]: https://github.com/PHeonix25/unifi_alerts/pull/207
+[#210]: https://github.com/PHeonix25/unifi_alerts/pull/210
+[#212]: https://github.com/PHeonix25/unifi_alerts/pull/212
+[#218]: https://github.com/PHeonix25/unifi_alerts/pull/218
+[#257]: https://github.com/PHeonix25/unifi_alerts/pull/257
+[#258]: https://github.com/PHeonix25/unifi_alerts/pull/258
+[#259]: https://github.com/PHeonix25/unifi_alerts/pull/259
+[#260]: https://github.com/PHeonix25/unifi_alerts/pull/260
+
 ## 2026-06-27
 
 - **release**: v1.9.0-pre1 tagged. First checkpoint of the v1.9.0 "Localisation and Scale" cycle. Headline: translatable per-category entity labels (#133) and the v2 system-log fetch-window clamp (#136), plus large-volume serialisation tests and CI/process hardening. Five further v1.9.0 PRs (#207, #210, #205, #212, #218) remain open and will land in a later checkpoint.


### PR DESCRIPTION
## Summary

Second pre-release checkpoint of the v1.9.0 "Localisation and Scale" cycle. Bumps `manifest.json` from `1.9.0-pre1` to `1.9.0-pre2` and records the nine PRs merged since the previous tag in `docs/HISTORY.md`.

## Changes

- `custom_components/unifi_alerts/manifest.json`: version `1.9.0-pre1` → `1.9.0-pre2`.
- `docs/HISTORY.md`: new `## 2026-07-03` block summarising #205, #207, #210, #212, #218, #257, #258, #259, #260 (the five PRs carried forward from pre1, plus four more landed since).

## How to test

```bash
make check   # lint + typecheck + validate + all tests
```

`make check` passes locally: 621 tests, 98.64% coverage.

## Checklist

- [x] `make check` passes locally
- [x] `CHANGELOG.md` `[Unreleased]` — not touched; this is a pre-release version bump, which per `CLAUDE.md` does not touch `CHANGELOG.md`
- [x] PR title starts with a Conventional Commit-adjacent prefix (`release:`); label applied manually since `release:` is not in the auto-mapped set
- [x] `docs/HISTORY.md` updated on this `claude/bump-*` branch, as required by `history-guard`
- [x] `strings.json`/`translations/en.json` untouched
- [x] No new category added
- [x] No blocking I/O introduced

After merge, tag with:
```bash
git checkout dev && git pull origin dev
git tag v1.9.0-pre2 && git push origin v1.9.0-pre2
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01YKo5UidtA7dkyUeCyWhuyM)_