### PR TITLE
release: bump version to 1.9.0-pre3

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -28,5 +28,5 @@
       "modelDescription": "UniFi Dream Machine Pro Max"
     }
   ],
-  "version": "1.9.0-pre2"
+  "version": "1.9.0-pre3"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -2,6 +2,29 @@
 
 Dated record of completed work. Newest first. Format per entry: category, short description, PR or commit reference, short why.
 
+## 2026-07-05
+
+- **release**: v1.9.0-pre3 tagged. Third checkpoint of the v1.9.0 cycle. Headline: five bug fixes closing out real defects found during triage (webhook dedup, non-string payload coercion, entry-removal cleanup, stale `unique_id` on controller URL change), CI now lints and type-checks the `tests/` tree, and all three remaining `v2.0-gate` documentation items land, closing out every `v2.0-gate` issue.
+- **chore**: repo hygiene quick wins from an agentic-delivery review: added the MIT `LICENSE` file (previously missing entirely, which would have blocked the HACS default catalogue submission), moved the pytest coverage gate off `addopts` onto `make test`/CI so single-file test runs no longer trip it, split cross-platform vs personal Claude Code settings, and fixed drifted references in `AGENTS.md`/`agentrc.eval.json` ([#290]).
+- **fix**: `push_alert()` no longer deduplicates two distinct keyless webhook alerts against each other; only genuine duplicate keys within the dedup window are still suppressed ([#291]). Closes #263.
+- **fix**: `UniFiAlert`'s three constructors now coerce `device_name`/`site` to `str` before use, matching the existing `message`/`key`/`severity` handling; a non-string value in either field previously raised `TypeError` and dropped the alert entirely ([#292]). Closes #266.
+- **ci**: CI's `lint` job now runs `ruff check`/`ruff format --check` against `tests/` as well as `custom_components/`, matching what `make lint` already enforced locally ([#293]). Closes #232.
+- **fix**: `async_remove_entry` now deletes the per-entry watermark storage file and all four repair issues when a config entry is removed, instead of leaving them behind permanently; the four issue-id strings were also promoted to shared `const.py` constants to prevent drift ([#294]). Closes #264.
+- **fix**: the config entry's `unique_id` now updates when the controller URL changes via the options flow, so duplicate-entry prevention and SSDP discovery matching stay correct after re-pointing an entry to a different controller ([#295]). Closes #276.
+- **docs**: added `docs/DATA_HANDLING.md`, the authoritative statement of what the integration persists, what stays memory-only, what appears in diagnostics downloads, and what is logged at DEBUG; linked from README and SECURITY.md ([#296]). Closes #273.
+- **docs**: added `docs/ALARM_MANAGER_SETUP.md`, a step-by-step guide for wiring UniFi Alarm Manager to the integration's webhook URLs, covering verification via `webhook_health` and the four most common failure modes ([#297]). Closes #274.
+- **docs**: closed out the v2.0 localisation-maturity gate: audited every translation-key surface (two gaps found and fixed, everything else clean), recorded the English-only decision for v2.0, documented the language-contribution path in `docs/LOCALISATION.md`, and removed the orphaned `config.error.unknown` translation key ([#298]). Closes #275.
+
+[#290]: https://github.com/PHeonix25/unifi_alerts/pull/290
+[#291]: https://github.com/PHeonix25/unifi_alerts/pull/291
+[#292]: https://github.com/PHeonix25/unifi_alerts/pull/292
+[#293]: https://github.com/PHeonix25/unifi_alerts/pull/293
+[#294]: https://github.com/PHeonix25/unifi_alerts/pull/294
+[#295]: https://github.com/PHeonix25/unifi_alerts/pull/295
+[#296]: https://github.com/PHeonix25/unifi_alerts/pull/296
+[#297]: https://github.com/PHeonix25/unifi_alerts/pull/297
+[#298]: https://github.com/PHeonix25/unifi_alerts/pull/298
+
 ## 2026-07-03
 
 - **release**: v1.9.0-pre2 tagged. Second checkpoint of the v1.9.0 "Localisation and Scale" cycle. Headline: site validation against the controller (#205), unrecognised event keys surfaced in diagnostics (#207), severity exposed on binary sensors (#210), SSDP discovery for UniFi OS consoles (#212), plus a `UniFiAuth` extraction (#218), narrowed exception handling with a `ConfigEntryAuthFailed` reauth-repair fix (#257), and test-infrastructure hardening (#258, #260) alongside an options-flow refactor (#259). Closes the five PRs carried forward from pre1.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,7 +10,6 @@ What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `
 
 ## v1.9.0: Localisation and Scale
 
-- Localisation: the remaining inline strings.
 - Capability: severity filtering for noisy categories; a self-healing key map.
 - Process: GitHub Issues is now the work tracker (see `docs/TODO.md` for the taxonomy).
 
@@ -20,7 +19,7 @@ Item-level detail: the `v1.9.0` [milestone](https://github.com/PHeonix25/unifi_a
 
 Prerequisites for submitting to <https://github.com/hacs/default>.
 
-- [ ] All `v2.0-gate` issues closed (raw-payload persistence, retention and data-handling statement, Alarm Manager onboarding docs, and localisation maturity).
+- [x] All `v2.0-gate` issues closed (raw-payload persistence, retention and data-handling statement, Alarm Manager onboarding docs, and localisation maturity).
 - [ ] Submit PR to `hacs/default`.
 
 ---


### PR DESCRIPTION
## Summary

Third pre-release checkpoint of the v1.9.0 cycle. Bumps `manifest.json` from `1.9.0-pre2` to `1.9.0-pre3` and writes the `docs/HISTORY.md` block covering every PR merged since the `v1.9.0-pre2` tag.

## Changes

- `custom_components/unifi_alerts/manifest.json`: version bump to `1.9.0-pre3`.
- `docs/HISTORY.md`: new `## 2026-07-05` block summarising #290-#298 (9 PRs).
- `docs/ROADMAP.md`: checked off "All `v2.0-gate` issues closed" (all four gate issues - #115, #273, #274, #275 - are now closed) and removed the completed "Localisation: the remaining inline strings" line from the v1.9.0 section.

## What's in this checkpoint

- **chore**: repo hygiene quick wins - MIT `LICENSE` added, coverage gate moved off `addopts` ([#290])
- **fix**: webhook dedup no longer suppresses distinct keyless alerts ([#291], closes #263)
- **fix**: `device_name`/`site` coerced to `str` in alert constructors ([#292], closes #266)
- **ci**: `tests/` now linted and format-checked in CI ([#293], closes #232)
- **fix**: config entry removal now cleans up watermark storage and repair issues ([#294], closes #264)
- **fix**: `unique_id` now follows the controller URL through the options flow ([#295], closes #276)
- **docs**: `docs/DATA_HANDLING.md` - data retention and handling statement ([#296], closes #273)
- **docs**: `docs/ALARM_MANAGER_SETUP.md` - Alarm Manager onboarding guide ([#297], closes #274)
- **docs**: localisation maturity audit closed out, two real gaps fixed ([#298], closes #275)

`CHANGELOG.md` is intentionally untouched - pre-release bumps don't touch it per `CLAUDE.md`.

## How to test

```bash
make check   # lint + typecheck + validate + all tests
```

Ran locally: 650 tests passed, 98.66% coverage.

## Checklist

- [x] `make check` passes locally
- [x] `docs/HISTORY.md` updated with this tag's summary (version-bump PR)
- [x] `docs/ROADMAP.md` updated: completed items checked off/removed
- [x] `CHANGELOG.md` NOT touched (pre-release bump, per `CLAUDE.md`)
- [x] PR title starts with a Conventional Commit prefix (none of the mapped prefixes fit `release:`, will apply `chore` label manually if pr-labeler doesn't catch it)

## After merge

```bash
git checkout dev && git pull origin dev
git tag v1.9.0-pre3 && git push origin v1.9.0-pre3
```

GitHub Actions will create the pre-release automatically once the tag is pushed.


---
_Generated by [Claude Code](https://claude.ai/code/session_014xckCmEQrDqRoFV7bBipjg)_