### PR TITLE
ci: lint, format-check, and type-check the tests/ tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,8 @@ jobs:
           cache: pip
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
-      - name: Ruff lint
-        run: ruff check custom_components/
-      - name: Ruff format check
-        run: ruff format --check custom_components/
+      - name: Ruff lint & format check (custom_components/ + tests/)
+        run: python scripts/run_lint.py
       - name: Mypy type check
         run: mypy custom_components/unifi_alerts --ignore-missing-imports
       - name: Check strings.json matches translations/en.json


### PR DESCRIPTION
## Summary

CI's `lint` job only ran `ruff check`/`ruff format --check` against `custom_components/`, while `scripts/run_lint.py` (invoked locally by `make lint`/`make check`) already covers both `custom_components/` and `tests/`. This meant CI was out of sync with local checks and any style/structure drift in `tests/` was never caught unless a dev ran `make check` themselves.

## Changes

- `.github/workflows/ci.yml`: replaced the `lint` job's two inline `Ruff lint` / `Ruff format check` steps (which only targeted `custom_components/`) with a single step calling `python scripts/run_lint.py`, which already runs `ruff check custom_components/ tests/` and `ruff format --check custom_components/ tests/`. This mirrors the existing precedent of `hacs-preflight` calling `scripts/validate_hacs.py`/`scripts/validate_docs.py` as single script invocations, and removes the duplication between CI and the local lint entry point.
- `mypy` step left untouched, scoped to `custom_components/unifi_alerts` only (see decision below).
- No reformatting was required: `tests/` already passes `ruff check` and `ruff format --check` cleanly as-is, verified locally before opening this PR.

**mypy-on-tests decision: out**, per issue #232, because strict mode fights the heavy mocking used in `tests/` (MagicMock/AsyncMock for the UniFi client throughout) and would produce a low signal-to-noise ratio. mypy remains scoped to `custom_components/unifi_alerts` only, as today.

## How to test

```bash
make check   # lint + typecheck + validate + all tests
```

Ran locally: `make setup` (full stack, needed both ruff and pytest), then `make check` — lint (ruff check + format over `custom_components/` + `tests/`), mypy, HACS preflight, docs/translations drift check, and the full pytest suite (621 tests, 98.64% coverage) all passed cleanly with no changes needed beyond the workflow edit.

Closes #232

## Checklist

- [x] Linked the issue this PR resolves (`Closes #232` above)
- [x] `make check` passes locally
- [ ] `CHANGELOG.md` `[Unreleased]` updated — skipped: internal CI-only change with no user-visible effect, per CLAUDE.md `CHANGELOG.md` guidance (only user-visible changes require an entry, and `changelog-guard` only fires on `custom_components/` edits, which this PR does not touch)
- [x] PR title starts with a Conventional Commit prefix (`ci:`)
- [x] PR has a label recognised by `.github/release.yml` (expect `pr-labeler` to apply `ci` from the title prefix; will apply manually if missing)
- [x] `strings.json` and `translations/en.json` are still identical (untouched by this PR; drift check passed)
- [ ] New category fully registered — N/A, no new category added
- [x] No blocking I/O introduced — N/A, CI workflow config only, no runtime code touched


---
_Generated by [Claude Code](https://claude.ai/code/session_014xckCmEQrDqRoFV7bBipjg)_