### PR TITLE
docs: add CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+# Contributor Covenant Code of Conduct
+
+## Our Commitment
+
+We as members, contributors, and leaders commit to making participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We commit to acting and interacting in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologising to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behaviour include:
+
+- The use of sexualised language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behaviour and will take appropriate and fair corrective action in response to any behaviour that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the community leaders responsible for enforcement via @PHeonix25 on GitHub. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact:** Use of inappropriate language or other behaviour deemed unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behaviour was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact:** A violation through a single incident or series of actions.
+
+**Consequence:** A warning with consequences for continued behaviour. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact:** A serious violation of community standards, including sustained inappropriate behaviour.
+
+**Consequence:** A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact:** Demonstrating a pattern of violation of community standards, including sustained inappropriate behaviour, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at <https://www.contributor-covenant.org/version/2_1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at <https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to UniFi Alerts
+
+Thanks for your interest in contributing! This guide covers the essentials. For detailed walkthroughs, refer to the full developer documentation.
+
+---
+
+## Local setup
+
+```bash
+git clone https://github.com/PHeonix25/unifi_alerts
+cd unifi_alerts
+git config core.hooksPath .githooks   # enable the pre-push gate
+make setup                             # python3.14 -m venv .venv + pip install
+```
+
+The pre-push hook at `.githooks/pre-push` runs the full test and lint suite automatically before every push. Do not bypass it with `--no-verify`.
+
+See [docs/DEVELOPING.md](docs/DEVELOPING.md) for the full setup instructions, including agent session bootstrap and Windows-specific notes.
+
+---
+
+## Pull request rules
+
+Every PR must satisfy the following checks. They all run mechanically in CI; no surprises on submission.
+
+### Branch target
+
+- **Target `dev`, never `main`.** The stable branch is only updated from `dev` via a merge commit. All feature and fix branches must target `dev`.
+
+### Title format
+
+- **Start with a Conventional Commit prefix:** `feat:`, `fix:`, `docs:`, `ci:`, `tests:`, `security:`, `chore:`, or `refactor:`.
+- Example: `fix: add unit test for webhook token validation`
+
+The `pr-labeler` workflow auto-applies release-notes labels based on your prefix. If you skip the prefix, apply a label manually (see below).
+
+### Labels
+
+- **Every PR must carry at least one release-notes label** so auto-generated release notes sort it into the right category. Valid labels: `security`, `bug` / `fix`, `enhancement` / `feat`, `documentation`, `tests`, `ci`, `github-actions`, `dependencies`.
+- PRs with Conventional Commit titles are labelled automatically.
+- If you skip the CC prefix, apply a label by hand.
+
+The `label-guard` workflow enforces this check.
+
+### CHANGELOG
+
+- **For user-visible changes to `custom_components/`,** add a bullet to the `[Unreleased]` section in `CHANGELOG.md`. Use past tense: "Added support for X", "Fixed Y bug", etc. Reference the PR number at the end: `([#NN])`.
+- **Exemptions:** internal changes, test-only changes, documentation changes, or changes with the `skip-changelog` label applied. Use `skip-changelog` when a code change genuinely has no user-visible effect.
+
+The `changelog-guard` workflow enforces this check.
+
+### Code quality
+
+- Run `make check` locally before pushing. This runs lint, type check, HACS preflight, and all tests:
+
+```bash
+make check       # full suite: lint + typecheck + validate + tests
+make lint        # ruff only
+make typecheck   # mypy only
+make test        # pytest only
+```
+
+For doc-only PRs (no `custom_components/` changes), use `make doc-check` instead; it skips the full test suite.
+
+See [docs/TESTING.md](docs/TESTING.md) for test layout, conventions, and how to run individual test files.
+
+### strings.json and translations/en.json
+
+- These two files must remain identical. If your change touches either, edit both together. The lint check will catch drift.
+
+---
+
+## Further reading
+
+| Document | When to read |
+|---|---|
+| [docs/DEVELOPING.md](docs/DEVELOPING.md) | Local setup, running checks, CI overview, branching and releases |
+| [docs/TESTING.md](docs/TESTING.md) | Test directory structure, test conventions, running tests |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | How the modules fit together |
+| [docs/HOMEASSISTANT.md](docs/HOMEASSISTANT.md) | Home Assistant specific patterns: coordinators, entities, config flow |
+| [docs/UNIFI.md](docs/UNIFI.md) | UniFi API, auth methods, alarm payload taxonomy |
+| [docs/REPO_LAYOUT.md](docs/REPO_LAYOUT.md) | Per-file responsibilities |
+| [CLAUDE.md](CLAUDE.md) | Non-negotiable constraints and coding conventions |
+
+Questions? Open an [issue](https://github.com/PHeonix25/unifi_alerts/issues) or post in the PR discussion thread.

--- a/README.md
+++ b/README.md
@@ -208,16 +208,17 @@ All data stays on your local network; the integration does not communicate with 
 
 ## Contributing
 
-Issues and PRs welcome. The full developer guide lives in [docs/DEVELOPING.md](docs/DEVELOPING.md): local setup, running checks, the CI pipeline, branching strategy, and release process.
+Issues and pull requests welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, branch rules, and PR requirements. We are committed to maintaining a respectful community - see [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).
 
-A short tour of the rest of the documentation:
+For deeper dives:
 
-| Document | When to read |
+| Document | Purpose |
 |---|---|
-| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | How the modules fit together |
-| [docs/HOMEASSISTANT.md](docs/HOMEASSISTANT.md) | HA-specific patterns: coordinators, entities, config flow |
-| [docs/UNIFI.md](docs/UNIFI.md) | UniFi API, auth methods, alarm payload taxonomy |
+| [docs/DEVELOPING.md](docs/DEVELOPING.md) | Full developer guide: setup, CI overview, branching strategy, release process |
 | [docs/TESTING.md](docs/TESTING.md) | Test layout and conventions |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | How the modules fit together |
+| [docs/HOMEASSISTANT.md](docs/HOMEASSISTANT.md) | Home Assistant specific patterns |
+| [docs/UNIFI.md](docs/UNIFI.md) | UniFi API and alarm payload taxonomy |
 | [docs/REPO_LAYOUT.md](docs/REPO_LAYOUT.md) | Per-file responsibilities |
-| [docs/LOCALISATION.md](docs/LOCALISATION.md) | Localisation maturity bar, audit history, and how to contribute a new language |
+| [docs/LOCALISATION.md](docs/LOCALISATION.md) | Contributing a new language |
 | [CLAUDE.md](CLAUDE.md) | Non-negotiable constraints and coding conventions |


### PR DESCRIPTION
## Summary

Add CONTRIBUTING.md with dev setup and PR rules that CI enforces, and CODE_OF_CONDUCT.md (Contributor Covenant v2.1). Update README to link both files instead of duplicating information.

## Changes

- **CONTRIBUTING.md**: Local setup (`make setup`, pre-push hook), PR rules (Conventional Commit titles, release-notes labels, CHANGELOG expectations, target `dev` branch), links to deeper docs (DEVELOPING.md, TESTING.md, etc.)
- **CODE_OF_CONDUCT.md**: Contributor Covenant v2.1 with contact at @PHeonix25 
- **README.md**: Contributing section now links to CONTRIBUTING.md and CODE_OF_CONDUCT.md instead of restating them

## Checklist

- [x] `make doc-check` passes
- [x] No CHANGELOG.md update (documentation-only change)
- [x] Links all existing relevant docs instead of duplicating

Closes #289

---
_Generated by [Claude Code](https://claude.ai/code/session_011iCy8HGLVXxUgghtrwQkVZ)_