### PR TITLE
fix: anchor Clear watermark to controller clock, not HA host clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Unselected alert categories no longer create entities that sit at Unknown; entities are created only for chosen categories, and orphaned entities from deselected categories are removed on reload.
+- Clearing a category now anchors the acknowledgement watermark to the newest alarm timestamp already known for that category (falling back to the HA clock only when none has ever been seen), instead of the HA host clock. This keeps `open_count` correct when the UniFi controller's clock and the HA host clock drift apart. ([#268])
 
 ## [1.9.0] - 2026-07-06
 
@@ -336,6 +337,7 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#265]: https://github.com/PHeonix25/unifi_alerts/issues/265
 [#270]: https://github.com/PHeonix25/unifi_alerts/issues/270
 [#282]: https://github.com/PHeonix25/unifi_alerts/issues/282
+[#268]: https://github.com/PHeonix25/unifi_alerts/issues/268
 [#283]: https://github.com/PHeonix25/unifi_alerts/issues/283
 [#228]: https://github.com/PHeonix25/unifi_alerts/issues/228
 [#311]: https://github.com/PHeonix25/unifi_alerts/pull/311

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -31,7 +31,7 @@ from .const import (
     STORAGE_VERSION_WATERMARKS,
     WEBHOOK_DEDUP_WINDOW_SECONDS,
 )
-from .models import CategoryState, UniFiAlert, UniFiClientConfig
+from .models import CategoryState, UniFiAlert, UniFiClientConfig, ensure_aware
 from .unifi_auth import CannotConnectError, InvalidAuthError
 from .unifi_client import UniFiClient
 
@@ -195,7 +195,7 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         """
         if not alerts:
             return
-        newest_seen = max(a.received_at for a in alerts)
+        newest_seen = max(ensure_aware(a.received_at) for a in alerts)
         if state.last_alarm_received_at is None or newest_seen > state.last_alarm_received_at:
             state.last_alarm_received_at = newest_seen
 

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -153,6 +153,7 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
                 state = self._category_states[cat]
                 if not state.enabled:
                     continue
+                self._track_newest_seen(state, alerts)
                 # Count only alarms newer than last_cleared_at so open_count reads as
                 # "since last Clear", not a lifetime total.
                 watermark = state.last_cleared_at
@@ -183,6 +184,20 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
                 state.open_count = 0
 
         return self._category_states
+
+    @staticmethod
+    def _track_newest_seen(state: CategoryState, alerts: list[UniFiAlert]) -> None:
+        """Advance ``last_alarm_received_at`` to the newest polled alarm, if any.
+
+        Feeds the Clear watermark (see ``CategoryState.clear()``) so it can be
+        anchored to the controller's own timeline instead of the HA host
+        clock (#268).
+        """
+        if not alerts:
+            return
+        newest_seen = max(a.received_at for a in alerts)
+        if state.last_alarm_received_at is None or newest_seen > state.last_alarm_received_at:
+            state.last_alarm_received_at = newest_seen
 
     async def _fetch_categorised(self) -> dict[str, list[UniFiAlert]]:
         """Fetch and categorise alarms using v2 or legacy path as appropriate.

--- a/custom_components/unifi_alerts/models.py
+++ b/custom_components/unifi_alerts/models.py
@@ -42,6 +42,17 @@ class UniFiClientConfig(TypedDict, total=False):
     site: str
 
 
+def ensure_aware(dt: datetime) -> datetime:
+    """Treat a naive datetime as UTC.
+
+    Real alarms are always tz-aware (`from_api_alarm`, `from_system_log_event`,
+    and `from_webhook_payload` all stamp UTC-aware timestamps); this only
+    guards the `last_alarm_received_at` comparisons against a naive value
+    slipping in (e.g. from a test fixture) and raising on `>` comparison.
+    """
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)
+
+
 def _render_message_raw(message_raw: str, parameters: dict[str, Any]) -> str:
     """Substitute {KEY} placeholders in message_raw with values from parameters.
 
@@ -286,8 +297,9 @@ class CategoryState:
         self.is_alerting = True
         self.last_alert = alert
         self.alert_count += 1
-        if self.last_alarm_received_at is None or alert.received_at > self.last_alarm_received_at:
-            self.last_alarm_received_at = alert.received_at
+        received_at = ensure_aware(alert.received_at)
+        if self.last_alarm_received_at is None or received_at > self.last_alarm_received_at:
+            self.last_alarm_received_at = received_at
 
     def clear(self) -> None:
         """Acknowledge everything seen so far for this category.

--- a/custom_components/unifi_alerts/models.py
+++ b/custom_components/unifi_alerts/models.py
@@ -275,15 +275,34 @@ class CategoryState:
     # only on the push path (never by polling) so it reflects webhook
     # connectivity specifically, which powers the onboarding/health signal.
     last_webhook_at: datetime | None = None
+    # Newest `received_at` seen for this category, from either the push or
+    # polling path. Tracked so Clear can anchor `last_cleared_at` to the
+    # controller's own timeline instead of the HA host clock (#268): using
+    # this as the watermark keeps the open_count comparison
+    # controller-clock vs controller-clock, immune to HA/controller skew.
+    last_alarm_received_at: datetime | None = None
 
     def apply_alert(self, alert: UniFiAlert) -> None:
         self.is_alerting = True
         self.last_alert = alert
         self.alert_count += 1
+        if self.last_alarm_received_at is None or alert.received_at > self.last_alarm_received_at:
+            self.last_alarm_received_at = alert.received_at
 
     def clear(self) -> None:
+        """Acknowledge everything seen so far for this category.
+
+        The watermark is anchored to the controller's own timeline: it is set
+        to the newest `received_at` already observed for this category (via
+        push or poll), falling back to the HA host clock only when no alarm
+        has ever been seen. See docs/UNIFI.md "Clock assumption".
+        """
         self.is_alerting = False
-        self.last_cleared_at = datetime.now(UTC)
+        self.last_cleared_at = (
+            self.last_alarm_received_at
+            if self.last_alarm_received_at is not None
+            else datetime.now(UTC)
+        )
 
     def webhook_health(self, now: datetime | None = None) -> str:
         """Classify webhook delivery health for this category.

--- a/docs/UNIFI.md
+++ b/docs/UNIFI.md
@@ -257,9 +257,11 @@ What the integration **cannot** do (controller-side state is read-only):
 
 - There is no documented write API to archive individual Network alarms. The community-discovered `POST /cmd/evtmgt {"cmd":"archive-all-alarms"}` returns `api.err.NotFound` on current firmware.
 - There is no UI option to dismiss or archive individual alarms.
-- Pressing Clear in HA resets HA-local state only (`is_alerting -> false`, `alert_count -> 0`, `last_cleared_at -> now`). The underlying alarms remain on the controller indefinitely. Without the watermark, `open_count` would grow to thousands without ever decreasing.
+- Pressing Clear in HA resets HA-local state only (`is_alerting -> false`, `alert_count -> 0`, `last_cleared_at -> newest known alarm, or now if none seen yet`). The underlying alarms remain on the controller indefinitely. Without the watermark, `open_count` would grow to thousands without ever decreasing.
 
-> **Design implication:** `open_count` without a watermark is a meaningless lifetime counter. The integration persists `last_cleared_at` per category via `homeassistant.helpers.storage.Store`. Polling counts only alarms newer than that timestamp; pressing Clear advances the timestamp to now.
+> **Design implication:** `open_count` without a watermark is a meaningless lifetime counter. The integration persists `last_cleared_at` per category via `homeassistant.helpers.storage.Store`. Polling counts only alarms newer than that timestamp.
+>
+> **Clock assumption:** `last_cleared_at` is anchored to the controller's own clock, not the HA host clock. On Clear, the watermark is set to the newest `received_at` among alarms already known for that category (poll or webhook), falling back to `datetime.now(UTC)` only when no alarm has ever been seen. This keeps the `open_count` comparison controller-clock vs controller-clock, so it is unaffected by clock skew between HA and the controller. The webhook path is the one exception: a webhook's `received_at` is stamped by HA at receipt time (there is no controller timestamp in the Alarm Manager payload), so a webhook-only alert's watermark contribution is still HA-clock-based by necessity.
 
 ### Event entities and webhooks
 

--- a/tests/unit/coordinator/test_clock_skew.py
+++ b/tests/unit/coordinator/test_clock_skew.py
@@ -1,0 +1,137 @@
+"""Tests for the Clear watermark under controller/HA clock skew (#268).
+
+Prior behaviour stamped the watermark from the HA host clock
+(``datetime.now(UTC)``) while polled alarms carry ``received_at`` timestamps
+parsed from the controller's own clock. When the two clocks disagree, that
+mismatch either re-counts already-acknowledged alarms (controller fast) or
+silently drops genuinely new ones (controller slow). The fix anchors the
+watermark to the newest ``received_at`` already known for the category,
+falling back to the HA clock only when nothing has ever been seen, making
+the ``open_count``/``is_alerting`` comparison controller-clock vs
+controller-clock, immune to skew in either direction.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.unifi_alerts.const import CATEGORY_NETWORK_WAN
+from custom_components.unifi_alerts.models import UniFiAlert
+
+from .conftest import make_alert, make_coordinator, make_full_coordinator, make_hass_and_client
+
+
+def _mock_store(coord) -> None:
+    coord._store = MagicMock()
+    coord._store.async_load = AsyncMock(return_value=None)
+    coord._store.async_save = AsyncMock()
+
+
+class TestClockSkewAcrossClear:
+    """Controller clock offset must not affect open_count/is_alerting correctness."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "controller_offset",
+        [
+            pytest.param(timedelta(minutes=15), id="controller-clock-fast"),
+            pytest.param(timedelta(minutes=-15), id="controller-clock-slow"),
+        ],
+    )
+    async def test_clear_watermark_excludes_already_seen_alarms_regardless_of_skew(
+        self, controller_offset
+    ):
+        """Clearing must exclude every alarm already known, whether the
+        controller's clock is ahead of or behind the HA host clock.
+
+        The controller's timeline is simulated by offsetting every
+        ``received_at`` from a real "now" by ``controller_offset``: the
+        offset itself never needs to be measured or corrected (out of scope
+        per #268); only the comparison must be internally consistent.
+        """
+        controller_now = datetime.now(UTC) + controller_offset
+        hass, client = make_hass_and_client()
+
+        first_batch = [
+            UniFiAlert(
+                category=CATEGORY_NETWORK_WAN,
+                message="first",
+                received_at=controller_now - timedelta(minutes=10),
+            ),
+            UniFiAlert(
+                category=CATEGORY_NETWORK_WAN,
+                message="second",
+                received_at=controller_now - timedelta(minutes=5),
+            ),
+        ]
+        client.categorise_alarms = AsyncMock(return_value={CATEGORY_NETWORK_WAN: first_batch})
+
+        coord = make_full_coordinator(hass, client)
+        _mock_store(coord)
+
+        # First poll discovers both alarms.
+        await coord._async_update_data()
+        state = coord.get_category_state(CATEGORY_NETWORK_WAN)
+        assert state.is_alerting is True
+        assert state.open_count == 2
+
+        # Clear: watermark must be anchored to the newest alarm already
+        # known (controller_now - 5min), not to the real HA clock.
+        await coord.async_clear_category(CATEGORY_NETWORK_WAN)
+        assert state.is_alerting is False
+        assert state.last_cleared_at == controller_now - timedelta(minutes=5)
+
+        # Re-polling the same (already-seen) alarms must not re-count them
+        # or re-assert is_alerting, no matter which way the clock is skewed.
+        await coord._async_update_data()
+        assert state.open_count == 0
+        assert state.is_alerting is False
+
+        # A genuinely new alarm on the controller's own timeline must still
+        # be picked up after Clear.
+        new_alarm = UniFiAlert(
+            category=CATEGORY_NETWORK_WAN,
+            message="new after clear",
+            received_at=controller_now + timedelta(minutes=1),
+        )
+        client.categorise_alarms = AsyncMock(
+            return_value={CATEGORY_NETWORK_WAN: [*first_batch, new_alarm]}
+        )
+        await coord._async_update_data()
+        assert state.open_count == 1
+        assert state.is_alerting is True
+        assert state.last_alert is new_alarm
+
+    @pytest.mark.asyncio
+    async def test_clear_falls_back_to_ha_clock_when_nothing_ever_seen(self):
+        """With no alarm ever observed, Clear must fall back to datetime.now(UTC)."""
+        hass, client = make_hass_and_client()
+        coord = make_full_coordinator(hass, client)
+        _mock_store(coord)
+
+        before = datetime.now(UTC)
+        await coord.async_clear_category(CATEGORY_NETWORK_WAN)
+        after = datetime.now(UTC)
+
+        state = coord.get_category_state(CATEGORY_NETWORK_WAN)
+        assert state.last_cleared_at is not None
+        assert before <= state.last_cleared_at <= after
+
+    @pytest.mark.asyncio
+    async def test_webhook_push_advances_watermark_source_too(self):
+        """push_alert (webhook path) must also feed last_alarm_received_at,
+        so a Clear right after a webhook-only alert anchors to that alert's
+        received_at rather than HA now."""
+        coord = make_coordinator()
+        _mock_store(coord)
+
+        alert = make_alert(CATEGORY_NETWORK_WAN, "webhook alert")
+        coord.push_alert(CATEGORY_NETWORK_WAN, alert)
+
+        await coord.async_clear_category(CATEGORY_NETWORK_WAN)
+
+        state = coord.get_category_state(CATEGORY_NETWORK_WAN)
+        assert state.last_cleared_at == alert.received_at

--- a/tests/unit/coordinator/test_clock_skew.py
+++ b/tests/unit/coordinator/test_clock_skew.py
@@ -19,7 +19,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.unifi_alerts.const import CATEGORY_NETWORK_WAN
-from custom_components.unifi_alerts.models import UniFiAlert
+from custom_components.unifi_alerts.coordinator import UniFiAlertsCoordinator
+from custom_components.unifi_alerts.models import CategoryState, UniFiAlert
 
 from .conftest import make_alert, make_coordinator, make_full_coordinator, make_hass_and_client
 
@@ -135,3 +136,65 @@ class TestClockSkewAcrossClear:
 
         state = coord.get_category_state(CATEGORY_NETWORK_WAN)
         assert state.last_cleared_at == alert.received_at
+
+    @pytest.mark.asyncio
+    async def test_naive_polled_timestamp_does_not_crash_watermark_tracking(self):
+        """A naive (tz-less) ``received_at`` from a polled alarm must not raise
+        when compared against an already-aware ``last_alarm_received_at``.
+
+        Regression: production alarms are always tz-aware, but polling after
+        an already-alerting webhook push exercised a bare `>` comparison
+        between whatever the poll returned and the webhook-derived (aware)
+        watermark source, raising ``TypeError: can't compare offset-naive and
+        offset-aware datetimes`` if the two ever disagreed on tzinfo.
+        """
+        hass, client = make_hass_and_client()
+        naive_alert = UniFiAlert(
+            category=CATEGORY_NETWORK_WAN,
+            message="naive timestamp",
+            received_at=datetime(2024, 1, 1, 10, 0),  # no tzinfo
+        )
+        client.categorise_alarms = AsyncMock(return_value={CATEGORY_NETWORK_WAN: [naive_alert]})
+        coord = make_full_coordinator(hass, client)
+
+        webhook_alert = make_alert(CATEGORY_NETWORK_WAN, "webhook alert")
+        coord.push_alert(CATEGORY_NETWORK_WAN, webhook_alert)
+
+        # Must not raise.
+        await coord._async_update_data()
+
+        state = coord.get_category_state(CATEGORY_NETWORK_WAN)
+        assert state.last_alarm_received_at == webhook_alert.received_at
+
+
+class TestWatermarkSourceEdgeCases:
+    """Direct coverage of the branches that only trigger on out-of-order timestamps."""
+
+    def test_apply_alert_does_not_regress_last_alarm_received_at_on_older_alert(self):
+        """A later-arriving alert with an older received_at must not move
+        last_alarm_received_at backwards."""
+        state = CategoryState(category=CATEGORY_NETWORK_WAN)
+        newer = UniFiAlert(
+            category=CATEGORY_NETWORK_WAN,
+            message="newer",
+            received_at=datetime(2024, 6, 1, 12, 0, tzinfo=UTC),
+        )
+        older = UniFiAlert(
+            category=CATEGORY_NETWORK_WAN,
+            message="older",
+            received_at=datetime(2024, 6, 1, 11, 0, tzinfo=UTC),
+        )
+
+        state.apply_alert(newer)
+        state.apply_alert(older)
+
+        assert state.last_alarm_received_at == newer.received_at
+
+    def test_track_newest_seen_noop_on_empty_alerts(self):
+        """_track_newest_seen must leave last_alarm_received_at untouched
+        when handed an empty alert list."""
+        state = CategoryState(category=CATEGORY_NETWORK_WAN)
+
+        UniFiAlertsCoordinator._track_newest_seen(state, [])
+
+        assert state.last_alarm_received_at is None


### PR DESCRIPTION
## Summary

Anchors the per-category Clear watermark (`last_cleared_at`) to the UniFi controller's own clock instead of the HA host clock, so `open_count`/`is_alerting` stay correct across a Clear regardless of clock skew between HA and the controller.

## Changes

- `custom_components/unifi_alerts/models.py`: `CategoryState` gains `last_alarm_received_at`, the newest `received_at` seen for the category via either the push or polling path. `apply_alert()` advances it on every webhook push. `clear()` now sets `last_cleared_at` to that value, falling back to `datetime.now(UTC)` only when no alarm has ever been seen.
- `custom_components/unifi_alerts/coordinator.py`: `_async_update_data()` calls a new `_track_newest_seen()` helper per category so polled alarms also advance `last_alarm_received_at`. The persisted-watermark restore path (`async_restore_watermarks`) is unchanged, it still reads/writes `last_cleared_at` as an ISO timestamp.
- `docs/UNIFI.md`: documents the new clock-anchoring behaviour and the one exception (a webhook-only alert's `received_at` is still HA-stamped at receipt, since the Alarm Manager payload carries no controller timestamp).
- `CHANGELOG.md`: `[Unreleased]` bullet.
- `tests/unit/coordinator/test_clock_skew.py`: new tests simulating a controller clock offset in both directions (fast and slow) across a Clear, plus the no-alarm-ever-seen fallback and the webhook-only path.

Also fixes a handful of `except A, B:` clauses in `models.py`, `coordinator.py`, and `unifi_auth.py` that had been reformatted into unparenthesized [PEP 758](https://peps.python.org/pep-0758/) style by ruff (this repo's target is Python 3.14) — no functional change, just confirming ruff's format output is preserved after my edits touched those files.

## How to test

```bash
make check   # lint + typecheck + validate + all tests
```

Note: this sandbox only has Python 3.11-3.13 available (no network path to install 3.14, which both `homeassistant` and this repo's `mypy`/`pytest` targets require), so `make typecheck` and `make test` could not be run locally. `make lint`, `make validate`, and `python3 scripts/validate_docs.py` all pass. CI runs the full suite on Python 3.14.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #268` in the description)
- [ ] `make check` passes locally (not run in this sandbox, see note above; relying on CI)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] PR title starts with a Conventional Commit prefix (`fix:`)
- [ ] PR has a label recognised by `.github/release.yml` (should be applied automatically by pr-labeler)
- [x] `strings.json` and `translations/en.json` are still identical (neither touched)
- [x] No blocking I/O introduced (all network/disk calls are `async`)

Closes #268


---
_Generated by [Claude Code](https://claude.ai/code/session_01LUvqRwxGdxiaePV9k3kBFJ)_