### PR TITLE
release: bump version to 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-07-06
+
 ### Changed
 
 - Category binary sensors now expose a `last_severity` attribute containing the severity string from the most recent alert (`"LOW"`, `"MEDIUM"`, `"HIGH"`, `"VERY_HIGH"` on v2 controllers; raw webhook severity on legacy controllers). The `any_alert` rollup sensor exposes the same attribute. Automations can condition on this to suppress or escalate alerts by severity without disabling the category. ([#135])
@@ -252,7 +254,8 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 - UCG-Ultra OS detection: two-stage fallback probe added.
 - Config-flow API-key field guidance reworded to be firmware-version agnostic.
 
-[Unreleased]: https://github.com/PHeonix25/unifi_alerts/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/PHeonix25/unifi_alerts/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.9.0
 [1.8.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.8.0
 [1.7.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.7.0
 [1.6.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.6.0

--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -28,5 +28,5 @@
       "modelDescription": "UniFi Dream Machine Pro Max"
     }
   ],
-  "version": "1.9.0-pre3"
+  "version": "1.9.0"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -2,6 +2,23 @@
 
 Dated record of completed work. Newest first. Format per entry: category, short description, PR or commit reference, short why.
 
+## 2026-07-06
+
+- **release**: v1.9.0 tagged. Closes out the v1.9.0 "Localisation and Scale" cycle: a webhook health sensor and setup-failure cleanup, a documented `webhook` runtime dependency, a full CI and tooling hardening pass, and a repo-wide documentation drift audit, on top of everything already shipped in pre1 through pre3.
+- **ci**: bumped `actions/setup-python` from 6.2.0 to 6.3.0 via the grouped Dependabot github-actions update ([#300]).
+- **ci**: single-sourced agent instructions into `AGENTS.md` and slimmed `CLAUDE.md`, added a `SessionStart` bootstrap hook so remote agent sessions install the venv automatically, aligned the declared minimum supported Home Assistant version (2025.1.0) with what CI actually tests via a new pinned-minimum test matrix leg, and expanded the ruff rule set (`ASYNC`, `RUF`, `PT`, `S`, complexity budgets) with justified suppressions ([#301]). Combines #281, #284, #286, #288.
+- **feat**: unregister webhooks and close the client when setup fails after registration, so the automatic retry no longer finds every deterministic webhook ID already taken and silently loads with an empty URL map; documented the runtime dependency on the `webhook` component in the README, since `manifest.json` cannot declare it as a HACS dependency; promoted `webhook_health`/`last_webhook_at` from a buried binary-sensor attribute to a first-class per-category diagnostic sensor entity ([#302]). Closes #265, #267, #270.
+- **tests**: closed five defect-detection gaps where assertions were too weak to catch a real bug even with green CI: auto-clear delay arithmetic, probe backoff duration, auto-clear strength, post-unload webhook dispatch, and same-category push concurrency; each new assertion was verified against a deliberately introduced bug before being finalised ([#303]). Closes #282.
+- **tests**: factored the repeated 5-patch `async_setup_entry` collaborator stack into a shared `conftest.py` helper, deduplicated three identical coordinator test helpers into one, split three oversized test modules (each over 1300 lines) into behaviour-grouped files under 800 lines, and parametrised `TestRegisterAll`'s six near-identical bodies; no behaviour or coverage change ([#304]).
+- **docs**: audited every doc for drift against current code: fixed `ARCHITECTURE.md`, `REPO_LAYOUT.md`, `HOMEASSISTANT.md`, `TESTING.md`, `DEVELOPING.md`, and `info.md`; refreshed `ROADMAP.md`'s status line; repointed stale references to the split test tree in `UNIFI.md`, `AGENTS.md`, `REPO_LAYOUT.md`, `TESTING.md`, and `.github/copilot-instructions.md` ([#305]). Closes #269.
+
+[#300]: https://github.com/PHeonix25/unifi_alerts/pull/300
+[#301]: https://github.com/PHeonix25/unifi_alerts/pull/301
+[#302]: https://github.com/PHeonix25/unifi_alerts/pull/302
+[#303]: https://github.com/PHeonix25/unifi_alerts/pull/303
+[#304]: https://github.com/PHeonix25/unifi_alerts/pull/304
+[#305]: https://github.com/PHeonix25/unifi_alerts/pull/305
+
 ## 2026-07-05
 
 - **release**: v1.9.0-pre3 tagged. Third checkpoint of the v1.9.0 cycle. Headline: five bug fixes closing out real defects found during triage (webhook dedup, non-string payload coercion, entry-removal cleanup, stale `unique_id` on controller URL change), CI now lints and type-checks the `tests/` tree, and all three remaining `v2.0-gate` documentation items land, closing out every `v2.0-gate` issue.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,18 +2,11 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-07-06):** v1.9.0 (Localisation and Scale) pre-releases are in progress (currently `1.9.0-pre3`). v2.0.0 (HACS default catalogue) is next. Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
+> **Status (2026-07-06):** v1.9.0 (Localisation and Scale) shipped stable on 2026-07-06. The next cycle (v1.10.0) is the path forward towards v2.0.0 (HACS default catalogue). Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
 
 > **Branching model:** see `CLAUDE.md § Branching and releasing`.
 
 ---
-
-## v1.9.0: Localisation and Scale
-
-- Capability: severity filtering for noisy categories; a self-healing key map.
-- Process: GitHub Issues is now the work tracker (see `docs/TODO.md` for the taxonomy).
-
-Item-level detail: the `v1.9.0` [milestone](https://github.com/PHeonix25/unifi_alerts/milestones).
 
 ## v2.0.0: HACS default catalogue
 


### PR DESCRIPTION
Promotes the v1.9.0 "Localisation and Scale" cycle from `1.9.0-pre3` to stable `1.9.0`.

- `manifest.json` version bumped to `1.9.0`.
- `CHANGELOG.md` `[Unreleased]` renamed to `[1.9.0] - 2026-07-06`, with a fresh empty `[Unreleased]` inserted above and the `[1.9.0]` link reference added.
- `docs/HISTORY.md` gets a new `## 2026-07-06` block summarising the six PRs merged since `v1.9.0-pre3` (#300-#305).
- `docs/ROADMAP.md` drops the completed `v1.9.0` section and updates the status line to reflect the stable ship date and the path forward to v1.10.0 towards v2.0.0.

Validated locally: `scripts/validate_hacs.py`, `scripts/validate_docs.py`, and `scripts/check_translations.py` all pass.

Next step after this merges: open a `dev` -> `main` PR to promote the release (merge-commit only, never squash).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtFBp5Xv9hcCVnuMy48zha)_