### PR TITLE
fix: clean up storage and repair issues on config entry removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - The v2 system-log fetch window is now clamped to `DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS` (24 hours). Previously, a rarely-cleared category could hold the oldest watermark to an arbitrarily old timestamp, causing every poll to paginate from that date forward and silently miss recent alarms once the 10-page cap was reached. The clamp ensures all categories are always within the paged window. A WARNING is now logged when the page cap is reached, indicating some events may have been missed. ([#136])
 - A `ConfigEntryAuthFailed` raised during the initial data fetch (for example, credentials rotated between setup's `authenticate()` call and the first coordinator poll) is no longer misclassified as `ConfigEntryNotReady`. Previously a blanket exception handler around the first refresh re-wrapped every failure, including a genuine auth failure, as "not ready": silently suppressing Home Assistant's reauth-repair flow. ([#257])
+- Removing a config entry now deletes its persisted watermark storage file and any open repair issues tied to it, instead of leaving them behind permanently. ([#294])
 
 ### Internal
 
@@ -304,4 +305,5 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#241]: https://github.com/PHeonix25/unifi_alerts/issues/241
 [#257]: https://github.com/PHeonix25/unifi_alerts/pull/257
 [#290]: https://github.com/PHeonix25/unifi_alerts/pull/290
+[#294]: https://github.com/PHeonix25/unifi_alerts/pull/294
 [#PR]: https://github.com/PHeonix25/unifi_alerts/pull/PR

--- a/custom_components/unifi_alerts/__init__.py
+++ b/custom_components/unifi_alerts/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import secrets
-from typing import cast
+from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -14,12 +14,18 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType
+from homeassistant.helpers.storage import Store
 
 from .const import (
     CONF_CONTROLLER_URL,
     CONF_VERIFY_SSL,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
+    ISSUE_ID_AUTH_FAILED,
+    ISSUE_ID_PERSIST_FAILED,
+    ISSUE_ID_WEBHOOK_SECRET_ROTATED,
+    ISSUE_ID_WEBHOOK_URLS_CHANGED,
+    STORAGE_VERSION_WATERMARKS,
 )
 from .coordinator import UniFiAlertsCoordinator
 from .models import RuntimeData, UniFiClientConfig
@@ -67,10 +73,10 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 ir.async_create_issue(
                     hass,
                     DOMAIN,
-                    f"webhook_urls_changed_{config_entry.entry_id}",
+                    f"{ISSUE_ID_WEBHOOK_URLS_CHANGED}_{config_entry.entry_id}",
                     is_fixable=False,
                     severity=ir.IssueSeverity.WARNING,
-                    translation_key="webhook_urls_changed",
+                    translation_key=ISSUE_ID_WEBHOOK_URLS_CHANGED,
                     translation_placeholders={"name": config_entry.title},
                 )
         else:
@@ -204,6 +210,30 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if not remaining:
             async_unregister_services(hass)
     return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Clean up persisted storage and repair issues after a config entry is removed.
+
+    Fires after async_unload_entry, once HA has decided the entry itself is
+    gone for good (not just reloading). Without this, the per-entry watermark
+    Store file and any open repair issues keyed to entry.entry_id would remain
+    orphaned forever, since nothing else ever reads or clears them again.
+    """
+    store: Store[dict[str, Any]] = Store(
+        hass, STORAGE_VERSION_WATERMARKS, f"{DOMAIN}_watermarks_{entry.entry_id}"
+    )
+    await store.async_remove()
+
+    for issue_id_base in (
+        ISSUE_ID_AUTH_FAILED,
+        ISSUE_ID_WEBHOOK_SECRET_ROTATED,
+        ISSUE_ID_WEBHOOK_URLS_CHANGED,
+        ISSUE_ID_PERSIST_FAILED,
+    ):
+        ir.async_delete_issue(hass, DOMAIN, f"{issue_id_base}_{entry.entry_id}")
+
+    _LOGGER.debug("Cleaned up storage and repair issues for removed entry %s", entry.entry_id)
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -40,6 +40,8 @@ from .const import (
     DEFAULT_SITE,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
+    ISSUE_ID_AUTH_FAILED,
+    ISSUE_ID_WEBHOOK_SECRET_ROTATED,
     webhook_id_for_category,
 )
 from .models import UniFiClientConfig
@@ -54,10 +56,10 @@ def _create_auth_failed_issue(hass: Any, entry: Any) -> None:
     ir.async_create_issue(
         hass,
         DOMAIN,
-        f"auth_failed_{entry.entry_id}",
+        f"{ISSUE_ID_AUTH_FAILED}_{entry.entry_id}",
         is_fixable=True,
         severity=ir.IssueSeverity.ERROR,
-        translation_key="auth_failed",
+        translation_key=ISSUE_ID_AUTH_FAILED,
         translation_placeholders={"name": entry.title},
     )
 
@@ -320,7 +322,7 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
                 self.hass.config_entries.async_update_entry(entry, data=new_data)
                 # Clear the repair issue now that auth is restored
-                ir.async_delete_issue(self.hass, DOMAIN, f"auth_failed_{entry.entry_id}")
+                ir.async_delete_issue(self.hass, DOMAIN, f"{ISSUE_ID_AUTH_FAILED}_{entry.entry_id}")
                 await self.hass.config_entries.async_reload(entry.entry_id)
                 return self.async_abort(reason="reauth_successful")
 
@@ -700,10 +702,10 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
                     ir.async_create_issue(
                         self.hass,
                         DOMAIN,
-                        f"webhook_secret_rotated_{self._config_entry.entry_id}",
+                        f"{ISSUE_ID_WEBHOOK_SECRET_ROTATED}_{self._config_entry.entry_id}",
                         is_fixable=False,
                         severity=ir.IssueSeverity.WARNING,
-                        translation_key="webhook_secret_rotated",
+                        translation_key=ISSUE_ID_WEBHOOK_SECRET_ROTATED,
                         translation_placeholders={"name": self._config_entry.title},
                     )
                 self.hass.config_entries.async_update_entry(

--- a/custom_components/unifi_alerts/const.py
+++ b/custom_components/unifi_alerts/const.py
@@ -61,6 +61,24 @@ MAX_SYSTEM_LOG_PAGES = 10  # safety cap: at most 100*10 = 1000 events per poll c
 DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS = 24  # hours to look back when no watermark exists
 
 # ──────────────────────────────────────────────
+# Persisted storage & repair-issue identifiers
+# ──────────────────────────────────────────────
+# Version for the per-entry watermark Store file (coordinator.py). Shared with
+# __init__.py so async_remove_entry can address the same file for deletion
+# without duplicating the version number.
+STORAGE_VERSION_WATERMARKS: Final = 1
+
+# Repair-issue id bases. Each is suffixed with f"_{entry.entry_id}" at the
+# creation site (config_flow.py, coordinator.py, __init__.py) so multi-entry
+# installs get independent repair cards. Centralised here, instead of as
+# inline f-string literals, so the creation site and the async_remove_entry
+# cleanup site can never drift apart.
+ISSUE_ID_AUTH_FAILED: Final = "auth_failed"
+ISSUE_ID_WEBHOOK_SECRET_ROTATED: Final = "webhook_secret_rotated"
+ISSUE_ID_WEBHOOK_URLS_CHANGED: Final = "webhook_urls_changed"
+ISSUE_ID_PERSIST_FAILED: Final = "watermark_persist_failed"
+
+# ──────────────────────────────────────────────
 # Category identifiers
 # ──────────────────────────────────────────────
 CATEGORY_NETWORK_DEVICE = "network_device"

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -26,6 +26,8 @@ from .const import (
     DEFAULT_SITE,
     DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS,
     DOMAIN,
+    ISSUE_ID_PERSIST_FAILED,
+    STORAGE_VERSION_WATERMARKS,
     WEBHOOK_DEDUP_WINDOW_SECONDS,
 )
 from .models import CategoryState, UniFiAlert, UniFiClientConfig
@@ -34,17 +36,11 @@ from .unifi_client import UniFiClient
 
 _LOGGER = logging.getLogger(__name__)
 
-_STORAGE_VERSION = 1
-
 # Debounce window for watermark persistence. push_alert is synchronous and can
 # fire in bursts; routing writes through Store.async_delay_save with this delay
 # coalesces a burst into a single durable write instead of one fire-and-forget
 # save per push.
 _PERSIST_DELAY_SECONDS = 1
-
-# Issue-registry id base for the repair surfaced when a watermark persist fails.
-# Suffixed with the config entry id so multi-entry installs report independently.
-_PERSIST_FAILED_ISSUE_BASE = "watermark_persist_failed"
 
 
 class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
@@ -80,7 +76,7 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         self._site: str = config.get(CONF_SITE, DEFAULT_SITE)
         self._entry_id: str = entry_id
         self._store: Store[dict[str, Any]] = Store(
-            hass, _STORAGE_VERSION, f"{DOMAIN}_watermarks_{entry_id}"
+            hass, STORAGE_VERSION_WATERMARKS, f"{DOMAIN}_watermarks_{entry_id}"
         )
 
         # Category state is long-lived; do NOT reset between coordinator refreshes
@@ -452,7 +448,7 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
     @property
     def _persist_failed_issue_id(self) -> str:
         """Per-entry issue-registry id for the watermark-persist-failed repair."""
-        return f"{_PERSIST_FAILED_ISSUE_BASE}_{self._entry_id}"
+        return f"{ISSUE_ID_PERSIST_FAILED}_{self._entry_id}"
 
     def _create_persist_failed_issue(self) -> None:
         """Raise a repair issue telling the user a watermark write failed."""
@@ -462,7 +458,7 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
             self._persist_failed_issue_id,
             is_fixable=False,
             severity=ir.IssueSeverity.WARNING,
-            translation_key=_PERSIST_FAILED_ISSUE_BASE,
+            translation_key=ISSUE_ID_PERSIST_FAILED,
         )
 
     def _delete_persist_failed_issue(self) -> None:

--- a/custom_components/unifi_alerts/webhook_handler.py
+++ b/custom_components/unifi_alerts/webhook_handler.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_WEBHOOK_ID_SUFFIX,
     CONF_WEBHOOK_SECRET,
     DOMAIN,
+    ISSUE_ID_WEBHOOK_SECRET_ROTATED,
     WEBHOOK_MAX_BODY_BYTES,
     webhook_id_for_category,
 )
@@ -181,7 +182,9 @@ class WebhookManager:
             self._push_callback(category, alert)
             # First valid webhook after a secret rotation proves Alarm Manager
             # was updated with the new URLs. Clear the rotation repair issue.
-            ir.async_delete_issue(hass, DOMAIN, f"webhook_secret_rotated_{self._entry_id}")
+            ir.async_delete_issue(
+                hass, DOMAIN, f"{ISSUE_ID_WEBHOOK_SECRET_ROTATED}_{self._entry_id}"
+            )
             return None
 
         return handle_webhook

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -456,6 +456,64 @@ class TestAsyncUnloadEntry:
         assert call_order == ["shutdown", "unregister", "close"]
 
 
+# ── async_remove_entry ────────────────────────────────────────────────────────
+
+
+class TestAsyncRemoveEntry:
+    """async_remove_entry must delete the watermark store file and all four repair issues."""
+
+    @pytest.mark.asyncio
+    async def test_removes_watermark_store_file(self):
+        from custom_components.unifi_alerts import async_remove_entry
+
+        hass = make_hass()
+        entry = make_entry(entry_id="entry-xyz")
+
+        mock_store = MagicMock()
+        mock_store.async_remove = AsyncMock()
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.Store", return_value=mock_store
+            ) as mock_store_cls,
+            patch("custom_components.unifi_alerts.ir.async_delete_issue"),
+        ):
+            await async_remove_entry(hass, entry)
+
+        mock_store_cls.assert_called_once()
+        call_args = mock_store_cls.call_args.args
+        assert call_args[0] is hass
+        assert call_args[2] == f"{DOMAIN}_watermarks_entry-xyz"
+        mock_store.async_remove.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_deletes_all_four_per_entry_repair_issues(self):
+        from custom_components.unifi_alerts import async_remove_entry
+
+        hass = make_hass()
+        entry = make_entry(entry_id="entry-xyz")
+
+        mock_store = MagicMock()
+        mock_store.async_remove = AsyncMock()
+
+        with (
+            patch("custom_components.unifi_alerts.Store", return_value=mock_store),
+            patch("custom_components.unifi_alerts.ir.async_delete_issue") as mock_delete_issue,
+        ):
+            await async_remove_entry(hass, entry)
+
+        deleted_issue_ids = {call.args[2] for call in mock_delete_issue.call_args_list}
+        assert deleted_issue_ids == {
+            "auth_failed_entry-xyz",
+            "webhook_secret_rotated_entry-xyz",
+            "webhook_urls_changed_entry-xyz",
+            "watermark_persist_failed_entry-xyz",
+        }
+        for call in mock_delete_issue.call_args_list:
+            assert call.args[0] is hass
+            assert call.args[1] == DOMAIN
+
+
 # ── device registry ───────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Deleting a config entry left two kinds of permanent orphans: the per-entry watermark `Store` file in `.storage/`, and up to four repair issues (`auth_failed`, `webhook_secret_rotated`, `webhook_urls_changed`, `watermark_persist_failed`) keyed to the removed `entry_id`. Nothing ever read or cleared either once the entry was gone. Adds `async_remove_entry` in `__init__.py` to clean up both.

## Changes

- `custom_components/unifi_alerts/__init__.py`: added `async_remove_entry(hass, entry)` that deletes the watermark `Store` file (`{DOMAIN}_watermarks_{entry_id}`) and calls `ir.async_delete_issue` for all four per-entry issue-id bases. Left `async_unload_entry` untouched (out of scope, distinct lifecycle hook).
- `custom_components/unifi_alerts/const.py`: promoted `_STORAGE_VERSION` (coordinator.py) to a shared `STORAGE_VERSION_WATERMARKS` constant, and added four `ISSUE_ID_*` constants (`ISSUE_ID_AUTH_FAILED`, `ISSUE_ID_WEBHOOK_SECRET_ROTATED`, `ISSUE_ID_WEBHOOK_URLS_CHANGED`, `ISSUE_ID_PERSIST_FAILED`) so the issue-id-base strings are no longer built ad hoc as inline f-strings at each creation/deletion site.
- `custom_components/unifi_alerts/coordinator.py`: uses `STORAGE_VERSION_WATERMARKS` and `ISSUE_ID_PERSIST_FAILED` instead of local module constants.
- `custom_components/unifi_alerts/config_flow.py`: uses `ISSUE_ID_AUTH_FAILED` and `ISSUE_ID_WEBHOOK_SECRET_ROTATED` at all creation/deletion sites.
- `custom_components/unifi_alerts/webhook_handler.py`: uses `ISSUE_ID_WEBHOOK_SECRET_ROTATED` at the deletion site (first valid webhook after secret rotation).
- `tests/unit/test_init.py`: added `TestAsyncRemoveEntry` asserting the `Store` is instantiated with the expected entry-scoped file name and `async_remove` is awaited, and that `ir.async_delete_issue` is called with all four correct per-entry issue ids.

Closes #264

## How to test

```bash
make check   # lint + typecheck + validate + all tests
```

## Checklist

- [x] Linked the issue this PR resolves (`Closes #264`)
- [x] `make check` passes locally
- [ ] `CHANGELOG.md` `[Unreleased]` updated (will follow up once PR number is known)
- [x] PR title starts with a Conventional Commit prefix (`fix:`)
- [x] PR has a label recognised by `.github/release.yml` (applied automatically via pr-labeler)
- [x] `strings.json` and `translations/en.json` are still identical (untouched by this change)
- [ ] New category fully registered (n/a, no category added)
- [x] No blocking I/O introduced (all network/disk calls are `async`)


---
_Generated by [Claude Code](https://claude.ai/code/session_014xckCmEQrDqRoFV7bBipjg)_