### PR TITLE
fix: coerce device_name/site to str in alert constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - The v2 system-log fetch window is now clamped to `DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS` (24 hours). Previously, a rarely-cleared category could hold the oldest watermark to an arbitrarily old timestamp, causing every poll to paginate from that date forward and silently miss recent alarms once the 10-page cap was reached. The clamp ensures all categories are always within the paged window. A WARNING is now logged when the page cap is reached, indicating some events may have been missed. ([#136])
 - A `ConfigEntryAuthFailed` raised during the initial data fetch (for example, credentials rotated between setup's `authenticate()` call and the first coordinator poll) is no longer misclassified as `ConfigEntryNotReady`. Previously a blanket exception handler around the first refresh re-wrapped every failure, including a genuine auth failure, as "not ready": silently suppressing Home Assistant's reauth-repair flow. ([#257])
+- Alert payloads with non-string `device_name` or `site` values no longer crash the webhook handler or the polling path; these fields are now always coerced to strings, matching how `message`/`key`/`severity` were already handled. ([#292])
 
 ### Internal
 
@@ -304,4 +305,5 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#241]: https://github.com/PHeonix25/unifi_alerts/issues/241
 [#257]: https://github.com/PHeonix25/unifi_alerts/pull/257
 [#290]: https://github.com/PHeonix25/unifi_alerts/pull/290
+[#292]: https://github.com/PHeonix25/unifi_alerts/pull/292
 [#PR]: https://github.com/PHeonix25/unifi_alerts/pull/PR

--- a/custom_components/unifi_alerts/models.py
+++ b/custom_components/unifi_alerts/models.py
@@ -98,10 +98,10 @@ class UniFiAlert:
             message=str(message)[:255],
             received_at=datetime.now(UTC),
             key=str(payload.get("key", ""))[:64],
-            device_name=(
+            device_name=str(
                 payload.get("device_name") or payload.get("ap_name") or payload.get("sw_name") or ""
             )[:255],
-            site=payload.get("site_name") or payload.get("site") or "",
+            site=str(payload.get("site_name") or payload.get("site") or ""),
             severity=str(payload.get("severity") or payload.get("subsystem") or "")[:32],
         )
 
@@ -131,8 +131,8 @@ class UniFiAlert:
             message=str(message)[:255],
             received_at=received_at,
             key=str(alarm.get("key", ""))[:64],
-            device_name=(alarm.get("device_name") or alarm.get("ap_name") or "")[:255],
-            site=alarm.get("site_name") or "",
+            device_name=str(alarm.get("device_name") or alarm.get("ap_name") or "")[:255],
+            site=str(alarm.get("site_name") or ""),
             severity=str(alarm.get("severity") or alarm.get("subsystem") or "")[:32],
         )
 
@@ -217,8 +217,8 @@ class UniFiAlert:
             message=str(message)[:255],
             received_at=received_at,
             key=key[:64],
-            device_name=(payload.get("device_name") or "")[:255],
-            site=payload.get("site_name") or payload.get("site") or "",
+            device_name=str(payload.get("device_name") or "")[:255],
+            site=str(payload.get("site_name") or payload.get("site") or ""),
             severity=str(payload.get("severity") or "")[:32],
         )
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
 from custom_components.unifi_alerts.const import (
     CATEGORY_NETWORK_CLIENT,
     CATEGORY_NETWORK_DEVICE,
@@ -130,6 +132,62 @@ class TestUniFiAlert:
         alarm = {"msg": "test", "datetime": "not-a-date"}
         alert = UniFiAlert.from_api_alarm(CATEGORY_SECURITY_THREAT, alarm)
         assert alert.received_at.tzinfo is not None
+
+
+class TestNonStringPayloadFields:
+    """device_name and site must coerce to str for any payload value, matching the
+    existing str(...) handling already applied to message/key/severity. Regression
+    tests for GitHub issue #266."""
+
+    _NON_STRING_VALUES = [123, {"nested": "dict"}, ["a", "list"], None]
+
+    @pytest.mark.parametrize("value", _NON_STRING_VALUES)
+    def test_webhook_device_name_non_string_coerced(self, value):
+        payload = {"message": "test", "device_name": value}
+        alert = UniFiAlert.from_webhook_payload(CATEGORY_NETWORK_WAN, payload)
+        assert isinstance(alert.device_name, str)
+
+    @pytest.mark.parametrize("value", _NON_STRING_VALUES)
+    def test_webhook_site_non_string_coerced(self, value):
+        payload = {"message": "test", "site_name": value}
+        alert = UniFiAlert.from_webhook_payload(CATEGORY_NETWORK_WAN, payload)
+        assert isinstance(alert.site, str)
+
+    @pytest.mark.parametrize("value", _NON_STRING_VALUES)
+    def test_api_alarm_device_name_non_string_coerced(self, value):
+        alarm = {"msg": "test", "device_name": value}
+        alert = UniFiAlert.from_api_alarm(CATEGORY_SECURITY_THREAT, alarm)
+        assert isinstance(alert.device_name, str)
+
+    @pytest.mark.parametrize("value", _NON_STRING_VALUES)
+    def test_api_alarm_site_non_string_coerced(self, value):
+        alarm = {"msg": "test", "site_name": value}
+        alert = UniFiAlert.from_api_alarm(CATEGORY_SECURITY_THREAT, alarm)
+        assert isinstance(alert.site, str)
+
+    @pytest.mark.parametrize("value", _NON_STRING_VALUES)
+    def test_system_log_event_device_name_non_string_coerced(self, value):
+        event = {
+            "key": "FIREWALL_BLOCK",
+            "category": "SECURITY",
+            "timestamp": 1700000000000,
+            "status": "NEW",
+            "device_name": value,
+        }
+        alert = UniFiAlert.from_system_log_event(event, set())
+        assert isinstance(alert.device_name, str)
+
+    @pytest.mark.parametrize("value", _NON_STRING_VALUES)
+    def test_system_log_event_site_non_string_coerced(self, value):
+        event = {
+            "key": "FIREWALL_BLOCK",
+            "category": "SECURITY",
+            "timestamp": 1700000000000,
+            "status": "NEW",
+            "site_name": value,
+        }
+        alert = UniFiAlert.from_system_log_event(event, set())
+        assert isinstance(alert.site, str)
 
 
 class TestCategoryState:


### PR DESCRIPTION
## Summary

Harden `UniFiAlert`'s three constructors against non-string `device_name`/`site` payload fields so odd controller firmware or malformed webhook bodies no longer crash the webhook handler or the polling path.

## Changes

- `custom_components/unifi_alerts/models.py`: wrap `device_name` and `site` in `str(...)` in `from_webhook_payload`, `from_api_alarm`, and `from_system_log_event`, matching the coercion already applied to `message`/`key`/`severity` in the same constructors. Previously a non-string value (e.g. an int, dict, or list) for these keys raised `TypeError` when sliced (`device_name`) or was assigned unwrapped into the dataclass (`site`), dropping the alert entirely even though the JSON body was well-formed.
- `tests/unit/test_models.py`: added `TestNonStringPayloadFields`, a parametrised test class feeding `int`, `dict`, `list`, and `None` values through `device_name` and `site` for all three constructors, asserting no exception is raised and the resulting field is always a plain `str`.

No behavior change for well-formed (string) payloads; the accepted/empty-body contract is untouched.

## How to test

```bash
make check   # lint + typecheck + validate + all tests
```

Or narrowly:

```bash
.venv/bin/pytest tests/unit/test_models.py -v -k NonStringPayloadFields
```

## Checklist

- [x] Linked the issue this PR resolves (`Closes #266` in the description)
- [x] `make check` passes locally
- [x] `CHANGELOG.md` `[Unreleased]` updated (will follow up in a second commit once the PR number is known, per project convention)
- [x] PR title starts with a Conventional Commit prefix (`fix:`)
- [x] PR has a label recognised by `.github/release.yml` (should be applied automatically by pr-labeler)
- [x] `strings.json` and `translations/en.json` are still identical (neither touched)
- [x] No new category added
- [x] No blocking I/O introduced

Closes #266


---
_Generated by [Claude Code](https://claude.ai/code/session_014xckCmEQrDqRoFV7bBipjg)_