### PR TITLE
release: bump version to v2.0.0-pre1

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -28,5 +28,5 @@
       "modelDescription": "UniFi Dream Machine Pro Max"
     }
   ],
-  "version": "1.9.0"
+  "version": "2.0.0-pre1"
 }


### PR DESCRIPTION
## Summary

Kicks off development of v2 and moves the manifest to `v2.0.0-pre1`!

## Changes

- Manifest updated

## How to test

```bash
make check   # lint + typecheck + validate + all tests
```

## Checklist

- [x] Linked the issue this PR resolves (`Closes #NN` in the description), if one exists
- [x] `make check` passes locally
- [x] `CHANGELOG.md` `[Unreleased]` updated (user-visible changes only; skip for internal/ci/docs)
- [x] PR title starts with a Conventional Commit prefix (`feat:`, `fix:`, `docs:`, `ci:`, `tests:`, `security:`, `chore:`, `refactor:`)
- [x] PR has a label recognised by `.github/release.yml` (applied automatically for CC-prefixed titles via pr-labeler)
- [x] `strings.json` and `translations/en.json` are still identical (if either was touched)
- [x] New category fully registered: `const.py`, `strings.json`, `translations/en.json` (if adding a category)
- [x] No blocking I/O introduced (all network/disk calls are `async`)
