### PR TITLE
ci: split ruff into its own fast job, route mypy through run_typecheck.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           category: integration
 
-  lint:
-    name: Lint & type-check
+  ruff:
+    name: Ruff lint & format check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -53,14 +53,28 @@ jobs:
         with:
           python-version: "3.14"
           cache: pip
-      - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+      - name: Install lint dependencies
+        run: pip install -r requirements-lint.txt
       - name: Ruff lint & format check (custom_components/ + tests/)
         run: python scripts/run_lint.py
-      - name: Mypy type check
-        run: mypy custom_components/unifi_alerts --ignore-missing-imports
       - name: Check strings.json matches translations/en.json
         run: python scripts/check_translations.py
+
+  typecheck:
+    name: Mypy type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3
+        with:
+          python-version: "3.14"
+          cache: pip
+      # mypy needs the full Home Assistant stack installed so it type-checks
+      # against real HA types rather than falling back to `Any` everywhere.
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Mypy type check
+        run: python scripts/run_typecheck.py
 
   test:
     name: Run tests (${{ matrix.name }})


### PR DESCRIPTION
## Summary

Closes #285

- Split the `lint` job into two: a `ruff` job that installs only `requirements-lint.txt` (no Home Assistant) and runs `scripts/run_lint.py` plus the translations drift check, and a `typecheck` job that keeps the full `requirements-dev.txt` install (mypy needs real HA types, not `Any` under `ignore_missing_imports`) and now runs `scripts/run_typecheck.py` instead of an inline `mypy` invocation.
- Dropped the CLI `--ignore-missing-imports` flag from CI, which duplicated `ignore_missing_imports = true` already set in `pyproject.toml`.
- Added a comment on the `typecheck` job explaining why it still needs the full HA stack.
- Every `uses:` reference is untouched and stays pinned to its existing 40-char SHA.

## Changes

- `.github/workflows/ci.yml`: `lint` job replaced by `ruff` (fast, `requirements-lint.txt`) and `typecheck` (full stack, `scripts/run_typecheck.py`).

## How to test

```bash
make check   # lint + typecheck + validate + test
```

This sandbox only has Python 3.13 available, and `requirements-dev.txt` now requires Home Assistant `>=2026.7.1` which needs Python `>=3.14.2` (per #311), so the full `make check` couldn't be run end-to-end here. Verified locally with what's available:
- `python scripts/run_lint.py` against a `requirements-lint.txt`-only venv: ruff check + format both pass.
- `.github/workflows/ci.yml` YAML parses cleanly.
- Confirmed no other workflow, doc, or badge references the old `lint` job name.

CI will exercise the new `ruff`/`typecheck` jobs end-to-end on Python 3.14.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #285` above)
- [ ] `make check` passes locally — not fully runnable in this sandbox (no Python 3.14); `scripts/run_lint.py` verified independently, full suite left to CI
- [x] PR title starts with a Conventional Commit prefix (`ci:`)
- [x] PR has a label recognised by `.github/release.yml` (expect `pr-labeler` to apply `ci` from the title prefix)
- [x] `strings.json`/`translations/en.json` untouched
- [x] No `custom_components/` changes, so no `CHANGELOG.md` entry needed
- [x] Every `uses:` reference still pinned to a full 40-char SHA (none were touched)


---
_Generated by [Claude Code](https://claude.ai/code/session_018nogVMjyzJksSpC5djqRBS)_