### PR TITLE
fix: remove entities for unselected alert categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Unselected alert categories no longer create entities that sit at Unknown; entities are created only for chosen categories, and orphaned entities from deselected categories are removed on reload.
+
 ## [1.9.0] - 2026-07-06
 
 ### Changed

--- a/custom_components/unifi_alerts/__init__.py
+++ b/custom_components/unifi_alerts/__init__.py
@@ -11,12 +11,14 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.storage import Store
 
 from .const import (
+    ALL_CATEGORIES,
     CONF_CONTROLLER_URL,
     CONF_VERIFY_SSL,
     DEFAULT_VERIFY_SSL,
@@ -84,6 +86,29 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         return True
 
     return True
+
+
+def _prune_disabled_category_entities(
+    hass: HomeAssistant, entry: ConfigEntry, coordinator: UniFiAlertsCoordinator
+) -> None:
+    """Remove registry entries for categories the user did not select.
+
+    Entity creation is gated on the enabled set, but entities registered by a
+    previous configuration - or before this behaviour existed - would otherwise
+    linger as orphaned, unavailable entries. This runs on every setup and reload,
+    so it also cleans up a category the user deselects later.
+    """
+    disabled_prefixes = tuple(
+        f"{entry.entry_id}_{cat}_"
+        for cat in ALL_CATEGORIES
+        if (state := coordinator.get_category_state(cat)) is None or not state.enabled
+    )
+    if not disabled_prefixes:
+        return
+    registry = er.async_get(hass)
+    for reg_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if reg_entry.unique_id.startswith(disabled_prefixes):
+            registry.async_remove(reg_entry.entity_id)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -165,6 +190,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         unregister_webhooks=webhook_manager.unregister_all,
         client=client,
     )
+
+    _prune_disabled_category_entities(hass, entry, coordinator)
 
     try:
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/unifi_alerts/binary_sensor.py
+++ b/custom_components/unifi_alerts/binary_sensor.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
     entities: list[BinarySensorEntity] = [
         UniFiCategoryBinarySensor(coordinator, entry, category)
         for category in ALL_CATEGORIES
-        if coordinator.get_category_state(category) is not None
+        if (state := coordinator.get_category_state(category)) is not None and state.enabled
     ]
     entities.append(UniFiRollupBinarySensor(coordinator, entry))
     async_add_entities(entities)

--- a/custom_components/unifi_alerts/button.py
+++ b/custom_components/unifi_alerts/button.py
@@ -28,7 +28,7 @@ async def async_setup_entry(
     entities: list[ButtonEntity] = [
         UniFiClearCategoryButton(coordinator, entry, category)
         for category in ALL_CATEGORIES
-        if coordinator.get_category_state(category) is not None
+        if (state := coordinator.get_category_state(category)) is not None and state.enabled
     ]
     entities.append(UniFiClearAllButton(coordinator, entry))
     async_add_entities(entities)

--- a/custom_components/unifi_alerts/event.py
+++ b/custom_components/unifi_alerts/event.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
     entities = [
         UniFiAlertEventEntity(coordinator, entry, category)
         for category in ALL_CATEGORIES
-        if coordinator.get_category_state(category) is not None
+        if (state := coordinator.get_category_state(category)) is not None and state.enabled
     ]
     async_add_entities(entities)
 

--- a/custom_components/unifi_alerts/sensor.py
+++ b/custom_components/unifi_alerts/sensor.py
@@ -35,7 +35,8 @@ async def async_setup_entry(
 
     entities: list[SensorEntity] = []
     for category in ALL_CATEGORIES:
-        if coordinator.get_category_state(category) is not None:
+        state = coordinator.get_category_state(category)
+        if state is not None and state.enabled:
             entities.append(UniFiCategoryMessageSensor(coordinator, entry, category))
             entities.append(UniFiCategoryCountSensor(coordinator, entry, category))
             entities.append(UniFiWebhookHealthSensor(coordinator, entry, category))

--- a/tests/integration/test_lifecycle.py
+++ b/tests/integration/test_lifecycle.py
@@ -81,7 +81,7 @@ async def test_clear_buttons_created(hass, entry):
 
 @pytest.mark.integration
 async def test_options_disable_category_makes_sensor_unavailable(hass, entry, mock_unifi_client):
-    """Disabling a category via options + reload → that binary sensor is unavailable."""
+    """Disabling a category via options + reload → that binary sensor is removed."""
     uid = f"{ENTRY_ID}_{CATEGORY_NETWORK_WAN}_binary"
     eid = entity_id_for(hass, "binary_sensor", uid)
     assert hass.states.get(eid).state == "off"  # starts available
@@ -91,4 +91,4 @@ async def test_options_disable_category_makes_sensor_unavailable(hass, entry, mo
     await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get(eid).state == "unavailable"
+    assert hass.states.get(eid) is None  # entity is pruned, not just unavailable

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -931,3 +931,144 @@ class TestTranslationKeys:
             == f"{eid}_{CATEGORY_NETWORK_WAN}_clear"
         )
         assert UniFiClearAllButton(coord, entry).unique_id == f"{eid}_clear_all"
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Platform setup honours enabled flag
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestPlatformSetupHonoursEnabled:
+    """Test that entity platforms only create entities for enabled categories."""
+
+    @pytest.mark.asyncio
+    async def test_binary_sensor_setup_skips_disabled(self):
+        """Disabled categories should not create binary sensor entities."""
+        from custom_components.unifi_alerts import binary_sensor
+
+        states = {
+            CATEGORY_NETWORK_WAN: make_state(category=CATEGORY_NETWORK_WAN, enabled=True),
+            CATEGORY_SECURITY_THREAT: make_state(category=CATEGORY_SECURITY_THREAT, enabled=False),
+        }
+        coord = make_coordinator(states)
+        entry = make_entry()
+        entry.runtime_data = MagicMock(coordinator=coord)
+
+        added: list = []
+        await binary_sensor.async_setup_entry(MagicMock(), entry, lambda e: added.extend(e))
+
+        uids = [e.unique_id for e in added]
+        # enabled category present, disabled absent, aggregate present
+        assert any(CATEGORY_NETWORK_WAN in u for u in uids)
+        assert not any(CATEGORY_SECURITY_THREAT in u for u in uids)
+        assert any(u.endswith("_rollup_binary") for u in uids)
+
+    @pytest.mark.asyncio
+    async def test_sensor_setup_skips_disabled(self):
+        """Disabled categories should not create sensor entities."""
+        from custom_components.unifi_alerts import sensor
+
+        states = {
+            CATEGORY_NETWORK_WAN: make_state(category=CATEGORY_NETWORK_WAN, enabled=True),
+            CATEGORY_SECURITY_THREAT: make_state(category=CATEGORY_SECURITY_THREAT, enabled=False),
+        }
+        coord = make_coordinator(states)
+        entry = make_entry()
+        entry.runtime_data = MagicMock(coordinator=coord)
+
+        added: list = []
+        await sensor.async_setup_entry(MagicMock(), entry, lambda e: added.extend(e))
+
+        uids = [e.unique_id for e in added]
+        # enabled category present (3 entities), disabled absent, aggregate present
+        assert any(CATEGORY_NETWORK_WAN in u for u in uids)
+        assert not any(CATEGORY_SECURITY_THREAT in u for u in uids)
+        assert any(u.endswith("_rollup_count") for u in uids)
+
+    @pytest.mark.asyncio
+    async def test_event_setup_skips_disabled(self):
+        """Disabled categories should not create event entities."""
+        from custom_components.unifi_alerts import event
+
+        states = {
+            CATEGORY_NETWORK_WAN: make_state(category=CATEGORY_NETWORK_WAN, enabled=True),
+            CATEGORY_SECURITY_THREAT: make_state(category=CATEGORY_SECURITY_THREAT, enabled=False),
+        }
+        coord = make_coordinator(states)
+        entry = make_entry()
+        entry.runtime_data = MagicMock(coordinator=coord)
+
+        added: list = []
+        await event.async_setup_entry(MagicMock(), entry, lambda e: added.extend(e))
+
+        uids = [e.unique_id for e in added]
+        # enabled category present, disabled absent
+        assert any(CATEGORY_NETWORK_WAN in u for u in uids)
+        assert not any(CATEGORY_SECURITY_THREAT in u for u in uids)
+
+    @pytest.mark.asyncio
+    async def test_button_setup_skips_disabled(self):
+        """Disabled categories should not create button entities."""
+        from custom_components.unifi_alerts import button
+
+        states = {
+            CATEGORY_NETWORK_WAN: make_state(category=CATEGORY_NETWORK_WAN, enabled=True),
+            CATEGORY_SECURITY_THREAT: make_state(category=CATEGORY_SECURITY_THREAT, enabled=False),
+        }
+        coord = make_coordinator(states)
+        entry = make_entry()
+        entry.runtime_data = MagicMock(coordinator=coord)
+
+        added: list = []
+        await button.async_setup_entry(MagicMock(), entry, lambda e: added.extend(e))
+
+        uids = [e.unique_id for e in added]
+        # enabled category present, disabled absent, aggregate present
+        assert any(CATEGORY_NETWORK_WAN in u for u in uids)
+        assert not any(CATEGORY_SECURITY_THREAT in u for u in uids)
+        assert any(u.endswith("_clear_all") for u in uids)
+
+    def test_prune_removes_disabled_and_keeps_enabled_and_aggregate(self):
+        """The prune function should remove only disabled-category registry entries."""
+        from unittest.mock import patch
+
+        from custom_components.unifi_alerts import _prune_disabled_category_entities
+
+        coord = make_coordinator(
+            {
+                CATEGORY_NETWORK_WAN: make_state(category=CATEGORY_NETWORK_WAN, enabled=True),
+                CATEGORY_SECURITY_THREAT: make_state(
+                    category=CATEGORY_SECURITY_THREAT, enabled=False
+                ),
+            }
+        )
+        entry = make_entry()
+
+        def reg_entry(uid: str):
+            m = MagicMock()
+            m.unique_id = uid
+            m.entity_id = uid
+            return m
+
+        entries = [
+            reg_entry(f"{entry.entry_id}_{CATEGORY_NETWORK_WAN}_binary"),  # keep
+            reg_entry(f"{entry.entry_id}_{CATEGORY_SECURITY_THREAT}_binary"),  # remove
+            reg_entry(f"{entry.entry_id}_{CATEGORY_SECURITY_THREAT}_count"),  # remove
+            reg_entry(f"{entry.entry_id}_rollup_binary"),  # keep (aggregate)
+        ]
+        registry = MagicMock()
+        registry.async_remove = MagicMock()
+
+        import custom_components.unifi_alerts as init_mod
+
+        with (
+            patch.object(init_mod.er, "async_get", return_value=registry),
+            patch.object(init_mod.er, "async_entries_for_config_entry", return_value=entries),
+        ):
+            _prune_disabled_category_entities(MagicMock(), entry, coord)
+
+        removed = {c.args[0] for c in registry.async_remove.call_args_list}
+        assert removed == {
+            f"{entry.entry_id}_{CATEGORY_SECURITY_THREAT}_binary",
+            f"{entry.entry_id}_{CATEGORY_SECURITY_THREAT}_count",
+        }


### PR DESCRIPTION
## Summary

Unselected alert categories no longer create entities that sit at Unknown. Entities are now created only for chosen categories, and orphaned entities from deselected categories are removed on reload.

## Changes

- **`custom_components/unifi_alerts/__init__.py`**: Added `_prune_disabled_category_entities()` function that removes registry entries for disabled categories on every setup/reload. Called during `async_setup_entry()` before platform setup.
- **`custom_components/unifi_alerts/binary_sensor.py`**: Updated entity creation to check both that category state exists AND is enabled.
- **`custom_components/unifi_alerts/sensor.py`**: Updated entity creation to check both that category state exists AND is enabled.
- **`custom_components/unifi_alerts/button.py`**: Updated entity creation to check both that category state exists AND is enabled.
- **`custom_components/unifi_alerts/event.py`**: Updated entity creation to check both that category state exists AND is enabled.
- **`tests/unit/test_entities.py`**: Added comprehensive test suite (`TestPlatformSetupHonoursEnabled`) covering entity creation filtering and pruning behavior for all platforms.
- **`tests/integration/test_lifecycle.py`**: Updated test expectation: disabling a category now removes the entity entirely rather than leaving it unavailable.
- **`CHANGELOG.md`**: Documented the fix in the `[Unreleased]` section.

## How to test

```bash
make check   # lint + typecheck + validate + all tests
```

The new unit tests in `TestPlatformSetupHonoursEnabled` verify:
- Binary sensor, sensor, event, and button platforms skip disabled categories
- Aggregate entities (rollup) are still created even when categories are disabled
- The pruning function correctly removes only disabled-category entries while preserving enabled ones and aggregates

Integration test updated to verify entities are removed (not just unavailable) when a category is deselected and the config entry is reloaded.

## Checklist

- [x] `make check` passes locally
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] PR title starts with `fix:` (Conventional Commit)
- [x] No blocking I/O introduced (all calls are async)

Closes #309

https://claude.ai/code/session_01GmCvdYbZ9QBQvykCoNi5RQ