### PR TITLE
ci: v1.9 CI and tooling improvements (#281, #284, #286, #288)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,5 +17,17 @@
       "WebFetch(domain:help.ui.com)",
       "WebSearch"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/scripts/bootstrap_venv.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,46 +1,13 @@
 # GitHub Copilot Instructions
 
-> Full project context, hard constraints, conventions, and working style live in [`CLAUDE.md`](../CLAUDE.md). Read it first.
-> Quick-reference links to architecture, HA patterns, UniFi API, testing, and outstanding work (GitHub Issues) are in [`AGENTS.md`](../AGENTS.md).
+> Claude-specific working style and the full non-negotiable constraint list live in [`CLAUDE.md`](../CLAUDE.md). Read it first.
+> Release and branching detail lives in [`docs/RELEASING.md`](../docs/RELEASING.md).
 
 ---
 
-## What this repo is
+## Shared facts (defined once in AGENTS.md)
 
-A Home Assistant custom integration (`domain: unifi_alerts`) that aggregates UniFi Network controller alerts into HA sensors, binary sensors, event entities, and buttons. Distributed via HACS.
-
-## Tech stack
-
-| Layer | Tool |
-|-------|------|
-| Language | Python 3.12+ |
-| Async HTTP | `aiohttp` |
-| Lint + format | `ruff` |
-| Type checking | `mypy` (strict) |
-| Tests | `pytest` + `MagicMock`/`AsyncMock` |
-| HA integration | `custom_components/unifi_alerts/` |
-
-## Build & test
-
-```bash
-make check      # lint + typecheck + validate + test (run before every commit)
-make lint       # ruff check + format check
-make typecheck  # mypy
-make validate   # HACS preflight + translation drift check
-make test       # pytest
-```
-
-All commands use `.venv` in the repo root, never the system Python.
-
-## Key source files
-
-| File | Role |
-|------|------|
-| `custom_components/unifi_alerts/const.py` | All constants, category defs, UniFi key to category map |
-| `custom_components/unifi_alerts/coordinator.py` | DataUpdateCoordinator, owns all category state |
-| `custom_components/unifi_alerts/webhook_handler.py` | Registers HA webhooks, validates `?token=` bearer auth |
-| `custom_components/unifi_alerts/config_flow.py` | Three-step UI setup + options flow |
-| `custom_components/unifi_alerts/strings.json` | Must stay identical to `translations/en.json` |
+Repo purpose, the tech stack, the build/test command block, the repository structure, and the key source-file map all live in [`AGENTS.md`](../AGENTS.md). Read that first; it is the single source for those facts, so they are not repeated here. `scripts/validate_docs.py` fails the build if the shared blocks are copied back into this file.
 
 ## Non-negotiable rules (summary)
 
@@ -62,7 +29,7 @@ See [`CLAUDE.md`](../CLAUDE.md) for the complete list with rationale.
 - Feature branches: `claude/*` or `feature/*`, always branched from `dev`.
 - Claude cannot push tags; provide the user with the exact `git tag` + `git push origin <tag>` command after a version-bump PR merges.
 
-See [`CLAUDE.md`](../CLAUDE.md) for the full release workflow.
+See [`docs/RELEASING.md`](../docs/RELEASING.md) for the full release workflow.
 
 ## Ways of working: outstanding work and findings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,22 @@ jobs:
         run: python scripts/check_translations.py
 
   test:
-    name: Run tests
+    name: Run tests (${{ matrix.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Latest HA: whatever requirements-dev.txt resolves (its pinned
+          # pytest-homeassistant-custom-component drives the HA version).
+          - name: latest HA
+            ha_pin: ""
+          # Minimum supported HA: the floor declared in hacs.json. The pinned
+          # pytest-homeassistant-custom-component release must match this HA
+          # version (0.13.201 maps to homeassistant 2025.1.0). When the floor
+          # moves, bump both pins here alongside hacs.json and the README.
+          - name: minimum HA (2025.1.0)
+            ha_pin: "homeassistant==2025.1.0 pytest-homeassistant-custom-component==0.13.201"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
@@ -73,12 +87,18 @@ jobs:
           cache: pip
       - name: Install test dependencies
         run: pip install -r requirements-dev.txt
+      - name: Pin minimum Home Assistant
+        # Override the requirements-dev pins for the minimum-HA leg only, so the
+        # declared floor is exercised by the suite rather than only the latest.
+        if: matrix.ha_pin != ''
+        run: pip install ${{ matrix.ha_pin }}
       - name: Run tests with coverage
         # --cov-fail-under lives here (and in `make test`), not in pytest
         # addopts, so targeted local runs of a single file still pass.
         run: pytest tests/ -v --cov-report=xml --cov-fail-under=95
       - name: Upload coverage to Codecov
-        if: always()
+        # Upload once (latest leg only) to avoid duplicate reports.
+        if: ${{ always() && matrix.ha_pin == '' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,15 @@
 # AGENTS.md - unifi_alerts
 
-> Full project context, hard constraints, conventions, and working style live in [`CLAUDE.md`](CLAUDE.md). Read it first.
-> Detailed architecture, HA patterns, UniFi API, testing, and TODO docs live in [`docs/`](docs/).
+> This file is the single home for the shared facts every agent needs: repo purpose, tech stack, build/test commands, and the repo map. Do not copy these blocks into [`CLAUDE.md`](CLAUDE.md) or [`.github/copilot-instructions.md`](.github/copilot-instructions.md); link here instead. `scripts/validate_docs.py` fails the build if the anchored blocks below are duplicated into another file.
+> Claude-specific working style and the full non-negotiable constraint list live in [`CLAUDE.md`](CLAUDE.md). Release and branching detail lives in [`docs/RELEASING.md`](docs/RELEASING.md). Extended docs (architecture, HA patterns, UniFi API, testing) live in [`docs/`](docs/).
 
 ---
 
 ## What this repo is
 
 A Home Assistant custom integration (`domain: unifi_alerts`) that aggregates UniFi Network controller alerts into HA sensors, binary sensors, event entities, and buttons. Distributed via HACS.
+
+This integration covers **UniFi Network** only (System Logs / SIEM events from the Network Application on UniFi OS). It does **not** support UniFi Protect (cameras, motion detection, NVR).
 
 Two data paths run in parallel:
 - **Webhook push** - UniFi Alarm Manager POSTs to per-category webhook URLs registered by HA. Real-time path.
@@ -30,6 +32,7 @@ Two data paths run in parallel:
 
 ## Tech stack
 
+<!-- shared:stack -->
 | Layer | Tool |
 | ----- | ---- |
 | Language | Python 3.12+ |
@@ -38,11 +41,13 @@ Two data paths run in parallel:
 | Type checking | `mypy` (strict) |
 | Tests | `pytest` + `MagicMock`/`AsyncMock` |
 | HA integration | `custom_components/unifi_alerts/` |
+<!-- /shared:stack -->
 
 ---
 
 ## Build & test commands
 
+<!-- shared:commands -->
 ```bash
 make check        # default: lint + typecheck + validate + test (run before every commit)
 make lint         # ruff check + format check
@@ -50,6 +55,7 @@ make typecheck    # mypy
 make validate     # HACS preflight + translation drift check
 make test         # pytest
 ```
+<!-- /shared:commands -->
 
 All commands use `.venv` in the repo root - never the system Python. Run `make setup` once after cloning to create it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Category binary sensors now expose a `last_severity` attribute containing the severity string from the most recent alert (`"LOW"`, `"MEDIUM"`, `"HIGH"`, `"VERY_HIGH"` on v2 controllers; raw webhook severity on legacy controllers). The `any_alert` rollup sensor exposes the same attribute. Automations can condition on this to suppress or escalate alerts by severity without disabling the category. ([#135])
+- Raised the declared minimum supported Home Assistant version from 2024.5 to 2025.1, matching the version the test suite actually runs against. CI now runs the full suite against both the declared minimum HA (pinned) and the latest HA. ([#284])
 
 ### Added
 
@@ -316,4 +317,5 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#295]: https://github.com/PHeonix25/unifi_alerts/pull/295
 [#297]: https://github.com/PHeonix25/unifi_alerts/pull/297
 [#298]: https://github.com/PHeonix25/unifi_alerts/pull/298
+[#284]: https://github.com/PHeonix25/unifi_alerts/issues/284
 [#PR]: https://github.com/PHeonix25/unifi_alerts/pull/PR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,7 @@ This is the primary context file for Claude Code. Read this first, then follow t
 
 ## What this project is
 
-A Home Assistant custom integration (`domain: unifi_alerts`) that aggregates UniFi Network controller alerts into HA sensors, binary sensors, event entities, and buttons. It is intended for publication as a HACS custom repository.
-
-This integration covers **UniFi Network** only (System Logs / SIEM events from the Network Application on UniFi OS). It does **not** support UniFi Protect (cameras, motion detection, NVR).
-
-**Two data paths run in parallel:**
-- **Webhook push** - UniFi Alarm Manager POSTs to per-category webhook URLs registered by HA. This is the real-time path.
-- **REST polling** - the integration polls the UniFi controller's alarm API on a configurable interval to populate open-count sensors and catch alerts that missed the webhook.
+[`AGENTS.md`](AGENTS.md) is the single home for the shared facts every agent needs: the repo purpose (a Home Assistant custom integration, `domain: unifi_alerts`, distributed via HACS), the tech stack, the build/test commands, and the repo map. Read it first. This file adds the Claude-specific working style, the full non-negotiable constraint list, and the day-to-day workflow rules; it does not repeat the shared facts.
 
 ## Reference documents
 
@@ -24,6 +18,7 @@ This integration covers **UniFi Network** only (System Logs / SIEM events from t
 | `docs/DEVELOPING.md` | Set up a local dev environment, run tests, contribute changes |
 | GitHub Issues | Find the outstanding-work backlog. Work is tracked in Issues (filter by milestone, sort by `priority:`, pick by `size:`), not in a file. `docs/TODO.md` is a pointer that documents the label and milestone taxonomy. Historical record lives in `docs/HISTORY.md`; per-release plan lives in `docs/ROADMAP.md`. |
 | `docs/ROADMAP.md` | See what's planned next per release (v1.8.0, v1.9.0, v2.0.0). Open items only; completed releases are removed once they ship. |
+| `docs/RELEASING.md` | Cut a release or bump a version: the two-branch model, version formats, the pre-release/stable/next-cycle workflow, the merge-commit-vs-squash rationale, the no-sync-merge note, tag-convention reminder, CI enforcement, and branch protection. |
 | `AGENTS.md` | Agent-facing context file for Copilot and third-party AI tools. Includes repo structure map, category-registration walkthrough, and common pitfalls. |
 | `docs/HISTORY.md` | Dated record of completed work, newest first. **Updated only at tag time** (pre-release or stable) by the version-bump PR, which adds one date block listing every PR merged since the previous tag. Format: `## YYYY-MM-DD` heading, bullets `- **category**: short description ([#PR] or [SHA]). Short why.` Categories: `feat`, `fix`, `security`, `docs`, `ci`, `chore`, `tests`, `release`. No WHO. No "bundle/cluster/track/session N" framing. PR backlinks via reference-style at the bottom of the file. |
 | `CHANGELOG.md` | User-facing release summary in [common-changelog](https://common-changelog.org) format. Past tense, one line per change, references at the bottom. Update the `[Unreleased]` section as user-visible changes land. |
@@ -61,73 +56,13 @@ Per-file annotations and load-bearing details live in [`docs/REPO_LAYOUT.md`](do
 - All `const.py` additions go in the appropriate labelled section with a comment.
 - Tests use `MagicMock` / `AsyncMock` for the UniFi client - never make real HTTP calls in tests.
 
-## Branching strategy and versioning
+## Branching and releasing
 
-This project uses a two-branch model. All active development happens on `dev`; `main` is stable-only.
+Two-branch model: all active development happens on `dev`; `main` is stable-only. Feature and `claude/*` branches must be cut from `dev` and target `dev` in their PRs, never `main`. `dev` carries `X.Y.Z-preN` versions (or a stable `X.Y.Z` when preparing a release); `main` carries stable `X.Y.Z` only. `manifest.json` is the single source of truth for the version, and `scripts/bump_version.py` drives every bump.
 
-### Branches
+**Claude cannot push tags.** When the user says "cut a release", "update the tag", "tag the branch", or similar, open a version-bump PR (via `scripts/bump_version.py`) targeting `dev` (or `main` for a stable release) and, after it merges, give the user the exact `git tag` + `git push origin <tag>` commands to run locally.
 
-| Branch | Purpose | Version format | Example |
-|--------|---------|---------------|---------|
-| `main` | Stable releases only. CI enforces no pre-release suffix. | `X.Y.Z` | `1.0.0`, `1.1.0` |
-| `dev` | Active development. CI accepts `-preN` during development, or stable `X.Y.Z` when preparing a release. | `X.Y.Z-preN` or `X.Y.Z` | `1.1.0-pre1`, `1.1.0` |
-| `feature/*` or `claude/*` | Short-lived work. **Must branch off `dev`, not `main`.** No version format enforced by CI. | Any | - |
-
-### Versioning conventions
-
-- **Minor bumps on main:** releases from `main` increment the minor version (`1.0.0 > 1.1.0 > 1.2.0`). Patch releases (`1.0.1`) are reserved for critical hotfixes.
-- **Pre-release sequence on dev:** each tagged checkpoint on `dev` increments the pre-release counter (`1.1.0-pre1 > 1.1.0-pre2`). The base version (`1.1.0`) matches the *next* planned minor release on `main`.
-- **`manifest.json` is the single source of truth** for the version - the release workflow validates the pushed tag matches it exactly.
-
-### Release workflow
-
-```
-dev  ──┬── (work) ──► tag v1.1.0-pre1  ──► GitHub pre-release  (automated)
-       │
-       ├── (work) ──► tag v1.1.0-pre2  ──► GitHub pre-release  (automated)
-       │
-       ├── bump manifest to 1.1.0 (via claude/* PR > dev)
-       │    └─► PR dev > main  [MERGE COMMIT - never squash]
-       │         └─► tag v1.1.0  ──► GitHub stable release  (automated)
-       │
-       └── bump manifest to 1.2.0-pre1 (via claude/* PR > dev)  (start next cycle)
-```
-
-**Use `scripts/bump_version.py` for steps 2, 3, and 4 below.** It computes the next version per these rules, checks out a fresh `dev`, creates the `claude/bump-<new-version>` branch, updates `manifest.json` (and `CHANGELOG.md` for stable promotions), stages the change, and prints the `git log <prev-tag>..HEAD --merges` list ready to summarise into `docs/HISTORY.md`. Modes: `--pre`, `--stable`, `--next-cycle`.
-
-1. **Development:** work on `dev`. Version in manifest stays at `X.Y.Z-preN`.
-2. **Pre-release checkpoint:** run `python3 scripts/bump_version.py --pre` to bump the `N` in manifest (e.g. `pre1 > pre2`) on a short-lived `claude/bump-*` branch, then open a PR targeting `dev`, merge it, and provide the user with the tag command (Claude cannot push tags). **In the same PR, write the HISTORY block** for this tag: the script prints the merge list since the previous tag; summarise it into a single `## YYYY-MM-DD` block in `docs/HISTORY.md` (newest first). **Drop completed items** from `docs/ROADMAP.md` for the section this tag advances. `CHANGELOG.md` is NOT touched on pre-release bumps. After the PR merges, the user runs:
-   ```bash
-   git checkout dev && git pull origin dev
-   git tag vX.Y.Z-preN && git push origin vX.Y.Z-preN
-   ```
-   GitHub Actions creates a pre-release automatically.
-3. **Stable release:** run `python3 scripts/bump_version.py --stable` to bump manifest from `X.Y.Z-preN` to `X.Y.Z` and rewrite `CHANGELOG.md` (rename `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD`, insert a fresh `[Unreleased]` above it, add the `[X.Y.Z]: .../releases/tag/vX.Y.Z` link reference). Open PR targeting `dev`. **In the same PR, write the HISTORY block** covering every PR merged since the previous tag (the most recent pre-release). `dev` CI now accepts stable versions, so this passes. Merge to `dev`, then open a PR from `dev` > `main`. After that merges, provide the user with the tag command:
-   ```bash
-   git checkout main && git pull origin main
-   git tag vX.Y.Z && git push origin vX.Y.Z
-   ```
-   GitHub Actions creates a stable release automatically; the auto-generated notes are grouped by the labels on PRs merged between the previous tag and this one.
-
-   > **CRITICAL - use "Create a merge commit", never "Squash and merge", for the `dev > main` PR.** Squashing creates a new commit on `main` whose only parent is the previous `main` tip; dev's individual commits have no ancestry path through it. The merge base between `main` and `dev` never advances past the last stable release, so the next release produces a conflict storm across every file that both branches touched. A regular merge commit preserves both parents and keeps the merge base current. The `main` ruleset is configured to enforce merge-commit-only.
-
-   > **No `main > dev` sync merge needed.** Earlier releases (v1.3.0, v1.4.0) ran a `claude/sync-main-to-dev-X.Y.Z` PR after every stable release because the `dev > main` PR was squash-merged, which left the release commit out of dev's ancestry. With merge-commit-only on `main` (above), dev's tip is already the second parent of the release commit; the merge base advances correctly and no sync is required. Attempting one now contradicts the squash-only-on-dev ruleset.
-
-4. **Start next cycle:** run `python3 scripts/bump_version.py --next-cycle` to bump manifest to `X.(Y+1).0-pre1` on a `claude/bump-*` branch, open PR targeting `dev`, merge. Development continues forward. Notable changes between releases accumulate under `CHANGELOG.md` `[Unreleased]` as their PRs land - don't batch them at release time.
-
-> **Tag convention reminder:** Claude cannot push tags directly. Whenever the user says "update the tag", "cut a release", "tag the branch", or similar - open a version-bump PR to `dev` (or `main` for stable), wait for merge, then give the user the exact `git tag` + `git push origin <tag>` commands to run locally.
-
-### CI enforcement
-
-- `version-check.yml` blocks pushes and PRs that violate the format for the target branch.
-- `release.yml` fails if the pushed tag does not exactly match `manifest.json`.
-- Never manually create a GitHub release - always push a version tag and let the workflow do it.
-
-### Branch protection (configure once in GitHub Settings > Branches)
-
-Recommended rules:
-- **`main`:** require PR, require status checks (`CI / *`, `Version Check / *`), no direct push, no force-push.
-- **`dev`:** require PR, require status checks (`CI / *`, `Version Check / *`), no direct push, no force-push. Version bumps go via a short-lived `claude/bump-*` branch PR (created by `scripts/bump_version.py`).
+The full detail - the pre-release/stable/next-cycle workflow, the merge-commit-vs-squash rationale for the `dev > main` PR, the no-sync-merge note, CI enforcement, and branch protection - lives in [`docs/RELEASING.md`](docs/RELEASING.md). Read it when cutting a release.
 
 ## Working style
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Aggregates **UniFi Network controller alerts** into Home Assistant sensors, bina
 
 ## Requirements
 
-- **Home Assistant** 2024.5 or later
+- **Home Assistant** 2025.1 or later
 - **UniFi OS console** - the classic self-hosted Network Application is not supported. The integration uses the `/proxy/network` API path, which is UniFi OS-only.
 - **Local network reachability** - your UniFi controller and HA must share a network. Webhook URLs are local-only and cannot be reached over Nabu Casa remote access or from cloud-hosted controllers.
 - **Credentials** - API key (recommended) or username + password.

--- a/custom_components/unifi_alerts/__init__.py
+++ b/custom_components/unifi_alerts/__init__.py
@@ -188,7 +188,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 def _redact_webhook_token(url: str) -> str:
     """Strip ``?token=<secret>`` from a webhook URL for safe DEBUG logging."""
-    token_marker = "?token="
+    token_marker = "?token="  # noqa: S105  # URL query marker for redaction, not a secret
     idx = url.find(token_marker)
     if idx == -1:
         return url

--- a/custom_components/unifi_alerts/event.py
+++ b/custom_components/unifi_alerts/event.py
@@ -47,7 +47,9 @@ class UniFiAlertEventEntity(CoordinatorEntity[UniFiAlertsCoordinator], EventEnti
 
     _attr_has_entity_name = True
     # Fixed at class level; HA requires declaring event types at init, not per-fire.
-    _attr_event_types = ["alert_received"]
+    # RUF012 is suppressed below: HA's EventEntity base types this as an instance
+    # attr, so a ClassVar override would fail mypy --strict (instance-vs-class-var).
+    _attr_event_types = ["alert_received"]  # noqa: RUF012
 
     def __init__(
         self,

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -111,7 +111,7 @@ Skip `make setup` for a doc-only branch on a fresh clone. The full setup install
 | `hacs-preflight` | Runs `scripts/validate_hacs.py` (pure-Python pre-flight) before the slower HACS action |
 | `hacs` | Validates `hacs.json` and repository structure for HACS listing |
 | `lint` | `ruff check` + `ruff format --check` + `mypy` + `strings.json`/`translations/en.json` drift diff |
-| `test` | `pytest` against `tests/unit/` and `tests/integration/` |
+| `test` | `pytest` against `tests/unit/` and `tests/integration/`, run twice via a matrix: once against the latest HA and once against the declared minimum HA floor |
 | `pip-audit` | Dependency vulnerability scan. Advisory only (`continue-on-error` on the audit step); currently non-blocking - see note below |
 
 Static security analysis (CodeQL SAST) for Python runs through GitHub's CodeQL **default setup**, configured in Settings > Code security and analysis, with findings in the repository Security tab. It is not a workflow in this repository: an advanced workflow-based CodeQL config cannot coexist with default setup (GitHub rejects the SARIF upload), so SAST lives in default setup and the workflow below owns dependency auditing only.
@@ -135,6 +135,18 @@ Three additional checks run on every pull request to `dev` or `main`:
 **Escaping the changelog guard:** apply the `skip-changelog` label if a code change genuinely has no user-visible effect (e.g. a coverage-only test change that incidentally touches a production file). The `ci`, `tests`, `documentation`, `dependencies`, and `github-actions` labels also bypass the guard automatically, since those categories of work rarely need a user-facing changelog entry.
 
 **Label timing:** `pr-labeler.yml` and `label-guard` run concurrently on PR open. If the auto-labeller wins first, both pass in a single round. If `label-guard` fires before the label is applied, it fails on the first run but re-runs on the `labeled` event and passes once the label is present. This is expected behaviour; the status check clears without any manual intervention. The self-heal flow depends on `pr-labeler.yml` having write access to apply the label, which is why that workflow uses the `pull_request_target` trigger: a plain `pull_request` trigger gets a read-only token on PRs from forks and cannot label them, leaving `label-guard` stuck red.
+
+## Minimum supported Home Assistant version
+
+The declared minimum HA version lives in three places that must always agree:
+
+1. `hacs.json` (`"homeassistant"`) - the floor HACS enforces for users installing the integration.
+2. The pinned minimum leg of the `test` job in `.github/workflows/ci.yml` - installs `homeassistant==<floor>` with the matching `pytest-homeassistant-custom-component` release so the floor is actually exercised by the suite.
+3. The README `## Requirements` section - the human-readable statement of the same floor.
+
+`requirements-dev.txt` uses `homeassistant>=` as a soft floor only. Pip resolves the latest version satisfying `>=`, not the floor, so that line does not test the minimum on its own; the pinned CI leg does.
+
+**Policy: when the floor moves, update all three in the same PR.** Pick the new floor, find the `pytest-homeassistant-custom-component` release that maps to it (each release title on the [p-h-c-c releases page](https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/releases) names its `homeassistant version`), and update `hacs.json`, the pinned CI leg (both the `homeassistant==` and `pytest-homeassistant-custom-component==` pins), and the README together. A floor that no CI leg installs is an unverified promise, so never lower the declared floor below the version the pinned leg tests.
 
 ## Branching and PRs
 

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -16,6 +16,18 @@ make setup                             # python3.12 -m venv .venv + pip install 
 
 `requirements-dev.txt` is the single source of truth for dev dependencies; both CI jobs install from the same file.
 
+## Agent session bootstrap
+
+AI coding agents start from a cold container each session. Before any test can run, the `.venv` (Home Assistant plus the full test stack, roughly 200 packages) has to be installed via `make setup`. Each agent surface provisions that environment through its own entry point, and all three run the identical `python3.12 -m venv .venv` + `pip install -r requirements-dev.txt` sequence so every surface matches CI:
+
+| Surface | Entry point | Behaviour |
+|---|---|---|
+| Claude Code (web / remote) | `SessionStart` hook in `.claude/settings.json` calling `scripts/bootstrap_venv.sh` | Runs `make setup` only when `.venv` is absent; a no-op otherwise. Registered as an async hook, so the session starts immediately while the install runs in the background. Gated on `$CLAUDE_CODE_REMOTE`, so local sessions are untouched. Tolerant: a failed install logs and exits 0 rather than breaking the session. |
+| GitHub Copilot coding agent | `.github/workflows/copilot-setup-steps.yml` | GitHub runs this workflow before the agent starts, creating `.venv` and installing `requirements-dev.txt`. |
+| Local developer | `make setup` (run manually, see [Local setup](#local-setup)) | Explicit and one-off. The Claude hook deliberately skips local sessions so it never installs behind your back. |
+
+Why not a slimmer `requirements-test.txt`? The install is dominated by Home Assistant, which `pytest-homeassistant-custom-component` pulls in transitively regardless of what else is trimmed. A pytest-only requirements file would still drag in the same heavy tree, so it would not meaningfully shorten setup. The full `requirements-dev.txt` install is required; the hook plus the container's pip cache is the mitigation, not a reduced dependency set.
+
 ## Running checks
 
 ```bash

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,71 @@
+# Releasing - unifi_alerts
+
+Branching model, version formats, and the full release workflow. `CLAUDE.md` keeps only a short two-branch summary and points here; read this document when cutting a release or bumping a version.
+
+## Branching strategy and versioning
+
+This project uses a two-branch model. All active development happens on `dev`; `main` is stable-only.
+
+### Branches
+
+| Branch | Purpose | Version format | Example |
+|--------|---------|---------------|---------|
+| `main` | Stable releases only. CI enforces no pre-release suffix. | `X.Y.Z` | `1.0.0`, `1.1.0` |
+| `dev` | Active development. CI accepts `-preN` during development, or stable `X.Y.Z` when preparing a release. | `X.Y.Z-preN` or `X.Y.Z` | `1.1.0-pre1`, `1.1.0` |
+| `feature/*` or `claude/*` | Short-lived work. **Must branch off `dev`, not `main`.** No version format enforced by CI. | Any | - |
+
+### Versioning conventions
+
+- **Minor bumps on main:** releases from `main` increment the minor version (`1.0.0 > 1.1.0 > 1.2.0`). Patch releases (`1.0.1`) are reserved for critical hotfixes.
+- **Pre-release sequence on dev:** each tagged checkpoint on `dev` increments the pre-release counter (`1.1.0-pre1 > 1.1.0-pre2`). The base version (`1.1.0`) matches the *next* planned minor release on `main`.
+- **`manifest.json` is the single source of truth** for the version - the release workflow validates the pushed tag matches it exactly.
+
+### Release workflow
+
+```
+dev  ──┬── (work) ──► tag v1.1.0-pre1  ──► GitHub pre-release  (automated)
+       │
+       ├── (work) ──► tag v1.1.0-pre2  ──► GitHub pre-release  (automated)
+       │
+       ├── bump manifest to 1.1.0 (via claude/* PR > dev)
+       │    └─► PR dev > main  [MERGE COMMIT - never squash]
+       │         └─► tag v1.1.0  ──► GitHub stable release  (automated)
+       │
+       └── bump manifest to 1.2.0-pre1 (via claude/* PR > dev)  (start next cycle)
+```
+
+**Use `scripts/bump_version.py` for steps 2, 3, and 4 below.** It computes the next version per these rules, checks out a fresh `dev`, creates the `claude/bump-<new-version>` branch, updates `manifest.json` (and `CHANGELOG.md` for stable promotions), stages the change, and prints the `git log <prev-tag>..HEAD --merges` list ready to summarise into `docs/HISTORY.md`. Modes: `--pre`, `--stable`, `--next-cycle`.
+
+1. **Development:** work on `dev`. Version in manifest stays at `X.Y.Z-preN`.
+2. **Pre-release checkpoint:** run `python3 scripts/bump_version.py --pre` to bump the `N` in manifest (e.g. `pre1 > pre2`) on a short-lived `claude/bump-*` branch, then open a PR targeting `dev`, merge it, and provide the user with the tag command (Claude cannot push tags). **In the same PR, write the HISTORY block** for this tag: the script prints the merge list since the previous tag; summarise it into a single `## YYYY-MM-DD` block in `docs/HISTORY.md` (newest first). **Drop completed items** from `docs/ROADMAP.md` for the section this tag advances. `CHANGELOG.md` is NOT touched on pre-release bumps. After the PR merges, the user runs:
+   ```bash
+   git checkout dev && git pull origin dev
+   git tag vX.Y.Z-preN && git push origin vX.Y.Z-preN
+   ```
+   GitHub Actions creates a pre-release automatically.
+3. **Stable release:** run `python3 scripts/bump_version.py --stable` to bump manifest from `X.Y.Z-preN` to `X.Y.Z` and rewrite `CHANGELOG.md` (rename `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD`, insert a fresh `[Unreleased]` above it, add the `[X.Y.Z]: .../releases/tag/vX.Y.Z` link reference). Open PR targeting `dev`. **In the same PR, write the HISTORY block** covering every PR merged since the previous tag (the most recent pre-release). `dev` CI now accepts stable versions, so this passes. Merge to `dev`, then open a PR from `dev` > `main`. After that merges, provide the user with the tag command:
+   ```bash
+   git checkout main && git pull origin main
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+   GitHub Actions creates a stable release automatically; the auto-generated notes are grouped by the labels on PRs merged between the previous tag and this one.
+
+   > **CRITICAL - use "Create a merge commit", never "Squash and merge", for the `dev > main` PR.** Squashing creates a new commit on `main` whose only parent is the previous `main` tip; dev's individual commits have no ancestry path through it. The merge base between `main` and `dev` never advances past the last stable release, so the next release produces a conflict storm across every file that both branches touched. A regular merge commit preserves both parents and keeps the merge base current. The `main` ruleset is configured to enforce merge-commit-only.
+
+   > **No `main > dev` sync merge needed.** Earlier releases (v1.3.0, v1.4.0) ran a `claude/sync-main-to-dev-X.Y.Z` PR after every stable release because the `dev > main` PR was squash-merged, which left the release commit out of dev's ancestry. With merge-commit-only on `main` (above), dev's tip is already the second parent of the release commit; the merge base advances correctly and no sync is required. Attempting one now contradicts the squash-only-on-dev ruleset.
+
+4. **Start next cycle:** run `python3 scripts/bump_version.py --next-cycle` to bump manifest to `X.(Y+1).0-pre1` on a `claude/bump-*` branch, open PR targeting `dev`, merge. Development continues forward. Notable changes between releases accumulate under `CHANGELOG.md` `[Unreleased]` as their PRs land - don't batch them at release time.
+
+> **Tag convention reminder:** Claude cannot push tags directly. Whenever the user says "update the tag", "cut a release", "tag the branch", or similar - open a version-bump PR to `dev` (or `main` for stable), wait for merge, then give the user the exact `git tag` + `git push origin <tag>` commands to run locally.
+
+### CI enforcement
+
+- `version-check.yml` blocks pushes and PRs that violate the format for the target branch.
+- `release.yml` fails if the pushed tag does not exactly match `manifest.json`.
+- Never manually create a GitHub release - always push a version tag and let the workflow do it.
+
+### Branch protection (configure once in GitHub Settings > Branches)
+
+Recommended rules:
+- **`main`:** require PR, require status checks (`CI / *`, `Version Check / *`), no direct push, no force-push.
+- **`dev`:** require PR, require status checks (`CI / *`, `Version Check / *`), no direct push, no force-push. Version bumps go via a short-lived `claude/bump-*` branch PR (created by `scripts/bump_version.py`).

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "content_in_root": false,
   "zip_release": false,
   "render_readme": true,
-  "homeassistant": "2024.5.0"
+  "homeassistant": "2025.1.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,25 @@ target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "B", "BLE", "C4", "SIM"]
+select = ["E", "F", "W", "I", "UP", "B", "BLE", "C4", "SIM", "ASYNC", "RUF", "PT", "S", "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915"]
 ignore = ["E501"]
+
+# Complexity and size budgets are pinned to the current codebase maxima so the
+# suite passes as-is; tighten them in later PRs to ratchet size down (see #281).
+[tool.ruff.lint.mccabe]
+max-complexity = 13
+
+[tool.ruff.lint.pylint]
+max-branches = 13
+max-returns = 6
+max-args = 6
+max-statements = 40
+
+[tool.ruff.lint.per-file-ignores]
+# assert plus dummy fixture credentials are expected in the test suite
+"tests/*" = ["S101", "S105", "S106", "S107"]
+# CONF_*/ISSUE_ID_* are config-key names and issue identifiers, not secrets
+"custom_components/unifi_alerts/const.py" = ["S105"]
 
 [tool.mypy]
 python_version = "3.12"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,8 +9,14 @@
 # - aiohttp uses >= because it is a runtime dependency that HA manages; the
 #   exact version is driven by pytest-homeassistant-custom-component's transitive
 #   requirements.
-# - homeassistant uses >= with a minimum floor so the integration is validated
-#   against the minimum supported HA release rather than whatever pip resolves.
+# - homeassistant uses >= as a soft floor for local dev installs. Note that pip
+#   resolves the LATEST version satisfying >=, NOT the floor, so this line does
+#   not by itself test the minimum supported release. The declared minimum
+#   (hacs.json "homeassistant") is exercised by a dedicated pinned leg in
+#   .github/workflows/ci.yml that installs homeassistant==<floor> together with
+#   the matching pytest-homeassistant-custom-component release. When the floor
+#   moves, update hacs.json, that CI leg, and the README requirements section in
+#   the same PR.
 aiohttp>=3.9.0
 aioresponses==0.7.9
 async-upnp-client>=0.42.0

--- a/scripts/bootstrap_venv.sh
+++ b/scripts/bootstrap_venv.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# SessionStart bootstrap for unifi_alerts.
+#
+# Creates the .venv dev environment (Home Assistant + full test stack) when it
+# is missing, so a fresh remote agent session can run `make test` without any
+# manual setup step. It mirrors what .github/workflows/copilot-setup-steps.yml
+# does for the Copilot coding agent, keeping every agent surface on the same
+# environment.
+#
+# Design guarantees:
+#   * No-op when .venv already exists (local devs and cached remote containers).
+#   * Non-blocking: wired as an async SessionStart hook, so the session starts
+#     immediately and this install runs in the background.
+#   * Tolerant: a failed install never aborts the session; failures are logged
+#     and the script exits 0 so Claude can still lint and inspect the tree.
+#   * Remote-only: gated on $CLAUDE_CODE_REMOTE so local sessions keep their
+#     existing behaviour (a local dev runs `make setup` deliberately).
+#   * POSIX sh, cross-platform-safe (checks both bin/ and Scripts/ layouts).
+set -u
+
+# Emit the async directive first so Claude Code starts the session immediately
+# and runs the rest of this script in the background.
+printf '{"async": true, "asyncTimeout": 600000}\n'
+
+# Only bootstrap in a remote agent container. Local developers set up their
+# venv on their own terms and should not have a ~200-package install kicked off
+# behind their back.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$PROJECT_DIR" 2>/dev/null || exit 0
+
+# No-op when a usable venv already exists. Cover both the Unix (bin/) and
+# Windows (Scripts/) venv layouts.
+if [ -x ".venv/bin/pytest" ] || [ -x ".venv/Scripts/pytest.exe" ]; then
+  echo "[bootstrap] .venv already present; skipping setup." >&2
+  exit 0
+fi
+
+echo "[bootstrap] .venv missing; running 'make setup' (Home Assistant + test stack)." >&2
+
+# Tolerant install: a failure must not abort the session. Log and exit 0 either
+# way so the session stays usable for lint-only or read-only work.
+if make setup >&2 2>&1; then
+  echo "[bootstrap] setup complete; 'make test' is now available." >&2
+else
+  echo "[bootstrap] setup failed; run 'make setup' manually. Session continues." >&2
+fi
+
+exit 0

--- a/scripts/validate_docs.py
+++ b/scripts/validate_docs.py
@@ -7,6 +7,8 @@ Catches AI-style prose patterns and HISTORY.md format drift before they land:
 - unicode arrows
 - "bundle/cluster/track/session N" framing phrases
 - HISTORY.md h2 headings that are not `## YYYY-MM-DD`
+- shared-fact blocks duplicated across the agent instruction files
+- cross-file markdown pointers that do not resolve to an existing file
 
 Scans every `*.md` file in the repository (excluding `.git`, `.venv`,
 `node_modules`, `.claude`, and similar generated/vendored directories) so
@@ -62,6 +64,125 @@ FORBIDDEN: list[tuple[re.Pattern[str], str]] = [
 # HISTORY.md every h2 must be a date heading. Plain `# History` (h1) is fine.
 HISTORY_H2_VALID = re.compile(r"^## \d{4}-\d{2}-\d{2}\s*$")
 
+# Single-sourcing of shared agent facts. AGENTS.md is the canonical home for the
+# repo purpose, tech stack, build/test commands, and repo map. Each shared block
+# is wrapped in a `<!-- shared:NAME -->` / `<!-- /shared:NAME -->` anchor pair in
+# AGENTS.md and must not be copied into any other markdown file. `CANONICAL_FILE`
+# is the one file allowed to carry the anchors.
+CANONICAL_FILE = "AGENTS.md"
+SHARED_ANCHORS: tuple[str, ...] = ("shared:stack", "shared:commands")
+
+# The agent instruction files whose cross-file `.md` links must resolve.
+AGENT_FILES: tuple[str, ...] = (
+    "CLAUDE.md",
+    "AGENTS.md",
+    ".github/copilot-instructions.md",
+)
+
+# Markdown inline link: `[text](target)`.
+MD_LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+
+def _significant_lines(text: str) -> list[str]:
+    """Return stripped, non-empty lines - a whitespace-insensitive signature."""
+    return [stripped for line in text.splitlines() if (stripped := line.strip())]
+
+
+def _extract_anchor_block(text: str, anchor: str) -> str | None:
+    """Return the inner text between `<!-- anchor -->` and `<!-- /anchor -->`."""
+    pattern = re.compile(
+        rf"<!--\s*{re.escape(anchor)}\s*-->(.*?)<!--\s*/{re.escape(anchor)}\s*-->",
+        re.DOTALL,
+    )
+    m = pattern.search(text)
+    return m.group(1) if m else None
+
+
+def _contains_subsequence(haystack: list[str], needle: list[str]) -> bool:
+    """True if `needle` appears as a contiguous run inside `haystack`."""
+    if not needle or len(needle) > len(haystack):
+        return False
+    first = needle[0]
+    for i in range(len(haystack) - len(needle) + 1):
+        if haystack[i] == first and haystack[i : i + len(needle)] == needle:
+            return True
+    return False
+
+
+def scan_shared_blocks(files: list[Path]) -> list[str]:
+    """Fail if a shared block is missing, multiply-anchored, or duplicated.
+
+    Each anchor must appear in exactly one file (`CANONICAL_FILE`), and the block
+    it wraps must not reappear (anchored or bare) in any other markdown file.
+    Returns a list of human-readable violation messages.
+    """
+    texts = {path: path.read_text(encoding="utf-8") for path in files}
+
+    violations: list[str] = []
+    for anchor in SHARED_ANCHORS:
+        marker = re.compile(rf"<!--\s*{re.escape(anchor)}\s*-->")
+        anchored = [p for p, t in texts.items() if marker.search(t)]
+        rels = sorted(str(p.relative_to(REPO)) for p in anchored)
+
+        if not anchored:
+            violations.append(
+                f"shared block '{anchor}' has no anchor; expected it in {CANONICAL_FILE}"
+            )
+            continue
+        if rels != [CANONICAL_FILE]:
+            violations.append(
+                f"shared block '{anchor}' must be anchored only in {CANONICAL_FILE}, "
+                f"found in: {', '.join(rels)}"
+            )
+
+        canonical_path = next(
+            (p for p in anchored if str(p.relative_to(REPO)) == CANONICAL_FILE), None
+        )
+        if canonical_path is None:
+            continue
+        inner = _extract_anchor_block(texts[canonical_path], anchor)
+        if inner is None:
+            violations.append(
+                f"shared block '{anchor}' in {CANONICAL_FILE} is missing its closing anchor"
+            )
+            continue
+        signature = _significant_lines(inner)
+        for path, text in texts.items():
+            if path == canonical_path:
+                continue
+            if _contains_subsequence(_significant_lines(text), signature):
+                rel = path.relative_to(REPO)
+                violations.append(
+                    f"{rel}: duplicates the '{anchor}' block that is canonical in "
+                    f"{CANONICAL_FILE}; link to {CANONICAL_FILE} instead"
+                )
+    return violations
+
+
+def scan_pointers() -> list[str]:
+    """Fail if an agent file links to a `.md` target that does not exist."""
+    violations: list[str] = []
+    for rel in AGENT_FILES:
+        path = REPO / rel
+        if not path.is_file():
+            continue
+        base = path.parent
+        for line_no, line in enumerate(
+            path.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            for m in MD_LINK.finditer(line):
+                target = m.group(1).split()[0]  # drop any `(url "title")`
+                target = target.split("#", 1)[0]  # drop anchor fragment
+                if not target or "://" in target or target.startswith("mailto:"):
+                    continue
+                if not target.endswith(".md"):
+                    continue
+                if not (base / target).resolve().is_file():
+                    violations.append(
+                        f"{rel}:{line_no}: pointer to '{target}' does not resolve"
+                    )
+    return violations
+
 
 def collect_files() -> list[Path]:
     """Collect every markdown file in the repo, skipping excluded directories."""
@@ -98,7 +219,8 @@ def scan_history_format(path: Path) -> list[tuple[int, int, str]]:
 def main() -> int:
     """Run documentation validation checks on target files."""
     rc = 0
-    for path in collect_files():
+    files = collect_files()
+    for path in files:
         rel = path.relative_to(REPO)
         violations = scan_forbidden(path)
         if path.name == "HISTORY.md":
@@ -107,6 +229,14 @@ def main() -> int:
         for line_no, col, msg in violations:
             print(f"{rel}:{line_no}:{col}: {msg}", file=sys.stderr)
             rc = 1
+
+    for msg in scan_shared_blocks(files):
+        print(msg, file=sys.stderr)
+        rc = 1
+    for msg in scan_pointers():
+        print(msg, file=sys.stderr)
+        rc = 1
+
     if rc == 0:
         print("✅ Docs validation passed.")
     return rc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 
-def pytest_configure(config):  # noqa: ARG001
+def pytest_configure(config):
     """Replace ``pytest_socket.disable_socket`` with a no-op on Windows.
 
     Home Assistant's test conftest (loaded via
@@ -68,6 +68,6 @@ def pytest_configure(config):  # noqa: ARG001
     if sys.platform != "win32":
         return
 
-    import pytest_socket  # noqa: PLC0415
+    import pytest_socket
 
     pytest_socket.disable_socket = lambda **kwargs: None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -44,10 +44,10 @@ from custom_components.unifi_alerts.const import (
 @pytest.fixture(autouse=True, scope="session")
 def _prime_pycares_shutdown_thread() -> None:
     """Warm up the optional aiodns/pycares resolver stack before tests run."""
-    import asyncio  # noqa: PLC0415
+    import asyncio
 
     try:
-        import aiodns  # noqa: PLC0415
+        import aiodns
     except ImportError:
         return
 

--- a/tests/unit/test_console_helper.py
+++ b/tests/unit/test_console_helper.py
@@ -41,7 +41,8 @@ def _load_console() -> ModuleType:
     `sys.path[0]` and the helper is importable as `_console`.
     """
     spec = importlib.util.spec_from_file_location("_console", CONSOLE_PATH)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -480,7 +480,7 @@ class TestPollingErrorPaths:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "categorise_side_effect,authenticate_side_effect",
+        ("categorise_side_effect", "authenticate_side_effect"),
         [
             pytest.param(
                 "auth_error",
@@ -653,7 +653,7 @@ class TestPollingErrorPaths:
 
 class TestRollupOpenCount:
     @pytest.mark.parametrize(
-        "enabled,open_counts,expected_rollup",
+        ("enabled", "open_counts", "expected_rollup"),
         [
             pytest.param(
                 None,
@@ -851,7 +851,7 @@ class TestWatermarks:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "watermark,alarm_times,expected_open_count",
+        ("watermark", "alarm_times", "expected_open_count"),
         [
             pytest.param(
                 datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC),
@@ -906,7 +906,7 @@ class TestSiteConfig:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "site_configured,expected_site",
+        ("site_configured", "expected_site"),
         [
             pytest.param("secondary", "secondary", id="explicit-site-forwarded"),
             pytest.param(None, "default", id="absent-site-defaults-to-default"),
@@ -1019,7 +1019,7 @@ class TestWebhookMidPollRace:
 
         gate = asyncio.Event()  # held open until the test releases it
 
-        async def blocking_categorise_alarms(site):  # noqa: ARG001
+        async def blocking_categorise_alarms(site):
             # Block the poll mid-await until the test fires the webhook
             await gate.wait()
             # Return empty list — the regression scenario: poll sees no alarms
@@ -1081,7 +1081,7 @@ class TestPushAlertOptimisticOpenCount:
     """
 
     @pytest.mark.parametrize(
-        "watermark,expected_open_count",
+        ("watermark", "expected_open_count"),
         [
             pytest.param(None, 1, id="no-watermark"),
             pytest.param(datetime(2020, 1, 1, tzinfo=UTC), 1, id="alert-after-watermark"),
@@ -1315,7 +1315,12 @@ class TestCoordinatorV2Dispatch:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "probe_return_value,probe_side_effect,expected_fetch_count,expected_categorise_count",
+        (
+            "probe_return_value",
+            "probe_side_effect",
+            "expected_fetch_count",
+            "expected_categorise_count",
+        ),
         [
             pytest.param(True, None, 1, 0, id="system-log-available"),
             pytest.param(False, None, 0, 1, id="legacy-fallback-probe-false"),
@@ -1669,7 +1674,7 @@ class TestWatermarkPersistFailureRepair:
 
         with (
             patch("custom_components.unifi_alerts.coordinator.ir") as mock_ir,
-            pytest.raises(OSError),
+            pytest.raises(OSError, match="disk full"),
         ):
             await coord._async_persist_watermarks()
 
@@ -1705,7 +1710,7 @@ class TestWatermarkPersistFailureRepair:
         with patch("custom_components.unifi_alerts.coordinator.ir") as mock_ir:
             # First save raises - repair issue created.
             coord._store.async_save = AsyncMock(side_effect=OSError("disk full"))
-            with pytest.raises(OSError):
+            with pytest.raises(OSError, match="disk full"):
                 await coord._async_persist_watermarks()
             assert mock_ir.async_create_issue.call_count == 1
 

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -96,7 +96,7 @@ class TestUniFiCategoryBinarySensor:
         return entity
 
     @pytest.mark.parametrize(
-        "state,expected",
+        ("state", "expected"),
         [
             pytest.param(make_state(is_alerting=True), True, id="alerting"),
             pytest.param(make_state(is_alerting=False), False, id="not-alerting"),
@@ -108,7 +108,7 @@ class TestUniFiCategoryBinarySensor:
         assert entity.is_on is expected
 
     @pytest.mark.parametrize(
-        "state,expected",
+        ("state", "expected"),
         [
             pytest.param(make_state(enabled=True), True, id="enabled"),
             pytest.param(make_state(enabled=False), False, id="disabled"),
@@ -119,7 +119,7 @@ class TestUniFiCategoryBinarySensor:
         assert entity.available is expected
 
     @pytest.mark.parametrize(
-        "is_alerting,expected_icon",
+        ("is_alerting", "expected_icon"),
         [
             pytest.param(True, CATEGORY_ICONS[CATEGORY_NETWORK_WAN], id="alerting"),
             pytest.param(False, CATEGORY_ICONS_OK[CATEGORY_NETWORK_WAN], id="not-alerting"),
@@ -193,7 +193,7 @@ class TestUniFiRollupBinarySensor:
         return UniFiRollupBinarySensor(coord, entry)
 
     @pytest.mark.parametrize(
-        "is_alerting,expected",
+        ("is_alerting", "expected"),
         [
             pytest.param(True, True, id="alerting"),
             pytest.param(False, False, id="not-alerting"),
@@ -205,7 +205,7 @@ class TestUniFiRollupBinarySensor:
         assert entity.is_on is expected
 
     @pytest.mark.parametrize(
-        "states,expected_icon",
+        ("states", "expected_icon"),
         [
             pytest.param(
                 {CATEGORY_NETWORK_WAN: make_state(is_alerting=True)},
@@ -256,7 +256,7 @@ class TestUniFiCategoryMessageSensor:
         return UniFiCategoryMessageSensor(coord, entry, CATEGORY_NETWORK_WAN)
 
     @pytest.mark.parametrize(
-        "state,expected",
+        ("state", "expected"),
         [
             pytest.param(
                 make_state(last_alert=make_alert(message="WAN went down")),
@@ -272,7 +272,7 @@ class TestUniFiCategoryMessageSensor:
         assert entity.native_value == expected
 
     @pytest.mark.parametrize(
-        "state,expected",
+        ("state", "expected"),
         [
             pytest.param(make_state(enabled=True), True, id="enabled"),
             pytest.param(make_state(enabled=False), False, id="disabled"),
@@ -283,7 +283,7 @@ class TestUniFiCategoryMessageSensor:
         assert entity.available is expected
 
     @pytest.mark.parametrize(
-        "is_alerting,expected_icon",
+        ("is_alerting", "expected_icon"),
         [
             pytest.param(True, CATEGORY_ICONS[CATEGORY_NETWORK_WAN], id="alerting"),
             pytest.param(False, CATEGORY_ICONS_OK[CATEGORY_NETWORK_WAN], id="not-alerting"),
@@ -411,7 +411,7 @@ class TestUniFiAlertEventEntity:
         return entity
 
     @pytest.mark.parametrize(
-        "state,expected",
+        ("state", "expected"),
         [
             pytest.param(make_state(enabled=True), True, id="enabled"),
             pytest.param(make_state(enabled=False), False, id="disabled"),
@@ -546,7 +546,7 @@ class TestUniFiClearCategoryButton:
         assert entity.unique_id == f"entry-abc_{CATEGORY_NETWORK_WAN}_clear"
 
     @pytest.mark.parametrize(
-        "state,expected",
+        ("state", "expected"),
         [
             pytest.param(make_state(enabled=True), True, id="enabled"),
             pytest.param(make_state(enabled=False), False, id="disabled"),
@@ -595,7 +595,7 @@ class TestUniFiClearAllButton:
         entity.coordinator.async_clear_all.assert_awaited_once()
 
     @pytest.mark.parametrize(
-        "states,expected",
+        ("states", "expected"),
         [
             pytest.param(
                 {
@@ -686,7 +686,7 @@ class TestEntityCategories:
     """Verify entity_category assignments for the polish items bundled into v1.3."""
 
     @pytest.mark.parametrize(
-        "entity_cls_path,expected_category",
+        ("entity_cls_path", "expected_category"),
         [
             pytest.param("sensor.UniFiCategoryMessageSensor", "DIAGNOSTIC", id="message-sensor"),
             pytest.param("button.UniFiClearCategoryButton", "CONFIG", id="clear-category-button"),
@@ -745,7 +745,7 @@ class TestTranslationKeys:
     """Verify each entity exposes the expected translation key + placeholders."""
 
     @pytest.mark.parametrize(
-        "entity_cls_path,expected_key",
+        ("entity_cls_path", "expected_key"),
         [
             pytest.param(
                 "binary_sensor.UniFiCategoryBinarySensor",
@@ -788,7 +788,7 @@ class TestTranslationKeys:
         assert entity.translation_placeholders == {}
 
     @pytest.mark.parametrize(
-        "entity_cls_path,expected_key",
+        ("entity_cls_path", "expected_key"),
         [
             pytest.param(
                 "binary_sensor.UniFiRollupBinarySensor", "any_alert", id="rollup-binary-sensor"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import ClassVar
 
 import pytest
 
@@ -139,7 +140,7 @@ class TestNonStringPayloadFields:
     existing str(...) handling already applied to message/key/severity. Regression
     tests for GitHub issue #266."""
 
-    _NON_STRING_VALUES = [123, {"nested": "dict"}, ["a", "list"], None]
+    _NON_STRING_VALUES: ClassVar = [123, {"nested": "dict"}, ["a", "list"], None]
 
     @pytest.mark.parametrize("value", _NON_STRING_VALUES)
     def test_webhook_device_name_non_string_coerced(self, value):
@@ -346,7 +347,7 @@ class TestFromSystemLogEvent:
     """Tests for UniFiAlert.from_system_log_event() — v2 system-log parser."""
 
     # Minimal valid event matching the field-confirmed schema from docs/research/alert-endpoints.md
-    _BASE_EVENT = {
+    _BASE_EVENT: ClassVar = {
         "id": "60a1b2c3d4e5f60718293a4b",
         "category": "SECURITY",
         "event": "THREAT_BLOCKED",
@@ -474,7 +475,7 @@ class TestUnknownSystemLogKeyObservability:
     get warn-once behaviour; pass None to warn on every call.
     """
 
-    _BASE_EVENT = {
+    _BASE_EVENT: ClassVar = {
         "id": "x",
         "category": "SECURITY",
         "key": "UNMAPPED_BUT_HAS_ENUM_FALLBACK",

--- a/tests/unit/test_unifi_client.py
+++ b/tests/unit/test_unifi_client.py
@@ -127,7 +127,7 @@ class TestClassify:
     """Test the static _classify method for event key → category mapping."""
 
     @pytest.mark.parametrize(
-        "key,expected",
+        ("key", "expected"),
         [
             # Access points
             ("EVT_AP_Disconnected", CATEGORY_NETWORK_DEVICE),
@@ -500,7 +500,7 @@ class TestFetchAlarms:
 
         with aioresponses() as m:
             m.get(_list_alarm_url(), status=200, payload=body)
-            with pytest.raises(CannotConnectError, match="api.err.InvalidObject"):
+            with pytest.raises(CannotConnectError, match=r"api\.err\.InvalidObject"):
                 await client.fetch_alarms()
 
     @pytest.mark.asyncio

--- a/tests/unit/test_webhook_handler.py
+++ b/tests/unit/test_webhook_handler.py
@@ -189,7 +189,7 @@ class TestMakeHandler:
         req = make_request(token="tok123")
         await handler(manager._hass, "wh-id", req)
         push_cb.assert_called_once()
-        call_category, call_alert = push_cb.call_args[0]
+        call_category, _call_alert = push_cb.call_args[0]
         assert call_category == CATEGORY_NETWORK_WAN
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Bundles four v1.9.0-milestone CI/tooling improvements: expanding the ruff rule set, aligning and testing the minimum supported Home Assistant version, single-sourcing the agent instruction files, and adding a fast-setup hook for remote agent sessions. One commit per issue.

## Changes

- **`ci: expand the ruff rule set (#281)`** - Enable `ASYNC`, `RUF`, `PT`, `S`, and complexity/size budgets (`C901`, `PLR0911/0912/0913/0915`) in `pyproject.toml`. `ASYNC` had zero violations. `RUF`/`PT` were mostly auto-fixable (parametrize tuples, split assertion, `match=` on broad `pytest.raises`, raw-string regex, `ClassVar` on mutable test-class attrs, stale-noqa removal). `S` (bandit) violations were all false positives, scoped precisely via per-file-ignores and justified `noqa` rather than by weakening the rules (config-key/issue-id name literals in `const.py`, the `?token=` redaction marker in `__init__.py`). Complexity budgets are pinned to the current codebase maxima (measured empirically on this tree, not the pre-refactor code) so the suite passes as-is and can be ratcheted down later.
- **`ci: align minimum supported HA version and test it in CI (#284)`** - Raise the declared floor from `2024.5.0` to `2025.1.0` in `hacs.json` and the README, correct the misleading `requirements-dev.txt` comment about `>=`, and add a pinned minimum-HA leg to the `test` job matrix (`homeassistant==2025.1.0` with the matching `pytest-homeassistant-custom-component==0.13.201`, verified via PyPI metadata) alongside the latest-HA leg. Policy for moving the floor recorded in `docs/DEVELOPING.md`.
- **`docs: single-source agent instructions and slim CLAUDE.md (#286)`** - Move shared facts (purpose, tech stack, build/test commands, repo map) into `AGENTS.md` behind `shared:*` anchors, relocate the release/branching detail from `CLAUDE.md` into a new `docs/RELEASING.md` (CLAUDE.md ~22% smaller), and extend `scripts/validate_docs.py` with a stdlib check that fails `make doc-check` on duplicated shared blocks or unresolved cross-file pointers. No behaviour rule dropped, only relocated.
- **`ci: add SessionStart bootstrap hook for remote agent sessions (#288)`** - Add a `SessionStart` hook in `.claude/settings.json` calling a new `scripts/bootstrap_venv.sh` that provisions `.venv` via `make setup` only when missing, runs async (non-blocking), is gated on `$CLAUDE_CODE_REMOTE`, and is tolerant of install failure. Brings Claude Code web sessions to parity with the Copilot setup workflow; documented per agent surface in `docs/DEVELOPING.md`.

## How to test

```bash
make check   # lint + typecheck + validate + all tests
```

Verified locally against the pinned dev stack (ruff 0.15.16, HA 2025.1.4): `make check` green, ruff clean across `custom_components/` and `tests/`, 650 tests passing at 98.66% coverage. The pinned minimum-HA CI leg is validated by construction and will be exercised on this PR's CI run.

## Checklist

- [x] Linked the issues this PR resolves (`Closes #281`, `Closes #284`, `Closes #286`, `Closes #288`)
- [x] `make check` passes locally
- [x] `CHANGELOG.md` `[Unreleased]` updated (user-visible min-HA-version change from #284; the other three are internal/ci/docs)
- [x] PR title starts with a Conventional Commit prefix (`ci:`)
- [x] PR has a label recognised by `.github/release.yml` (`ci`, applied via pr-labeler)
- [x] `strings.json` and `translations/en.json` are still identical (neither touched)
- [x] No blocking I/O introduced (all network/disk calls are `async`)

Closes #281
Closes #284
Closes #286
Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017QYP5Ao1GxbWbmPuBzWJ82)_