### PR TITLE
docs: audit every doc for drift against current code

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,7 +71,7 @@ Never remove the `?token=` validation check - it is a security hard requirement.
 | `custom_components/unifi_alerts/sensor.py` | Reads `coordinator.data` - check all `@property` accessors |
 | `custom_components/unifi_alerts/event.py` | Reads `coordinator.data` - check all `@property` accessors |
 | `custom_components/unifi_alerts/button.py` | Reads `coordinator.data` - check all `@property` accessors |
-| `tests/unit/test_coordinator.py` | Coordinator unit tests |
+| `tests/unit/coordinator/` | Coordinator unit tests |
 | `tests/integration/test_lifecycle.py` | Full lifecycle integration tests |
 
 ### Modifying `UniFiClientConfig` or `UniFiAlert`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ This is the most common extension task. Every step is required - missing any one
 2. **`strings.json`** - add `"cat_<name>"` key under each config step that lists categories (`categories.data`, `options.data`). Add webhook URL label under `finish.data` and `options.data`. Add the per-category entity display-name keys (binary sensor, last message, open count, event, clear button) under `entity` - these supply the localised entity names that used to come from `CATEGORY_LABELS`.
 3. **`translations/en.json`** - mirror every change made to `strings.json` exactly. Run `scripts/check_translations.py` to validate.
 4. **`binary_sensor.py`**, **`sensor.py`**, **`event.py`**, **`button.py`** - no code changes needed for most categories (platforms iterate `ALL_CATEGORIES` dynamically), but review each if adding a category with unusual display logic.
-5. **`tests/`** - add the new category key to fixtures in `tests/unit/conftest.py` and `tests/integration/conftest.py`. Check `test_coordinator.py` and `test_entities.py` for category-enumerated tests that need updating.
+5. **`tests/`** - add the new category key to fixtures in `tests/unit/conftest.py` and `tests/integration/conftest.py`. Check `tests/unit/coordinator/` and `test_entities.py` for category-enumerated tests that need updating.
 6. Run `make check` - this runs the translation drift check and all tests. Fix any failures before committing.
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -14,9 +14,22 @@ UniFi Controller
     |--- HTTP POST --> WebhookManager --> coordinator.push_alert()
     |    (real-time)                              |
     |                                             v
-    |--- HTTP GET  --> UniFiClient   --> coordinator._async_update_data()
-         (polling)     (aiohttp)                  |
-                                                  v
+    |--- HTTP GET/POST --> UniFiClient --> coordinator._async_update_data()
+         (polling; GET=legacy, POST=v2) --> coordinator._fetch_categorised()
+                                                  |
+                              probe_system_log_endpoint() (once per client,
+                              cached with backoff on repeated failure)
+                                       /                        \
+                              v2 available                v2 unavailable / older firmware
+                                       |                          |
+                    fetch_system_log_alarms()          categorise_alarms()
+                    (timestampFrom watermark,           (legacy /list/alarm,
+                     pagination, status="NEW")           /alarm, /stat/alarm
+                                       |                  probe chain)
+                                       v                          |
+                        UniFiAlert.from_system_log_event()       /
+                                        \                       /
+                                         v                     v
                                     UniFiAlertsCoordinator
                                     +--------------------+
                                     | _category_states   |
@@ -33,6 +46,8 @@ UniFi Controller
                           +-------------------------------+
 ```
 
+The v2 system-log path (Network 9.x+) is the primary polling path on current firmware; it supports `timestampFrom`-based filtering and real pagination, avoiding the legacy endpoint's ~3000-record cap. `_fetch_categorised()` probes for it once per client instance and falls back to the legacy `/list/alarm` probe chain (`categorise_alarms()`) on 404, on a run of transient probe failures, or on older controllers. See `docs/UNIFI.md` for the full endpoint reference.
+
 ## Module responsibilities
 
 ### `models.py`
@@ -40,7 +55,7 @@ UniFi Controller
 Pure data; no HA dependencies. Three dataclasses:
 
 - **`UniFiAlert`**: immutable snapshot of a single alert event. Built from either a webhook payload (`from_webhook_payload`) or a polled alarm record (`from_api_alarm`). Both constructors normalise field names across the inconsistent UniFi API surface.
-- **`CategoryState`**: mutable runtime state for one category. Owned exclusively by the coordinator. Tracks `enabled`, `is_alerting`, `last_alert`, `alert_count` (webhook-incremented), `open_count` (poll-set), `last_cleared_at`. The `last_cleared_at` field doubles as the **acknowledgement watermark**: `open_count` only counts polled alarms newer than this timestamp, so pressing Clear bounds the counter to "since last acknowledged" rather than a lifetime total.
+- **`CategoryState`**: mutable runtime state for one category. Owned exclusively by the coordinator. Tracks `enabled`, `is_alerting`, `last_alert`, `alert_count` (webhook-incremented), `open_count` (poll-set), `last_cleared_at`, and `last_webhook_at`. The `last_cleared_at` field doubles as the **acknowledgement watermark**: `open_count` only counts polled alarms newer than this timestamp, so pressing Clear bounds the counter to "since last acknowledged" rather than a lifetime total. `last_webhook_at` is set only on the push path (never by polling) and feeds `webhook_health()`, which classifies delivery as `never_received` / `healthy` / `stale` (stale after `WEBHOOK_STALE_AFTER_SECONDS`, 7 days) - the basis for the per-category webhook health sensor.
 - **`RuntimeData`**: container stored on `entry.runtime_data`. Holds the coordinator, generated webhook URLs, the unregister callable, and the `UniFiClient` instance.
 
 ### `const.py`
@@ -62,20 +77,23 @@ Stateful async HTTP client. Always uses the UniFi OS API surface:
 
 Auto-detects auth method: tries API key first if present, falls back to username/password session cookies. Auth state is held on the client instance; on `InvalidAuthError` during a poll, the coordinator re-authenticates once and retries.
 
-`fetch_alarms()` walks the alarm-endpoint probe chain `[/list/alarm, /alarm, /stat/alarm]` (newest UniFi Network firmware first); 404 / 400 falls through to the next path, only surfacing an error after every path is exhausted.
+`fetch_alarms()` walks the legacy alarm-endpoint probe chain `[/list/alarm, /alarm, /stat/alarm]` (newest UniFi Network firmware first); 404 / 400 falls through to the next path, only surfacing an error after every path is exhausted. `categorise_alarms()` calls `fetch_alarms()` and groups the results by category via `_classify()`.
 
-`_classify()` is a static method (pure function, easily testable) mapping raw alarm dicts to categories.
+`probe_system_log_endpoint()` checks whether the v2 `/v2/api/site/{site}/system-log/count` endpoint is available (200 = yes, 404 = no, cached until re-auth; a run of transient failures triggers a timed backoff before re-probing). `fetch_system_log_alarms()` pages through `/v2/api/site/{site}/system-log/all` using a `timestampFrom` watermark, filtering to `status == "NEW"` events, up to `MAX_SYSTEM_LOG_PAGES`.
+
+`_classify()` is a static method (pure function, easily testable) mapping raw legacy alarm dicts to categories. `UniFiAlert.from_system_log_event()` is the equivalent parser for the v2 event schema (`message_raw` + `parameters` templating, no `EVT_` prefix on keys).
 
 ### `coordinator.py`
 
 The integration's single source of truth at runtime. Key design decisions:
 
-- **`_category_states` is long-lived**: not re-created on each poll. Polling updates `open_count` and may apply an alert if the category is not already alerting. Webhook pushes update `is_alerting` and `alert_count` immediately.
-- **Auto-clear**: each `push_alert()` cancels any existing `asyncio.Task` for that category and schedules a new one via `hass.async_create_background_task`. Repeated alerts reset the timer rather than stacking.
+- **`_category_states` is long-lived**: not re-created on each poll. Polling updates `open_count` and may set `is_alerting` directly (without incrementing `alert_count`) if the category is not already alerting. Webhook pushes update `is_alerting` and `alert_count` immediately via `apply_alert()`.
+- **Polling path dispatch**: `_fetch_categorised()` probes for the v2 system-log endpoint once per client instance and prefers it when available, computing a `timestampFrom` watermark as the oldest `last_cleared_at` across enabled categories (clamped to `DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS` so an uncleared category cannot grow the fetch window without bound). Falls back to the legacy `categorise_alarms()` path when the probe returns unavailable or fails. Both paths feed `unrecognised_keys` (exposed via diagnostics) for keys that cannot be mapped to a category.
+- **Auto-clear**: each `push_alert()` cancels any existing `asyncio.Task` for that category and schedules a new one via `hass.async_create_background_task` (or `async_create_task` / `asyncio.ensure_future` as fallbacks). Repeated alerts reset the timer rather than stacking. Background task failures are logged via a done-callback instead of being silently swallowed.
 - **`async_set_updated_data()`** is called on webhook push to bypass the polling interval and notify entities immediately.
 - **Polling does not clear `is_alerting`**: only the auto-clear timeout or a button press does. Prevents a polling race where a momentarily empty alarm list falsely clears an active alert.
-- **Acknowledgement watermarks**: `last_cleared_at` on each `CategoryState` is the per-category watermark. Polling counts only alarms newer than the watermark (`open_count` = "alarms since last Clear"). Watermarks persist via `homeassistant.helpers.storage.Store` (keyed per entry) so they survive HA restarts. `async_clear_category()` and `async_clear_all()` are the sole entry points for clearing: cancel auto-clear tasks, call `state.clear()` (advances the watermark), persist, notify. Buttons and services delegate to these methods.
-- **Webhook debounce**: `push_alert()` keeps `_last_push_at` per `(category, alert_key)` and drops repeats inside `WEBHOOK_DEDUP_WINDOW_SECONDS = 5.0`. Stale entries are pruned opportunistically so the dict is bounded by "distinct (category, key) pairs within the window", not the controller's lifetime vocabulary.
+- **Acknowledgement watermarks**: `last_cleared_at` on each `CategoryState` is the per-category watermark. Polling counts only alarms newer than the watermark (`open_count` = "alarms since last Clear"). `push_alert()` also optimistically increments `open_count` for alerts newer than the watermark so the count sensor doesn't lag a full poll interval; the next poll reconciles it to the authoritative value. Watermarks (plus `alert_count`, `last_alert`, and `last_webhook_at`) persist via `homeassistant.helpers.storage.Store` (keyed per entry) so they survive HA restarts - bursts of webhook pushes are debounced through `Store.async_delay_save`, while clears persist immediately and raise a `watermark_persist_failed` repair issue on write failure. `async_clear_category()` and `async_clear_all()` are the sole entry points for clearing: cancel auto-clear tasks, call `state.clear()` (advances the watermark), persist, notify. Buttons and services delegate to these methods.
+- **Webhook debounce**: `push_alert()` keeps `_last_push_at` per `(category, alert.key)` and drops repeats inside `WEBHOOK_DEDUP_WINDOW_SECONDS = 5.0` (keyless alerts, e.g. the empty-body ping, are never deduplicated against each other). Stale entries are pruned opportunistically so the dict is bounded by "distinct (category, key) pairs within the window", not the controller's lifetime vocabulary.
 
 ### `webhook_handler.py`
 
@@ -83,10 +101,12 @@ Registers one HA webhook per enabled category using `homeassistant.components.we
 
 - Scoped to `local_only=True` (LAN only).
 - Accepted on POST only; GET requests are rejected with HTTP 405. UniFi Alarm Manager must be configured to send POST.
-- Bearer-token authenticated: `?token=` query parameter compared against `CONF_WEBHOOK_SECRET` via `hmac.compare_digest`.
+- Fail-closed if no secret is configured: HTTP 500 with an error log pointing the user at Configure to re-save the entry. Never skips the token check.
+- Bearer-token authenticated: `?token=` query parameter compared against `CONF_WEBHOOK_SECRET` via `hmac.compare_digest`; missing or wrong token returns HTTP 401.
 - Body-capped at `WEBHOOK_MAX_BODY_BYTES`; oversized bodies return HTTP 413.
-- Parsed as JSON; decode failures log at WARNING with class name and 80-byte body preview, then fall back to `{}`.
+- Parsed as JSON; a body that fails JSON or UTF-8 decoding is rejected with HTTP 400 (logged at WARNING with class name and 80-byte body preview) rather than falling back to `{}`. An empty body (`{}`) or a body with no recognised fields is accepted and yields `UniFiAlert.from_webhook_payload()`'s "Unknown alert" fallback - only genuine parse failures return 400.
 - DEBUG-payload narrowed to `{category, alert_key, severity, device_name, key}` to avoid surfacing future-firmware fields.
+- The first valid webhook received after a secret rotation clears the `webhook_secret_rotated` repair issue, confirming Alarm Manager was updated with the new token.
 
 The webhook ID format is `unifi_alerts_{suffix}_{category}` when a per-entry `CONF_WEBHOOK_ID_SUFFIX` is present (always set on new entries from v1.4.0 onwards), or `unifi_alerts_{category}` for legacy single-entry installs. IDs are deterministic so they survive HA restarts without re-registration. Multi-entry isolation is the suffix's whole purpose.
 
@@ -94,7 +114,7 @@ The webhook ID format is `unifi_alerts_{suffix}_{category}` when a per-entry `CO
 
 Three-step setup flow:
 
-1. **`async_step_user`**: URL + credentials. Calls `UniFiClient.authenticate()` for validation. Generates `CONF_WEBHOOK_SECRET` (`secrets.token_urlsafe(32)`) and `CONF_WEBHOOK_ID_SUFFIX` (`secrets.token_hex(4)`) on success.
+1. **`async_step_user`**: URL + credentials (with SSDP discovery pre-filling the URL via `async_step_ssdp`). Calls `UniFiClient.authenticate()` for validation. Generates `CONF_WEBHOOK_SECRET` (`secrets.token_urlsafe(32)`) and `CONF_WEBHOOK_ID_SUFFIX` (`secrets.token_hex(4)`) on success.
 2. **`async_step_categories`**: per-category boolean toggles plus `poll_interval`, `clear_timeout`, and `site`.
 3. **`async_step_finish`**: displays generated webhook URLs (with bearer token) for the user to copy into UniFi Alarm Manager.
 
@@ -135,12 +155,18 @@ After setup, `entry.data` contains:
 
 Runtime state lives on `entry.runtime_data` (`RuntimeData` dataclass): coordinator, webhook URLs, unregister callable, client. Not in `hass.data`.
 
-`ConfigFlow.VERSION = 2`. `async_migrate_entry` strips the legacy `is_unifi_os` key from version-1 entries on first load.
+`ConfigFlow.VERSION = 3`. `async_migrate_entry` runs migrations sequentially in `__init__.py`:
+
+- **v1 -> v2**: strips the legacy `is_unifi_os` key.
+- **v2 -> v3**: backfills `webhook_secret` and/or `webhook_id_suffix` on entries that predate v1.4.0 and were never reconfigured via the options flow. If `webhook_id_suffix` was backfilled (changing every webhook URL for that entry), raises a `webhook_urls_changed` repair issue prompting the user to re-paste URLs into Alarm Manager.
 
 ## Tooling and validation
 
 - **`scripts/validate_hacs.py`**: pure-Python HACS manifest pre-flight. Required fields, valid `iot_class`, version format, and the no-core-built-ins guard on `dependencies` (the HACS action rejects what hassfest accepts). Run via `make validate` or by the pre-push hook and CI's `hacs-preflight` job.
-- **`Makefile`**: convenience targets (`make check`, `make lint`, `make typecheck`, `make validate`, `make test`).
+- **`scripts/validate_docs.py`**: pure-Python docs prose linter (bans em-dash, unicode arrows, "bundle/cluster/track/session N" framing; enforces `docs/HISTORY.md` heading format). Run via `make validate`, `make doc-check`, the pre-push hook, and CI.
+- **`scripts/check_translations.py`**: byte-identical check between `strings.json` and `translations/en.json`, cross-platform. Run via `make doc-check` and the CI lint job.
+- **`scripts/bump_version.py`**: release-prep helper for the pre-release / stable / next-cycle version bumps described in `docs/RELEASING.md`.
+- **`Makefile`**: convenience targets (`make check`, `make lint`, `make typecheck`, `make validate`, `make doc-check`, `make test`).
 - **`requirements-dev.txt`**: single source of truth for dev dependencies; used by `make setup` and both CI jobs so local and CI environments are identical.
 
 ## Key invariants

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -44,7 +44,7 @@ If you prefer raw commands:
 
 ```bash
 .venv/bin/pytest tests/ -v                                  # all tests (unit + integration)
-.venv/bin/pytest tests/unit/test_coordinator.py -v          # one file
+.venv/bin/pytest tests/unit/coordinator/test_polling.py -v  # one file
 .venv/bin/pytest tests/integration/ -v -m integration       # integration only
 .venv/bin/pytest tests/ --cov=custom_components/unifi_alerts --cov-report=term-missing
 ```
@@ -69,11 +69,11 @@ tests/integration/                # full HA lifecycle tests using the hass fixtu
 3. Add entries to `CATEGORY_ICONS` and `CATEGORY_ICONS_OK`.
 4. Add the per-category entity display-name keys (binary sensor, last message, open count, event, clear button) to `strings.json` and mirror them in `translations/en.json`. Run `scripts/check_translations.py` to validate.
 5. Map any known UniFi event keys to it in `UNIFI_KEY_TO_CATEGORY`.
-6. Add parametrised test cases to `tests/unit/test_unifi_client.py::TestClassify::test_known_keys`.
+6. Add parametrised test cases to `tests/unit/unifi_client/test_legacy.py::TestClassify::test_known_keys`.
 
 ## Adding new UniFi event keys
 
-When a user reports an unrecognised alert key, add it to `UNIFI_KEY_TO_CATEGORY` in `const.py` and add a corresponding entry to `tests/unit/test_unifi_client.py::TestClassify::test_known_keys`. See `docs/UNIFI.md` for the key taxonomy.
+When a user reports an unrecognised alert key, add it to `UNIFI_KEY_TO_CATEGORY` in `const.py` and add a corresponding entry to `tests/unit/unifi_client/test_legacy.py::TestClassify::test_known_keys`. See `docs/UNIFI.md` for the key taxonomy.
 
 **How users find unrecognised keys without DEBUG logging:** the integration accumulates event keys that could not be matched to any category and exposes them in the HA diagnostics download (Settings > Devices & Services > UniFi Alerts > Download diagnostics, look for `coordinator.unrecognised_keys`). Ask users reporting missed alerts to share their diagnostics file and look for entries there first.
 

--- a/docs/HOMEASSISTANT.md
+++ b/docs/HOMEASSISTANT.md
@@ -4,7 +4,7 @@ Reference for Home Assistant-specific patterns used in this integration. Consult
 
 ## Minimum supported version
 
-**Home Assistant 2024.5** (requires Python 3.12). `ConfigEntry.runtime_data` (introduced in HA 2024.2), `ConfigFlowResult` return type annotation, and `Platform` enum usage require this version or newer.
+**Home Assistant 2025.1** (requires Python 3.12), enforced by `hacs.json` and the pinned minimum-version CI leg. `ConfigEntry.runtime_data` (introduced in HA 2024.2), `ConfigFlowResult` return type annotation, and `Platform` enum usage require this version or newer. See `docs/DEVELOPING.md` § "Minimum supported Home Assistant version" for how the floor is kept in sync across `hacs.json`, CI, and the README.
 
 ## Config entries
 
@@ -14,7 +14,7 @@ This integration uses config entries exclusively; no `configuration.yaml` suppor
 - Runtime state (coordinator, webhook URLs, unregister callable, HTTP client) is stored on `entry.runtime_data` as a `RuntimeData` dataclass (see `models.py`). Do **not** use `hass.data` for per-entry state.
 - `async_unload_entry` must cleanly reverse everything `async_setup_entry` does: unload platforms, unregister webhooks, close the HTTP client.
 - Options changes trigger `_async_update_listener`, which calls `async_reload`; this tears down and re-sets-up the entry cleanly. No partial reload logic needed.
-- Config entry `VERSION = 2` (in `config_flow.py`). `async_migrate_entry` in `__init__.py` strips the legacy `is_unifi_os` key from version-1 entries on first load. Bump `VERSION` and add a migration if the data schema changes again in a breaking way.
+- Config entry `VERSION = 3` (in `config_flow.py`). `async_migrate_entry` in `__init__.py` runs migrations sequentially: v1->v2 strips the legacy `is_unifi_os` key; v2->v3 backfills `webhook_secret`/`webhook_id_suffix` and raises a repair issue if the suffix changed. Bump `VERSION` and add a migration if the data schema changes again in a breaking way.
 
 ## DataUpdateCoordinator
 

--- a/docs/REPO_LAYOUT.md
+++ b/docs/REPO_LAYOUT.md
@@ -47,6 +47,7 @@ tests/
       conftest.py                 # shared client fixtures
       test_legacy.py              # _classify, fetch_alarms probe chain, categorise_alarms, authenticate, close
       test_v2.py                  # probe_system_log_endpoint (cache/backoff), fetch_system_log_alarms (pagination, watermark)
+    test_console_helper.py        # tests scripts/_console.py UTF-8 stdout forcing on Windows
     test_diagnostics.py           # diagnostics platform: redaction, webhook URL exposure, coordinator state
     test_entities.py              # all entity property methods: binary_sensor, sensor, event, button
     test_init.py                  # async_setup_entry / async_unload_entry lifecycle, teardown order, migration (v1->v2->v3)

--- a/docs/REPO_LAYOUT.md
+++ b/docs/REPO_LAYOUT.md
@@ -2,7 +2,7 @@
 
 Per-file annotations describing what lives where, what each module is responsible for, and the load-bearing details that have caused regressions before. CLAUDE.md keeps the rules tight and points here for the detail.
 
-```
+```plain
 custom_components/unifi_alerts/   # integration source
   __init__.py                     # entry setup/teardown, platform forwarding; raises ConfigEntryNotReady on auth or first-refresh failure so HA retries; emits _LOGGER.warning when SSL verification is disabled; unload order: coordinator.async_shutdown() > unregister webhooks > client.close()
   manifest.json                   # HA metadata (domain, version, iot_class); do NOT add "homeassistant" min-version key - it is not in the HA manifest schema and breaks hassfest
@@ -30,15 +30,28 @@ tests/
       __init__.py
       conftest.py                 # shared flow helpers and mock builders (make_flow, make_options_flow, make_reauth_flow)
       test_setup.py               # initial setup flow: user, categories, finish steps
-      test_options.py             # options flow: credential changes, category toggles, regenerate secret
+      test_discovery.py           # SSDP discovery: async_step_ssdp URL pre-fill, dedup
+      test_options_credentials.py # options flow: credential/URL changes, verify_ssl, duplicate-entry guard
+      test_options_helpers.py     # pure options-flow helpers: form parsing, credential overrides, pending-data builders
+      test_options_rotation_validation.py # options flow: regenerate-secret rotation, controller-side validation paths
       test_reauth.py              # reauth flow: async_step_reauth, repair issue
-    test_coordinator.py
+    coordinator/                  # coordinator tests (split from monolithic test_coordinator.py)
+      __init__.py
+      conftest.py                 # shared coordinator fixtures
+      test_autoclear.py           # auto-clear scheduling, cancellation, async_shutdown
+      test_persistence.py         # watermark persist/restore, legacy string format, persist-failed repair issue
+      test_polling.py             # _async_update_data: v2/legacy dispatch, open_count, already-alerting guard, auth retry
+      test_push_dedup.py          # push_alert: apply_alert, webhook dedup window, optimistic open_count increment
+    unifi_client/                 # UniFiClient tests (split from monolithic test_unifi_client.py)
+      __init__.py
+      conftest.py                 # shared client fixtures
+      test_legacy.py              # _classify, fetch_alarms probe chain, categorise_alarms, authenticate, close
+      test_v2.py                  # probe_system_log_endpoint (cache/backoff), fetch_system_log_alarms (pagination, watermark)
     test_diagnostics.py           # diagnostics platform: redaction, webhook URL exposure, coordinator state
     test_entities.py              # all entity property methods: binary_sensor, sensor, event, button
-    test_init.py                  # async_setup_entry / async_unload_entry lifecycle, teardown order
+    test_init.py                  # async_setup_entry / async_unload_entry lifecycle, teardown order, migration (v1->v2->v3)
     test_models.py
     test_services.py
-    test_unifi_client.py
     test_unifi_auth.py            # UniFiAuth in isolation via make_auth() - no full UniFiClient needed
     test_webhook_handler.py       # WebhookManager: register/unregister, token auth, alert dispatch
   integration/                    # full HA lifecycle tests using hass fixture
@@ -52,6 +65,10 @@ tests/
   version-check.yml               # enforces version format per branch: main=X.Y.Z stable, dev=X.Y.Z-preN; runs on push/PR to main and dev
   release.yml                     # triggered by version tags (v1.0.0 stable, v1.0.0-pre1 pre-release); validates tag matches manifest, packages the integration, and publishes via `gh release create --generate-notes` (NOT softprops/action-gh-release - that was removed; do not re-introduce it). Pre-release detection regex uses `grep -qE -- '-pre[0-9]+$'` (the `--` terminator is load-bearing).
   pr-labeler.yml                  # auto-applies a release-notes label to PRs based on Conventional Commit title prefix (feat/fix/docs/tests/ci/security). Manual labels always win. Eliminates the need to follow up `mcp__github__create_pull_request` with a manual `issue_write` label call.
+  pr-guards.yml                   # three PR checks on dev/main PRs: changelog-guard (custom_components/ edits need a CHANGELOG.md bullet), label-guard (PR must carry a release-notes label), history-guard (docs/HISTORY.md only changes on claude/bump-* branches)
+  codeql.yml                      # CodeQL workflow scaffold; Python SAST actually runs via GitHub's CodeQL default setup (Settings > Code security and analysis), not this workflow - see docs/DEVELOPING.md CI overview
+  dependency-audit.yml            # pip-audit dependency vulnerability scan; advisory only (continue-on-error on the audit step); runs on push/PR to dev and main plus a weekly Monday 06:00 UTC schedule
+  copilot-setup-steps.yml         # provisions .venv (make setup) before the GitHub Copilot coding agent starts a session
 .github/
   dependabot.yml                  # tracks the github-actions ecosystem only (weekly, Brisbane TZ); minor+patch grouped, major bumps individual. Required to keep the SHA pins fresh - do NOT remove. Python deps stay manual.
   release.yml                     # release-notes categories file used by `gh release create --generate-notes` to group merged PRs by label (Security / Bug Fixes / Features / Documentation / Tests / CI / Other). DIFFERENT FILE from .github/workflows/release.yml.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,9 +2,9 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-06-19):** v1.8.0 stable shipped. Path to v2.0.0: v1.9.0 (Localisation and Scale), then v2.0.0 (HACS default catalogue). Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
+> **Status (2026-07-06):** v1.9.0 (Localisation and Scale) pre-releases are in progress (currently `1.9.0-pre3`). v2.0.0 (HACS default catalogue) is next. Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
 
-> **Branching model:** see `CLAUDE.md § Branching strategy and versioning`.
+> **Branching model:** see `CLAUDE.md § Branching and releasing`.
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -110,6 +110,7 @@ tests/
       conftest.py
       test_legacy.py
       test_v2.py
+    test_console_helper.py
     test_diagnostics.py
     test_entities.py
     test_init.py

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -39,7 +39,7 @@ Individual commands if you prefer to skip the Makefile:
 
 # Single file (passes on its own: the 95% whole-suite coverage gate lives in
 # `make test` and the CI test job, not in pytest addopts)
-.venv/bin/pytest tests/unit/test_coordinator.py -v
+.venv/bin/pytest tests/unit/coordinator/test_polling.py -v
 
 # Lint
 .venv/bin/ruff check custom_components/
@@ -92,14 +92,30 @@ tests/
   conftest.py              # root shared fixtures; Windows-only event-loop and socket workarounds (no-op on Linux/macOS)
   unit/                    # plain-mock unit tests - no real HA instance
     conftest.py            # MOCK_CONFIG, make_hass(), make_entry(), unit-test fixtures
-    test_coordinator.py
-    test_config_flow.py
+    config_flow/           # config flow tests, split by flow area
+      conftest.py
+      test_setup.py
+      test_discovery.py
+      test_options_credentials.py
+      test_options_helpers.py
+      test_options_rotation_validation.py
+      test_reauth.py
+    coordinator/           # coordinator tests, split by functional area
+      conftest.py
+      test_autoclear.py
+      test_persistence.py
+      test_polling.py
+      test_push_dedup.py
+    unifi_client/          # UniFiClient tests, split legacy vs v2
+      conftest.py
+      test_legacy.py
+      test_v2.py
     test_diagnostics.py
     test_entities.py
     test_init.py
     test_models.py
     test_services.py
-    test_unifi_client.py
+    test_unifi_auth.py
     test_webhook_handler.py
   integration/             # full HA lifecycle tests using hass fixture
     __init__.py            # enables relative imports within the package
@@ -109,6 +125,8 @@ tests/
     test_multi_entry.py    # two config entries active simultaneously
     test_webhook.py        # webhook HTTP dispatch end-to-end
 ```
+
+See `docs/REPO_LAYOUT.md` for what each split-out test file covers.
 
 `tests/unit/` has **no** `__init__.py` so pytest adds it to `sys.path`, enabling bare `from conftest import` in unit test files.
 
@@ -132,13 +150,22 @@ Key conventions:
 
 | File | Coverage |
 |---|---|
-| `test_models.py` | `UniFiAlert` construction from webhook and API payloads, field fallback, 255-char truncation; `CategoryState` init, apply_alert, clear |
-| `test_coordinator.py` | Init; `push_alert`; rollup properties; `cancel_clear`; `async_shutdown`; polling path (no count increment, already-alerting guard); polling error paths (`InvalidAuthError` re-auth, `UpdateFailed`); `rollup_open_count`; `_auto_clear` state transition |
-| `test_unifi_client.py` | `_classify`, `_headers`, `_login_userpass`; `fetch_alarms` (probe-chain fallback, archived filter, 401, ClientError, SSL fail-closed); `categorise_alarms` (grouping, skip unknown, empty); `authenticate` (API key, fallback, no-fallback); `close` (UniFi OS logout, API key skip, unauthenticated skip, logout error logging); migration path from version 1 (`is_unifi_os` stripped) |
-| `test_config_flow.py` | All config-flow steps; duplicate URL guard; options flow defaults; webhook URL fields; error value preservation |
+| `test_models.py` | `UniFiAlert` construction from webhook, legacy API, and v2 system-log payloads, field fallback, 255-char truncation; `CategoryState` init, apply_alert, clear, `webhook_health` |
+| `coordinator/test_polling.py` | `_async_update_data` / `_fetch_categorised`: v2-vs-legacy dispatch, open_count, already-alerting guard; polling error paths (`InvalidAuthError` re-auth, `UpdateFailed`); rollup properties |
+| `coordinator/test_push_dedup.py` | `push_alert`: `apply_alert`, webhook dedup window, optimistic `open_count` increment, unknown-category guard |
+| `coordinator/test_autoclear.py` | `_schedule_clear`, `cancel_clear`, `async_shutdown`, `_auto_clear` state transition |
+| `coordinator/test_persistence.py` | Watermark persist/restore (current and legacy string format), `_build_persist_data`, persist-failed repair issue |
+| `unifi_client/test_legacy.py` | `_classify`, `_headers`, `_login_userpass`; `fetch_alarms` (probe-chain fallback, archived filter, 401, ClientError, SSL fail-closed); `categorise_alarms` (grouping, skip unknown, empty); `authenticate`; `close` |
+| `unifi_client/test_v2.py` | `probe_system_log_endpoint` (cache, 404, transient-failure backoff); `fetch_system_log_alarms` (pagination, `timestampFrom` watermark, `status=NEW` filter, page-cap warning) |
+| `config_flow/test_setup.py` | Initial setup steps: user, categories, finish |
+| `config_flow/test_discovery.py` | SSDP discovery: URL pre-fill, dedup |
+| `config_flow/test_options_credentials.py` | Options flow credential/URL changes, verify_ssl toggle, duplicate-entry guard |
+| `config_flow/test_options_helpers.py` | Pure options-flow helper functions (form parsing, credential overrides, pending-data builders) |
+| `config_flow/test_options_rotation_validation.py` | Options flow secret rotation and controller-side validation paths |
+| `config_flow/test_reauth.py` | Reauth flow: `async_step_reauth`, repair issue |
 | `test_diagnostics.py` | Redaction of sensitive fields; webhook URL exposure; coordinator state; missing-data handling |
-| `test_webhook_handler.py` | `register_all` (category filter, token URL, _registered list); `unregister_all` (cleanup, exception suppression); `_make_handler` (valid token, missing token > 401, wrong token > 401, no secret, malformed JSON fallback, payload field mapping) |
-| `test_init.py` | `async_setup_entry` (happy path, auth failure, first-refresh failure, SSL warning, platform forwarding); `async_unload_entry` (teardown order, failed-unload guard); `_async_update_listener` |
+| `test_webhook_handler.py` | `register_all` (category filter, token URL, _registered list); `unregister_all` (cleanup, exception suppression); `_make_handler` (valid token, missing token > 401, wrong token > 401, no secret > 500, malformed JSON > 400, payload field mapping) |
+| `test_init.py` | `async_setup_entry` (happy path, auth failure, first-refresh failure, SSL warning, platform forwarding); `async_unload_entry` (teardown order, failed-unload guard); `_async_update_listener`; `async_migrate_entry` (v1->v2->v3); `async_remove_entry` |
 | `test_entities.py` | All entity property methods across binary_sensor, sensor, event, button; event-entity increment guard; button press / clear-all logic |
 
 ---
@@ -178,7 +205,7 @@ Mark all integration tests with `@pytest.mark.integration`.
 
 ## Adding a test for a new event key
 
-When adding a new entry to `UNIFI_KEY_TO_CATEGORY`, add a corresponding parametrize case to `tests/unit/test_unifi_client.py::TestClassify::test_known_keys`:
+When adding a new entry to `UNIFI_KEY_TO_CATEGORY`, add a corresponding parametrize case to `tests/unit/unifi_client/test_legacy.py::TestClassify::test_known_keys`:
 
 ```python
 @pytest.mark.parametrize("key,expected", [

--- a/docs/UNIFI.md
+++ b/docs/UNIFI.md
@@ -73,7 +73,7 @@ X-API-Key: your-key-here
 >
 > A path that doesn't exist may return either 404 or `400 api.err.InvalidObject` depending on firmware; both are treated as "try the next path". A genuine 400 (e.g. wrong site name) is surfaced only after every path is exhausted.
 >
-> **If UniFi changes the endpoint again:** add the new path to the head of `alarm_paths` in `unifi_client.py::fetch_alarms`, update the table above, and add a fallback test in `tests/unit/test_unifi_client.py` (see `TestFetchAlarms::test_falls_back_*`).
+> **If UniFi changes the endpoint again:** add the new path to the head of `alarm_paths` in `unifi_client.py::fetch_alarms`, update the table above, and add a fallback test in `tests/unit/unifi_client/test_legacy.py` (see `TestFetchAlarms::test_falls_back_*`).
 
 Default site name is `default`. Multi-site is configurable via `CONF_SITE` per entry; per-category site selection is not implemented (see `docs/ROADMAP.md`, Deferred).
 
@@ -302,7 +302,7 @@ Guidelines:
 
 - Use the shortest prefix that uniquely identifies the event family (e.g. `EVT_GW_Honeypot` not `EVT_GW_HoneypotDetected` if there are multiple honeypot variants).
 - Add a comment with the category group.
-- Add a corresponding test case in `test_unifi_client.py::TestClassify`.
+- Add a corresponding test case in `tests/unit/unifi_client/test_legacy.py::TestClassify`.
 
 ## Known API inconsistencies
 

--- a/info.md
+++ b/info.md
@@ -35,7 +35,7 @@ Aggregates **UniFi Network controller alerts** into Home Assistant sensors, bina
 
 ## Requirements
 
-- Home Assistant 2024.5 or later
+- Home Assistant 2025.1 or later
 - UniFi OS console (UDM, UDM-Pro, UDM-SE, UCG-Ultra, UCG-Max, Cloud Key Gen2+). Classic self-hosted Network Application is not supported.
 - UniFi controller reachable on the same local network as your HA instance
 - Credentials: API key (recommended) or username + password


### PR DESCRIPTION
## Summary

Doc-drift audit per #269. This PR is the second (and final) pass; the first commit on this branch already fixed 6 files, this commit fills the remaining 5 confirmed gaps.

## Per-file ledger

| File | Status | Notes |
|---|---|---|
| `docs/ARCHITECTURE.md` | CHANGED (earlier commit) | v2 system-log data path, `VERSION=3` migrations, `CategoryState` fields incl. `last_webhook_at`/`webhook_health`, persistence contents, webhook dedup, SSDP, tooling list |
| `docs/HOMEASSISTANT.md` | CHANGED (earlier commit) | HA 2025.1, `VERSION=3` migration |
| `docs/REPO_LAYOUT.md` | CHANGED (earlier commit + this commit) | Earlier: split test tree, added codeql/dependency-audit/pr-guards/copilot-setup-steps workflows. This commit: added `test_console_helper.py` to the unit-test tree |
| `docs/TESTING.md` | CHANGED (earlier commit + this commit) | Earlier: split test tree + coverage table. This commit: added `test_console_helper.py` to the unit-test tree |
| `docs/DEVELOPING.md` | CHANGED (earlier commit) | Test path renames |
| `info.md` | CHANGED (earlier commit) | HA 2025.1 |
| `docs/ROADMAP.md` | CHANGED (this commit) | Refreshed status line to v1.9.0-pre3 in progress (2026-07-06), dropped stale "v1.8.0 stable shipped" framing, fixed the `CLAUDE.md § Branching strategy and versioning` cross-reference to the actual section title `Branching and releasing` |
| `docs/UNIFI.md` | CHANGED (this commit) | Repointed two stale `test_unifi_client.py` references to `tests/unit/unifi_client/test_legacy.py` |
| `AGENTS.md` | CHANGED (this commit) | Repointed `test_coordinator.py` reference to `tests/unit/coordinator/` |
| `.github/copilot-instructions.md` | CHANGED (this commit) | Repointed the coverage-table row from `tests/unit/test_coordinator.py` to `tests/unit/coordinator/` |
| `README.md` | VERIFIED CLEAN | HA version already 2025.1; entity/category lists current |
| `SECURITY.md` | VERIFIED CLEAN | No change needed |
| `CLAUDE.md` | VERIFIED CLEAN | No change needed |
| `docs/HISTORY.md` | OUT OF SCOPE | Guarded by `history-guard`; must only change in version-bump PRs |

## Test plan

- [x] `make doc-check` passes (prose linter + HISTORY h2 format + translation drift check)
- [x] Manually re-grepped touched files for remaining stale `test_unifi_client.py` / `test_coordinator.py` / `test_config_flow.py` references - none found (the three hits in `docs/REPO_LAYOUT.md` describing "split from monolithic X" are intentional historical framing, not current paths)

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtFBp5Xv9hcCVnuMy48zha

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtFBp5Xv9hcCVnuMy48zha)_