### PR TITLE
fix: don't dedup distinct keyless webhook alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - The v2 system-log fetch window is now clamped to `DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS` (24 hours). Previously, a rarely-cleared category could hold the oldest watermark to an arbitrarily old timestamp, causing every poll to paginate from that date forward and silently miss recent alarms once the 10-page cap was reached. The clamp ensures all categories are always within the paged window. A WARNING is now logged when the page cap is reached, indicating some events may have been missed. ([#136])
 - A `ConfigEntryAuthFailed` raised during the initial data fetch (for example, credentials rotated between setup's `authenticate()` call and the first coordinator poll) is no longer misclassified as `ConfigEntryNotReady`. Previously a blanket exception handler around the first refresh re-wrapped every failure, including a genuine auth failure, as "not ready": silently suppressing Home Assistant's reauth-repair flow. ([#257])
+- Two distinct webhook alerts with no `key` field arriving in the same category within the dedup window no longer suppress each other; only genuine duplicate keys are still deduplicated. ([#291])
 
 ### Internal
 
@@ -304,4 +305,5 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#241]: https://github.com/PHeonix25/unifi_alerts/issues/241
 [#257]: https://github.com/PHeonix25/unifi_alerts/pull/257
 [#290]: https://github.com/PHeonix25/unifi_alerts/pull/290
+[#291]: https://github.com/PHeonix25/unifi_alerts/pull/291
 [#PR]: https://github.com/PHeonix25/unifi_alerts/pull/PR

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -264,7 +264,9 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         ``WEBHOOK_DEDUP_WINDOW_SECONDS`` are dropped — without this, a
         misconfigured Alarm Manager or noisy category can flood the webhook
         endpoint and cause unbounded ``alert_count`` increments and event
-        entity fires for the same underlying event.
+        entity fires for the same underlying event. Keyless alerts (e.g. the
+        empty-body webhook ping) have no identity to dedup on, so they are
+        never suppressed against each other.
         """
         if category not in self._category_states:
             _LOGGER.warning("push_alert called with unknown category: %s", category)
@@ -274,28 +276,32 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         if not state.enabled:
             return
 
-        dedup_key = (category, alert.key or "")
-        now = time.monotonic()
-        # Absorbs duplicate webhook deliveries from the controller within the window;
-        # monotonic time makes the window immune to clock skew during HA suspend/resume.
-        prev = self._last_push_at.get(dedup_key)
-        if prev is not None and (now - prev) < WEBHOOK_DEDUP_WINDOW_SECONDS:
-            _LOGGER.debug(
-                "Suppressing duplicate webhook push for %s/%s within %.1fs window",
-                category,
-                dedup_key[1],
-                WEBHOOK_DEDUP_WINDOW_SECONDS,
-            )
-            return
-        # Opportunistically drop expired entries before recording the new one.
-        # Bounds the dict size at "distinct (category, alert_key) pairs seen
-        # within the last WEBHOOK_DEDUP_WINDOW_SECONDS" — a misconfigured
-        # controller emitting high-cardinality keys cannot grow it without
-        # bound. Cost is O(n) per push, but n is naturally small (capped by
-        # the active windowed set).
-        cutoff = now - WEBHOOK_DEDUP_WINDOW_SECONDS
-        self._last_push_at = {k: t for k, t in self._last_push_at.items() if t >= cutoff}
-        self._last_push_at[dedup_key] = now
+        # Alerts without a key (e.g. the empty-body webhook ping) have no
+        # identity to dedup on — treating them as duplicates of each other
+        # would silently drop distinct events that merely lack a key.
+        if alert.key:
+            dedup_key = (category, alert.key)
+            now = time.monotonic()
+            # Absorbs duplicate webhook deliveries from the controller within the window;
+            # monotonic time makes the window immune to clock skew during HA suspend/resume.
+            prev = self._last_push_at.get(dedup_key)
+            if prev is not None and (now - prev) < WEBHOOK_DEDUP_WINDOW_SECONDS:
+                _LOGGER.debug(
+                    "Suppressing duplicate webhook push for %s/%s within %.1fs window",
+                    category,
+                    dedup_key[1],
+                    WEBHOOK_DEDUP_WINDOW_SECONDS,
+                )
+                return
+            # Opportunistically drop expired entries before recording the new one.
+            # Bounds the dict size at "distinct (category, alert_key) pairs seen
+            # within the last WEBHOOK_DEDUP_WINDOW_SECONDS" — a misconfigured
+            # controller emitting high-cardinality keys cannot grow it without
+            # bound. Cost is O(n) per push, but n is naturally small (capped by
+            # the active windowed set).
+            cutoff = now - WEBHOOK_DEDUP_WINDOW_SECONDS
+            self._last_push_at = {k: t for k, t in self._last_push_at.items() if t >= cutoff}
+            self._last_push_at[dedup_key] = now
 
         state.apply_alert(alert)
         # Record webhook receipt for the per-category health signal. Set only

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -273,16 +273,20 @@ class TestPushDedup:
 
         assert coord.get_category_state(CATEGORY_NETWORK_WAN).alert_count == 2
 
-    def test_empty_key_still_dedups(self):
-        """Alerts with no `key` field still dedup on the empty-string token —
-        prevents a misconfigured controller (which omits `key`) from flooding."""
+    def test_distinct_keyless_alerts_are_not_suppressed(self):
+        """Alerts with no `key` field (e.g. the empty-body webhook ping) have no
+        identity to dedup on — two distinct keyless alerts in the same window
+        must both count, unlike two keyed alerts sharing the same key (issue #263)."""
         coord = make_coordinator()
         coord.async_set_updated_data = MagicMock()
         a1 = make_alert(CATEGORY_NETWORK_WAN, "first")  # key=""
         a2 = make_alert(CATEGORY_NETWORK_WAN, "second")  # key=""
         coord.push_alert(CATEGORY_NETWORK_WAN, a1)
         coord.push_alert(CATEGORY_NETWORK_WAN, a2)
-        assert coord.get_category_state(CATEGORY_NETWORK_WAN).alert_count == 1
+        assert coord.get_category_state(CATEGORY_NETWORK_WAN).alert_count == 2
+        assert coord.async_set_updated_data.call_count == 2
+        # Keyless pushes must not pollute _last_push_at — only real keys are tracked.
+        assert coord._last_push_at == {}
 
     def test_last_push_at_dict_bounded_by_dedup_window(self):
         """Regression: ``_last_push_at`` must not grow without bound.


### PR DESCRIPTION
## Summary

`push_alert()` collapsed every keyless webhook alert into the same `(category, "")` dedup key, so two distinct keyless alerts arriving in the same category within the 5s dedup window silently dropped the second one. This is a real data-loss bug because `webhook_handler.py`'s empty-body ping contract explicitly produces a keyless "Unknown alert".

## Changes

- `custom_components/unifi_alerts/coordinator.py`: `push_alert()` now skips the dedup check entirely when `alert.key` is falsy. Keyless alerts are no longer treated as duplicates of each other or recorded in `_last_push_at`. Keyed alerts keep the exact same dedup behavior (`(category, alert.key)` pair, same `WEBHOOK_DEDUP_WINDOW_SECONDS` window, same opportunistic pruning).
- `tests/unit/test_coordinator.py`: replaced `test_empty_key_still_dedups` (which asserted the old, buggy behavior) with `test_distinct_keyless_alerts_are_not_suppressed`, covering two distinct keyless alerts both incrementing `alert_count` and both notifying listeners, and confirming `_last_push_at` stays empty for keyless pushes. Existing keyed-dedup tests (`test_duplicate_within_window_is_suppressed`, etc.) are unchanged and still pass.

## How to test

```bash
make check   # lint + typecheck + validate + all tests
```

## Checklist

- [x] Linked the issue this PR resolves (`Closes #263` in the description)
- [x] `make check` passes locally
- [ ] `CHANGELOG.md` `[Unreleased]` updated (user-visible changes only; skip for internal/ci/docs) — will follow up once this PR number is known
- [x] PR title starts with a Conventional Commit prefix (`fix:`)
- [ ] PR has a label recognised by `.github/release.yml` (applied automatically for CC-prefixed titles via pr-labeler)
- [x] `strings.json` and `translations/en.json` are still identical (not touched)
- [x] No blocking I/O introduced (all network/disk calls are `async`; this change is synchronous dict bookkeeping only)

Closes #263

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_014xckCmEQrDqRoFV7bBipjg)_