### PR TITLE
fix: update config entry unique_id on controller URL change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - The v2 system-log fetch window is now clamped to `DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS` (24 hours). Previously, a rarely-cleared category could hold the oldest watermark to an arbitrarily old timestamp, causing every poll to paginate from that date forward and silently miss recent alarms once the 10-page cap was reached. The clamp ensures all categories are always within the paged window. A WARNING is now logged when the page cap is reached, indicating some events may have been missed. ([#136])
 - A `ConfigEntryAuthFailed` raised during the initial data fetch (for example, credentials rotated between setup's `authenticate()` call and the first coordinator poll) is no longer misclassified as `ConfigEntryNotReady`. Previously a blanket exception handler around the first refresh re-wrapped every failure, including a genuine auth failure, as "not ready": silently suppressing Home Assistant's reauth-repair flow. ([#257])
+- The config entry's `unique_id` now updates when the controller URL is changed via the options flow, so duplicate-entry prevention and SSDP discovery matching stay correct after re-pointing an entry to a different controller. ([#295])
 
 ### Internal
 
@@ -304,4 +305,5 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#241]: https://github.com/PHeonix25/unifi_alerts/issues/241
 [#257]: https://github.com/PHeonix25/unifi_alerts/pull/257
 [#290]: https://github.com/PHeonix25/unifi_alerts/pull/290
+[#295]: https://github.com/PHeonix25/unifi_alerts/pull/295
 [#PR]: https://github.com/PHeonix25/unifi_alerts/pull/PR

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -706,9 +706,22 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
                         translation_key="webhook_secret_rotated",
                         translation_placeholders={"name": self._config_entry.title},
                     )
-                self.hass.config_entries.async_update_entry(
-                    self._config_entry, data=self._pending_data
-                )
+                # unique_id tracks the controller URL from initial setup (see
+                # async_step_user). If the URL changed here, the entry's unique_id
+                # must follow it — otherwise it stays pinned to the old URL forever,
+                # which breaks both future duplicate-prevention (a fresh entry for
+                # the old URL would wrongly abort as already_configured) and SSDP
+                # discovery matching (keyed on unique_id) for the new controller.
+                # _build_verify_ssl_and_secret_only_pending leaves
+                # CONF_CONTROLLER_URL unchanged, so this only fires on an actual
+                # URL change (issue #276). Passing unique_id=None here (unchanged
+                # case) would be interpreted by HA as "clear the unique_id", so
+                # the kwarg is omitted entirely rather than passed as None.
+                update_kwargs: dict[str, Any] = {"data": self._pending_data}
+                new_url = self._pending_data.get(CONF_CONTROLLER_URL)
+                if new_url and new_url != self._config_entry.data.get(CONF_CONTROLLER_URL):
+                    update_kwargs["unique_id"] = new_url
+                self.hass.config_entries.async_update_entry(self._config_entry, **update_kwargs)
             return self.async_create_entry(title="", data=self._pending_options)
 
         enabled: list[str] = self._pending_options.get(CONF_ENABLED_CATEGORIES, ALL_CATEGORIES)

--- a/tests/unit/config_flow/test_options.py
+++ b/tests/unit/config_flow/test_options.py
@@ -967,6 +967,157 @@ class TestWebhookSecretRotationRepairIssue:
         mock_ir.async_create_issue.assert_not_called()
 
 
+class TestOptionsFlowUniqueIdFollowsUrl:
+    """The config entry's unique_id must track the controller URL (issue #276).
+
+    Prior to the fix, async_step_finish persisted entry.data with the new
+    controller URL but never passed unique_id= to async_update_entry, so the
+    entry's unique_id stayed pinned to whatever URL was used at initial setup.
+    That left duplicate-prevention and SSDP discovery matching (both keyed on
+    unique_id) looking at a stale URL after a re-point.
+    """
+
+    @pytest.mark.asyncio
+    async def test_url_change_updates_entry_unique_id(self) -> None:
+        """Changing the controller URL through the options flow must update
+        entry.unique_id to the new URL when finish is submitted."""
+        flow = make_options_flow(url="https://192.168.1.1")
+        flow.async_show_form = MagicMock(
+            side_effect=lambda **kwargs: {"type": "form", "step_id": kwargs["step_id"]}
+        )
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+        new_creds = {
+            CONF_CONTROLLER_URL: "https://10.0.0.1",
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance._is_unifi_os = False
+            await flow.async_step_credentials(new_creds)
+
+        cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+        with patch(
+            "custom_components.unifi_alerts.config_flow.async_generate_url",
+            return_value="http://ha.local/webhook/x",
+        ):
+            await flow.async_step_categories(cat_input)
+            result = await flow.async_step_finish(user_input={})
+
+        assert result["type"] == "create_entry"
+        flow.hass.config_entries.async_update_entry.assert_called_once()
+        call_kwargs = flow.hass.config_entries.async_update_entry.call_args.kwargs
+        assert call_kwargs["unique_id"] == "https://10.0.0.1"
+        assert call_kwargs["data"][CONF_CONTROLLER_URL] == "https://10.0.0.1"
+
+    @pytest.mark.asyncio
+    async def test_unchanged_url_leaves_unique_id_untouched(self) -> None:
+        """Rotating only verify_ssl/secret (URL untouched) must NOT pass
+        unique_id= to async_update_entry."""
+        flow = make_options_flow(url="https://192.168.1.1")
+        flow.async_show_form = MagicMock(
+            side_effect=lambda **kwargs: {"type": "form", "step_id": kwargs["step_id"]}
+        )
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+        ssl_only = {
+            CONF_CONTROLLER_URL: "",
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: False,
+        }
+        await flow.async_step_credentials(ssl_only)
+
+        cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+        with patch(
+            "custom_components.unifi_alerts.config_flow.async_generate_url",
+            return_value="http://ha.local/webhook/x",
+        ):
+            await flow.async_step_categories(cat_input)
+            result = await flow.async_step_finish(user_input={})
+
+        assert result["type"] == "create_entry"
+        flow.hass.config_entries.async_update_entry.assert_called_once()
+        call_kwargs = flow.hass.config_entries.async_update_entry.call_args.kwargs
+        assert "unique_id" not in call_kwargs
+        assert call_kwargs["data"][CONF_CONTROLLER_URL] == "https://192.168.1.1"
+
+    @pytest.mark.asyncio
+    async def test_url_change_unique_id_does_not_collide_with_another_entry(self) -> None:
+        """The new unique_id must not collide with another entry's URL.
+
+        _find_duplicate_entry already runs in async_step_credentials and
+        aborts before staging if the new URL matches ANOTHER entry's
+        entry.data[CONF_CONTROLLER_URL] -- so by the time async_step_finish
+        runs and sets unique_id=new_url, no other entry can already be using
+        that URL/unique_id.
+        """
+        from custom_components.unifi_alerts.config_flow import _find_duplicate_entry
+
+        flow = make_options_flow(url="https://192.168.1.1")
+        flow.async_show_form = MagicMock(
+            side_effect=lambda **kwargs: {"type": "form", "step_id": kwargs["step_id"]}
+        )
+        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+        other_entry = MagicMock()
+        other_entry.entry_id = "other-entry"
+        other_entry.data = {CONF_CONTROLLER_URL: "https://172.16.0.1"}
+        flow.hass.config_entries.async_entries = MagicMock(return_value=[other_entry])
+
+        new_creds = {
+            CONF_CONTROLLER_URL: "https://10.0.0.1",
+            CONF_USERNAME: "",
+            CONF_PASSWORD: "",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance._is_unifi_os = False
+            result = await flow.async_step_credentials(new_creds)
+
+        # Not aborted -- the new URL doesn't collide with the other entry.
+        assert result["step_id"] == "categories"
+
+        cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+        with patch(
+            "custom_components.unifi_alerts.config_flow.async_generate_url",
+            return_value="http://ha.local/webhook/x",
+        ):
+            await flow.async_step_categories(cat_input)
+            await flow.async_step_finish(user_input={})
+
+        call_kwargs = flow.hass.config_entries.async_update_entry.call_args.kwargs
+        new_unique_id = call_kwargs["unique_id"]
+        assert new_unique_id == "https://10.0.0.1"
+        # Confirm the helper that gated staging would still find no collision
+        # for the URL that just became the entry's unique_id.
+        assert _find_duplicate_entry(flow.hass, flow._config_entry.entry_id, new_unique_id) is None
+
+
 class TestOptionsCredentialsErrorsAndStaging:
     @pytest.mark.asyncio
     async def test_credentials_cannot_connect_shows_error(self) -> None:


### PR DESCRIPTION
## Summary

Update the config entry's `unique_id` when the controller URL is changed via the options flow, so duplicate-entry prevention and SSDP discovery matching stay correct after re-pointing an entry to a different controller.

## Changes

- `custom_components/unifi_alerts/config_flow.py`: `UniFiAlertsOptionsFlow.async_step_finish` now passes `unique_id=<new url>` to `hass.config_entries.async_update_entry(...)` when the staged `_pending_data` carries a `CONF_CONTROLLER_URL` that differs from the entry's current URL. When only `verify_ssl` or the webhook secret changed (URL untouched), the `unique_id` kwarg is omitted entirely, since passing `unique_id=None` would clear it.
- `tests/unit/config_flow/test_options.py`: added `TestOptionsFlowUniqueIdFollowsUrl` covering (1) a URL change updates `entry.unique_id` to the new URL, (2) an unchanged URL (verify_ssl-only rotation) leaves `unique_id` untouched, (3) the new unique_id does not collide with another entry's URL, using the existing `_find_duplicate_entry` guard that already runs before staging.

## How to test

```bash
make check   # lint + typecheck + validate + all tests
```

Manually: set up an entry against controller A, then use Settings > Devices & Services > Configure to change the controller URL to B. Confirm (via `hass.config_entries.async_entries`) that the entry's `unique_id` now matches URL B, then confirm a fresh setup flow against URL A no longer aborts as `already_configured`.

Closes #276

## Checklist

- [x] Linked the issue this PR resolves (`Closes #276` in the description)
- [x] `make check` passes locally
- [ ] `CHANGELOG.md` `[Unreleased]` updated (user-visible changes only; skip for internal/ci/docs) — added in a follow-up commit once the PR number is known
- [x] PR title starts with a Conventional Commit prefix (`fix:`)
- [x] PR has a label recognised by `.github/release.yml` (applied automatically for CC-prefixed titles via pr-labeler)
- [x] `strings.json` and `translations/en.json` are still identical (not touched)
- [x] No new category added
- [x] No blocking I/O introduced (all network/disk calls are `async`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_014xckCmEQrDqRoFV7bBipjg)_