### PR TITLE
docs: add data retention and handling statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,13 +184,7 @@ See [docs/EXAMPLES.md](docs/EXAMPLES.md) for a Lovelace dashboard card and an au
 
 ## Privacy and data retention
 
-All data stays on your local network; the integration does not communicate with any external service.
-
-**What is stored:** each alert records `message` (truncated to 255 characters), `category`, `device_name`, `alert_key`, `severity`, `site`, and `received_at` (UTC timestamp). The most recent alert per category is kept in memory and persisted to `.storage/unifi_alerts` so it survives HA restarts.
-
-**What clearing does:** pressing Clear (or letting auto-clear fire) marks the category as acknowledged (`is_alerting = False`) and advances the watermark (`last_cleared_at`). It does NOT delete `last_alert` - the most recent alert details remain visible in entity attributes. This is intentional: dashboards and automations can still reference the last seen event after acknowledging it.
-
-**How to purge stored data:** delete the integration entry via Settings > Devices & Services > UniFi Alerts > three-dot menu > Delete. This removes all persisted state including every `last_alert`.
+All data stays on your local network; the integration does not communicate with any external service. For the full statement of what is stored, where, what appears in diagnostics downloads, and how to purge it, see [docs/DATA_HANDLING.md](docs/DATA_HANDLING.md).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,11 @@ Security-relevant components of this integration include:
 - CI / release workflows (`.github/workflows/`): supply-chain integrity (action
   pinning, release packaging).
 
+See [docs/DATA_HANDLING.md](docs/DATA_HANDLING.md) for the full statement of
+what this integration persists to disk, what stays memory-only, what appears
+in diagnostics downloads (and what is redacted from them), and what is logged
+at DEBUG.
+
 ## Webhook secret rotation
 
 The options flow can regenerate the per-entry webhook bearer secret. Rotation

--- a/docs/DATA_HANDLING.md
+++ b/docs/DATA_HANDLING.md
@@ -1,0 +1,91 @@
+# Data handling and retention
+
+This page is the authoritative statement of what this integration stores, where, and for how long. It is written for self-hosters auditing their Home Assistant install and for HACS default-catalogue reviewers.
+
+> **No data leaves your HA host.** This integration only talks to your local UniFi controller: the controller pushes alerts to HA via webhook, and HA polls the controller's REST API for open-alarm counts. There is no cloud relay, no third-party telemetry, and no external service of any kind in either direction.
+
+## What's persisted to disk
+
+Each config entry (one per UniFi controller/site) gets its own `Store` file at:
+
+```
+.storage/unifi_alerts_watermarks_<entry_id>
+```
+
+`<entry_id>` is the config entry's internal HA identifier, not anything UniFi-supplied. The file is created and written by `coordinator.py` (`_build_persist_data()`) via `homeassistant.helpers.storage.Store`.
+
+Per enabled alert category, the following fields are written:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `last_cleared_at` | ISO timestamp | Watermark: when the category was last cleared (manually or by auto-clear) |
+| `alert_count` | int | Running count of alerts applied to this category |
+| `last_alert` | object or `null` | The most recent alert for this category, see field list below |
+| `last_webhook_at` | ISO timestamp | When the last webhook was received for this category (powers the webhook-health signal) |
+
+`last_alert`, when present, is a `UniFiAlert` serialised via `UniFiAlert.to_dict()` (`models.py`). Only these scalar fields are written:
+
+- `category`
+- `message` (truncated to 255 characters)
+- `received_at` (ISO timestamp)
+- `key` (the UniFi event key, e.g. `EVT_WU_Disconnected`)
+- `device_name` (truncated to 255 characters)
+- `site`
+- `severity`
+
+**The raw controller payload is never persisted.** `UniFiAlert.raw` (the full webhook body or poll-API alarm object, which can carry client MACs, IPs, and hostnames) is deliberately excluded from `to_dict()`. This was a deliberate decision (tracked historically as decision #115) and the exclusion is documented inline in `models.py` next to `to_dict()`.
+
+Credentials (`CONF_PASSWORD`, `CONF_API_KEY`, `CONF_USERNAME`) and the webhook bearer secret (`CONF_WEBHOOK_SECRET`) live in HA's own config entry storage (`.storage/core.config_entries`), governed by HA core, not by this integration's watermark file.
+
+### Deletion
+
+Removing the config entry (Settings > Devices & Services > UniFi Alerts > three-dot menu > Delete) deletes the watermark file entirely. `async_remove_entry` in `__init__.py` calls `Store.async_remove()` on the same `unifi_alerts_watermarks_<entry_id>` path, so nothing about that controller/site is left behind.
+
+## What's memory-only (lost on restart)
+
+These are never written to disk and reset to their defaults on every Home Assistant restart:
+
+- **`open_count` per category** - recomputed from a live controller poll every update cycle (`coordinator.py`). Not persisted because it is only ever a snapshot of current controller state, not a fact about the past.
+- **Webhook dedup window state (`_last_push_at`)** - per category+alert-key monotonic timestamps used to drop duplicate pushes from a noisy controller within a short window. Bounded in size, held only in the coordinator instance.
+- **`unrecognised_keys`** - a diagnostic counter of UniFi v2 system-log event keys seen during polling that don't map to a known category. Used to help users report gaps in the category mapping; not meaningful across restarts.
+
+## What's in a diagnostics download
+
+Settings > Devices & Services > UniFi Alerts > Download diagnostics produces a JSON file built by `diagnostics.py` (`async_get_config_entry_diagnostics`).
+
+**Redacted before inclusion:** `CONF_PASSWORD`, `CONF_API_KEY`, `CONF_USERNAME`, `CONF_WEBHOOK_SECRET` (the `_TO_REDACT` set), applied via `homeassistant.components.diagnostics.async_redact_data` to both `entry.data` and `entry.options`.
+
+**Included but stripped:** webhook URLs are included (so a shared diagnostics file still shows what was configured), but the `?token=...` query string is removed before inclusion, so the bearer secret itself never appears in the file.
+
+**Included, coordinator state only:** per-category `enabled`, `is_alerting`, `open_count`, `alert_count`, `last_cleared_at`, `last_webhook_at`, `webhook_health()`, plus the rollup counters (`any_alerting`, `rollup_alert_count`, `rollup_open_count`) and the `unrecognised_keys` counts.
+
+**Deliberately excluded:** per-category alert content, meaning `message`, `device_name`, and any raw alert body. These fields can carry controller-supplied hostnames, MAC addresses, or IP addresses, which should not appear verbatim in a file a user might paste into a public support thread or bug report. This exclusion is documented inline in `diagnostics.py` next to `coordinator_info`; if alert detail is ever added to diagnostics in the future, it must be routed through `async_redact_data` with an explicit field list rather than included directly.
+
+## What's logged at DEBUG
+
+When the `custom_components.unifi_alerts` logger is set to `DEBUG`, webhook receipt logs a narrowed view of the inbound payload, not the payload itself. `webhook_handler.py` defines `_SAFE_DEBUG_FIELDS`:
+
+- `category`
+- `alert_key`
+- `key`
+- `severity`
+- `device_name`
+
+Only these fields (when present in the payload) are logged, one line per webhook received. Any other field the controller sends, including the raw payload structure, firmware-specific additions, or free-text fields not in this list, is never written to the log.
+
+The webhook bearer token is never logged. Webhook URLs that appear anywhere in logs or diagnostics always have the `?token=...` query string stripped first, the same pattern used in diagnostics output above.
+
+## Retention policy
+
+There is no time-based retention window. Data for a category persists until one of:
+
+1. **The category is cleared** - `last_cleared_at` advances, but `last_alert` is not deleted (see README "Privacy and data retention" for the clear-vs-delete distinction that affects entity attributes visible in the UI).
+2. **The config entry is removed** - the watermark `Store` file is deleted outright (see Deletion above).
+3. **Home Assistant itself is reset or uninstalled** - nothing in this integration outlives the HA install; there is no separate database, external store, or backup mechanism of its own.
+
+## Summary for reviewers
+
+- All storage is local to the HA host filesystem (`.storage/`), scoped per config entry, and removable in one action.
+- No raw controller payloads are ever written to disk.
+- No alert content (message, device name) appears in diagnostics downloads.
+- No data is transmitted to any destination other than the user's own UniFi controller and the user's own Home Assistant instance.

--- a/docs/DATA_HANDLING.md
+++ b/docs/DATA_HANDLING.md
@@ -79,7 +79,7 @@ The webhook bearer token is never logged. Webhook URLs that appear anywhere in l
 
 There is no time-based retention window. Data for a category persists until one of:
 
-1. **The category is cleared** - `last_cleared_at` advances, but `last_alert` is not deleted (see README "Privacy and data retention" for the clear-vs-delete distinction that affects entity attributes visible in the UI).
+1. **The category is cleared** - pressing Clear (or auto-clear firing) marks the category as acknowledged (`is_alerting = False`) and advances the watermark (`last_cleared_at`). It does NOT delete `last_alert` - the most recent alert's details remain visible in entity attributes. This is intentional: dashboards and automations can still reference the last-seen event after it has been acknowledged.
 2. **The config entry is removed** - the watermark `Store` file is deleted outright (see Deletion above).
 3. **Home Assistant itself is reset or uninstalled** - nothing in this integration outlives the HA install; there is no separate database, external store, or backup mechanism of its own.
 


### PR DESCRIPTION
## Summary

Adds `docs/DATA_HANDLING.md` as the authoritative statement of what the integration stores, where, and for how long. This is a v2.0-gate item blocking the HACS default-catalogue submission (#143), so security-conscious self-hosters and HACS reviewers have a precise, code-verified answer to "what does this integration do with my data."

## Changes

- `docs/DATA_HANDLING.md` (new): what's persisted to disk (`.storage/unifi_alerts_watermarks_<entry_id>`, exact field list per category, exact `last_alert` field list), what's memory-only (`open_count`, webhook dedup state, `unrecognised_keys`), what's in diagnostics downloads and what's redacted, what's logged at DEBUG (`_SAFE_DEBUG_FIELDS`), retention policy, and a "no data leaves your HA host" statement.
- `README.md`: replaced the existing "Privacy and data retention" section's inline detail (which had drifted from the code, e.g. the storage filename was missing the `entry_id` suffix) with a short pointer to the new doc, so the facts live in one place.
- `SECURITY.md`: added a line under "What's in scope" pointing to the new doc.

Every fact in the new doc was checked directly against `coordinator.py`, `models.py`, `diagnostics.py`, `webhook_handler.py`, and `__init__.py` (`async_remove_entry`) rather than carried over from prior assumptions.

## How to test

Docs-only change; per `CLAUDE.md`'s doc-only PR path, ran `make doc-check` (prose linter + HISTORY format + translation drift, no venv needed) instead of the full `make check`.

```bash
make doc-check
```

## Checklist

- [x] Linked the issue this PR resolves (`Closes #273`)
- [x] `make doc-check` passes locally (docs-only change, lighter path per `CLAUDE.md`)
- [x] `CHANGELOG.md` `[Unreleased]` updated - intentionally skipped: this documents existing behavior, no user-visible product change
- [x] PR title starts with a Conventional Commit prefix (`docs:`)
- [x] PR has a label recognised by `.github/release.yml` (expect `documentation` via pr-labeler)
- [x] `strings.json` and `translations/en.json` are still identical (unaffected, verified via `make doc-check`)
- [x] New category fully registered - N/A, no category changes
- [x] No blocking I/O introduced - docs-only, no code changes

Closes #273


---
_Generated by [Claude Code](https://claude.ai/code/session_014xckCmEQrDqRoFV7bBipjg)_