### PR TITLE
test: migrate unifi_client HTTP tests from aioresponses to aioclient_mock

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,6 @@
 #   moves, update hacs.json, that CI leg, and the README requirements section in
 #   the same PR.
 aiohttp>=3.9.0
-aioresponses==0.7.9
 async-upnp-client>=0.42.0
 homeassistant>=2026.7.1
 mypy==2.1.0

--- a/tests/unit/unifi_client/conftest.py
+++ b/tests/unit/unifi_client/conftest.py
@@ -1,51 +1,51 @@
 """Shared HTTP-test helpers for UniFiClient tests.
 
-HTTP-hitting tests use aioresponses to mock at the aiohttp transport layer
-(``aiohttp.ClientSession._request``) rather than hand-building fake response
-objects. This means they exercise the real ``aiohttp.ClientSession``
-request/response plumbing (headers, status codes, JSON parsing, exception
-raising) instead of a fabricated surface that could drift from real aiohttp
-behaviour, and assertions can be made against the outbound request itself
-(URL, method, headers, body) via aioresponses' request history. See issue
-#229.
+HTTP-hitting tests use pytest-homeassistant-custom-component's aioclient_mock
+fixture (AiohttpClientMocker) to mock at the aiohttp transport layer
+(``aiohttp.ClientSession._request``). This is Home Assistant core's own test
+double, used by HA core's integration test suites; it is structurally immune
+to aiohttp internals changing underneath it (unlike aioresponses, which
+constructs a real ``aiohttp.ClientResponse`` and broke on aiohttp 3.14 — see
+issue #312). Assertions can still be made against the outbound request itself
+(URL, method, headers, body) via the call recorder below. See issue #229 for
+the original rationale that led to aioresponses, and #312 for the migration.
 """
 
 from __future__ import annotations
 
-import inspect
+import asyncio
 from collections.abc import Generator
-from types import SimpleNamespace
+from dataclasses import dataclass, field
+from typing import Any
 
-import aiohttp
-import aioresponses.core as _aioresponses_core
 import pytest
-from aiohttp.resolver import ThreadedResolver
-from aioresponses import aioresponses
+from pytest_homeassistant_custom_component.test_util.aiohttp import (
+    AiohttpClientMocker,
+    AiohttpClientMockResponse,
+)
 
 from custom_components.unifi_alerts.unifi_client import UNIFI_OS_NETWORK_PREFIX, UniFiClient
-
-# aiohttp>=3.14 made `stream_writer` a required keyword-only argument on
-# ClientResponse.__init__ (previously `writer` served double duty for both the
-# streaming task and the output-size lookup). aioresponses 0.7.9 - the latest
-# release on PyPI - still only passes `writer=None`, which raises
-# `TypeError: ClientResponse.__init__() missing 1 required keyword-only
-# argument: 'stream_writer'` on aiohttp>=3.14. The CI test matrix runs both a
-# "latest HA" leg (aiohttp>=3.14, needs the shim) and a "minimum HA" leg
-# (older aiohttp, does NOT accept stream_writer at all - passing it there
-# would itself raise a TypeError), so detect the parameter instead of
-# assuming either way. Remove once aioresponses ships a fix upstream.
-if "stream_writer" in inspect.signature(_aioresponses_core.ClientResponse.__init__).parameters:
-
-    class _ClientResponseCompat(_aioresponses_core.ClientResponse):
-        def __init__(self, *args, **kwargs):
-            kwargs.setdefault("stream_writer", SimpleNamespace(output_size=0))
-            super().__init__(*args, **kwargs)
-
-    _aioresponses_core.ClientResponse = _ClientResponseCompat
 
 BASE_URL = "https://192.168.1.1"
 LOGIN_URL = f"{BASE_URL}/api/auth/login"
 LOGOUT_URL = f"{BASE_URL}/api/auth/logout"
+
+
+@dataclass
+class RecordedCall:
+    """One outbound HTTP request captured from the mocked ClientSession.
+
+    aioclient_mock.mock_calls records only (method, url, data, headers), which
+    drops kwargs tests need to assert on (e.g. ssl=), so requests are captured
+    via a thin wrapper around ClientSession._request instead.
+    """
+
+    method: str
+    url: str
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+_recorded_calls: list[RecordedCall] = []
 
 # Sessions created by make_client() during the current test, closed by the
 # _close_client_sessions autouse fixture below. pytest-homeassistant-custom-component
@@ -53,27 +53,25 @@ LOGOUT_URL = f"{BASE_URL}/api/auth/logout"
 # aiohttp.ClientSession schedules its own cleanup on the loop's default
 # executor, which trips that check — so every session made here must be
 # closed before the test ends.
-_created_sessions: list[aiohttp.ClientSession] = []
+_created_sessions: list = []
 
 
-def make_client(config: dict | None = None) -> UniFiClient:
-    """Build a UniFiClient wired to a real aiohttp.ClientSession.
+def make_client(aioclient_mock: AiohttpClientMocker, config: dict | None = None) -> UniFiClient:
+    """Build a UniFiClient wired to aioclient_mock via a real aiohttp.ClientSession.
 
-    aioresponses patches ClientSession._request, so no real socket is ever
-    opened here; using the real session (instead of a MagicMock) means these
-    tests exercise actual aiohttp request/response plumbing rather than a
-    hand-built double of it. The session is tracked for teardown by
+    aioclient_mock.create_session() builds a real aiohttp.ClientSession with its
+    _request bound method replaced, so no real socket is ever opened and no
+    connector/resolver setup is needed. The session is tracked for teardown by
     _close_client_sessions.
-
-    Uses a TCPConnector pinned to ThreadedResolver rather than aiohttp's
-    aiodns-backed default. No DNS lookup ever actually happens (aioresponses
-    intercepts before the connector runs), but constructing and then closing
-    an AsyncResolver spins up pycares' global shutdown thread on first use —
-    a daemon thread that outlives the test and trips the HA test harness's
-    "no lingering threads" check. ThreadedResolver has no such side effect.
     """
-    connector = aiohttp.TCPConnector(resolver=ThreadedResolver())
-    session = aiohttp.ClientSession(connector=connector)
+    session = aioclient_mock.create_session(asyncio.get_running_loop())
+    mocked_request = session._request
+
+    async def _recording_request(method: str, url: Any, **kwargs: Any):
+        _recorded_calls.append(RecordedCall(method.upper(), str(url), kwargs))
+        return await mocked_request(method, url, **kwargs)
+
+    object.__setattr__(session, "_request", _recording_request)
     _created_sessions.append(session)
     cfg = config or {
         "username": "admin",
@@ -91,6 +89,14 @@ async def _close_client_sessions() -> Generator[None]:
         session = _created_sessions.pop()
         if not session.closed:
             await session.close()
+
+
+@pytest.fixture(autouse=True)
+def _clear_recorded_calls() -> Generator[None]:
+    """Reset the outbound-request recorder between tests."""
+    _recorded_calls.clear()
+    yield
+    _recorded_calls.clear()
 
 
 def list_alarm_url(site: str = "default") -> str:
@@ -113,18 +119,38 @@ def system_log_url(site: str = "default") -> str:
     return f"{BASE_URL}{UNIFI_OS_NETWORK_PREFIX}/v2/api/site/{site}/system-log/all"
 
 
-def find_calls(m: aioresponses, method: str, url: str) -> list:
-    """Return the recorded request history for one (method, url) pair.
+def find_calls(method: str, url: str) -> list[RecordedCall]:
+    """Return the recorded request history for one (method, url) pair."""
+    return [c for c in _recorded_calls if c.method == method.upper() and c.url == url]
 
-    Compares by string rather than by yarl.URL equality so this stays robust
-    to aioresponses' internal key normalisation across versions.
+
+def total_calls() -> int:
+    return len(_recorded_calls)
+
+
+def queue_responses(
+    aioclient_mock: AiohttpClientMocker,
+    method: str,
+    url: str,
+    responses: list[dict[str, Any]],
+) -> None:
+    """Register a sequence of distinct responses for repeated calls to one (method, url).
+
+    aioclient_mock never consumes a matched registration — every call to a
+    given (method, url) is answered by the *first* matching registration
+    forever. That makes it unsuitable, out of the box, for tests exercising a
+    URL that must answer differently across successive calls (e.g. a
+    transient failure followed by success, or successive pagination
+    responses). This registers a single mock whose side_effect hands out
+    ``responses`` one at a time, in order, one per call; a call made after the
+    queue is exhausted raises AssertionError, same as an unmatched request
+    would.
     """
-    calls: list = []
-    for (recorded_method, recorded_url), call_list in m.requests.items():
-        if recorded_method == method and str(recorded_url) == url:
-            calls.extend(call_list)
-    return calls
+    queue = list(responses)
 
+    async def _next(method: str, url: Any, data: Any) -> AiohttpClientMockResponse:
+        if not queue:
+            raise AssertionError(f"No more queued responses for {method.upper()} {url}")
+        return AiohttpClientMockResponse(method=method, url=url, **queue.pop(0))
 
-def total_calls(m: aioresponses) -> int:
-    return sum(len(v) for v in m.requests.values())
+    aioclient_mock.request(method, url, side_effect=_next)

--- a/tests/unit/unifi_client/test_legacy.py
+++ b/tests/unit/unifi_client/test_legacy.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
-from aioresponses import aioresponses
+from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 
 from custom_components.unifi_alerts.const import (
     CATEGORY_NETWORK_CLIENT,
@@ -151,8 +151,8 @@ class TestFetchAlarms:
     """Tests for UniFiClient.fetch_alarms."""
 
     @pytest.mark.asyncio
-    async def test_returns_non_archived_alarms(self):
-        client = make_client()
+    async def test_returns_non_archived_alarms(self, aioclient_mock: AiohttpClientMocker):
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         body = {
             "meta": {"rc": "ok"},
@@ -161,63 +161,64 @@ class TestFetchAlarms:
                 {"key": "EVT_AP_Disconnected", "archived": True},  # should be filtered
             ],
         }
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload=body)
-            alarms = await client.fetch_alarms()
+        aioclient_mock.get(list_alarm_url(), status=200, json=body)
+        alarms = await client.fetch_alarms()
         assert len(alarms) == 1
         assert alarms[0]["key"] == "EVT_GW_WANTransition"
 
     @pytest.mark.asyncio
-    async def test_filters_out_archived_alarms(self):
-        client = make_client()
+    async def test_filters_out_archived_alarms(self, aioclient_mock: AiohttpClientMocker):
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         body = {"meta": {"rc": "ok"}, "data": [{"key": "EVT_GW_WANTransition", "archived": True}]}
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload=body)
-            alarms = await client.fetch_alarms()
+        aioclient_mock.get(list_alarm_url(), status=200, json=body)
+        alarms = await client.fetch_alarms()
         assert alarms == []
 
     @pytest.mark.asyncio
-    async def test_401_raises_invalid_auth_and_clears_authenticated(self):
-        client = make_client()
+    async def test_401_raises_invalid_auth_and_clears_authenticated(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=401)
-            with pytest.raises(InvalidAuthError):
-                await client.fetch_alarms()
+        aioclient_mock.get(list_alarm_url(), status=401)
+        with pytest.raises(InvalidAuthError):
+            await client.fetch_alarms()
         assert client._auth._authenticated is False
 
     @pytest.mark.asyncio
-    async def test_client_error_raises_cannot_connect(self):
-        client = make_client()
+    async def test_client_error_raises_cannot_connect(self, aioclient_mock: AiohttpClientMocker):
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.get(list_alarm_url(), exception=aiohttp.ClientConnectionError("unreachable"))
-            with pytest.raises(CannotConnectError):
-                await client.fetch_alarms()
+        aioclient_mock.get(list_alarm_url(), exc=aiohttp.ClientConnectionError("unreachable"))
+        with pytest.raises(CannotConnectError):
+            await client.fetch_alarms()
 
     @pytest.mark.asyncio
-    async def test_client_error_message_is_class_name_not_url(self):
+    async def test_client_error_message_is_class_name_not_url(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """CannotConnectError message must be the exception class name, not str(err).
 
         aiohttp exceptions can embed the controller URL (including credentials) in
         their string representation.  Using type(err).__name__ prevents credential
         leaks via HA log output.
         """
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.get(
-                list_alarm_url(),
-                exception=aiohttp.ClientConnectionError("https://admin:secret@192.168.1.1/api"),
-            )
-            with pytest.raises(CannotConnectError) as exc_info:
-                await client.fetch_alarms()
+        aioclient_mock.get(
+            list_alarm_url(),
+            exc=aiohttp.ClientConnectionError("https://admin:secret@192.168.1.1/api"),
+        )
+        with pytest.raises(CannotConnectError) as exc_info:
+            await client.fetch_alarms()
         assert "secret" not in str(exc_info.value)
         assert exc_info.value.args[0] == "ClientConnectionError"
 
     @pytest.mark.asyncio
-    async def test_response_error_preserves_status_code_in_message(self):
+    async def test_response_error_preserves_status_code_in_message(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """A ClientResponseError (e.g. 503) must surface its status code in the error.
 
         Before this test existed, the handler wrapped all aiohttp errors as
@@ -226,12 +227,11 @@ class TestFetchAlarms:
         status code. Status code only — no URL — to avoid leaking credentials
         that may be embedded in a misconfigured controller URL.
         """
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=503)
-            with pytest.raises(CannotConnectError) as exc_info:
-                await client.fetch_alarms()
+        aioclient_mock.get(list_alarm_url(), status=503)
+        with pytest.raises(CannotConnectError) as exc_info:
+            await client.fetch_alarms()
 
         message = str(exc_info.value)
         assert "503" in message, f"Status code must be in the error message; got: {message!r}"
@@ -240,42 +240,40 @@ class TestFetchAlarms:
         )
 
     @pytest.mark.asyncio
-    async def test_tries_list_alarm_path_first(self):
+    async def test_tries_list_alarm_path_first(self, aioclient_mock: AiohttpClientMocker):
         """fetch_alarms must try /list/alarm before any older path.
 
         /list/alarm is the newest UniFi Network endpoint (9.x+); the older /alarm
         and /stat/alarm paths are kept as fallbacks so the integration keeps
         working on older firmware. See docs/UNIFI.md § "Alarm API endpoint".
         """
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload={"meta": {"rc": "ok"}, "data": []})
-            await client.fetch_alarms()
-            list_calls = find_calls(m, "GET", list_alarm_url())
-            total = total_calls(m)
+        aioclient_mock.get(list_alarm_url(), status=200, json={"meta": {"rc": "ok"}, "data": []})
+        await client.fetch_alarms()
+        list_calls = find_calls("GET", list_alarm_url())
+        total = total_calls()
 
         assert len(list_calls) == 1, "Expected exactly one GET to /list/alarm"
         # Only one call expected — /list/alarm worked, no fallback needed
         assert total == 1
 
     @pytest.mark.asyncio
-    async def test_fetch_alarms_uses_proxy_network_path(self):
+    async def test_fetch_alarms_uses_proxy_network_path(self, aioclient_mock: AiohttpClientMocker):
         """fetch_alarms must always use the /proxy/network prefix for all alarm paths."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         expected_url = list_alarm_url()
         assert "/proxy/network/api/s/default/" in expected_url
 
-        with aioresponses() as m:
-            m.get(expected_url, status=200, payload={"meta": {"rc": "ok"}, "data": []})
-            await client.fetch_alarms()
-            calls = find_calls(m, "GET", expected_url)
+        aioclient_mock.get(expected_url, status=200, json={"meta": {"rc": "ok"}, "data": []})
+        await client.fetch_alarms()
+        calls = find_calls("GET", expected_url)
 
         assert len(calls) == 1, f"fetch_alarms must GET {expected_url} exactly once"
 
     @pytest.mark.asyncio
-    async def test_falls_back_through_full_path_chain(self):
+    async def test_falls_back_through_full_path_chain(self, aioclient_mock: AiohttpClientMocker):
         """fetch_alarms must walk the full path chain when each preceding path is missing.
 
         Order is: /list/alarm (newest) → /alarm → /stat/alarm (oldest). A 404 on each
@@ -283,78 +281,79 @@ class TestFetchAlarms:
         against future regressions if someone reorders or drops an entry from
         ``alarm_paths`` without updating both code and docs.
         """
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=404)
-            m.get(alarm_url(), status=404)
-            m.get(stat_alarm_url(), status=200, payload={"meta": {"rc": "ok"}, "data": []})
-            result = await client.fetch_alarms()
+        aioclient_mock.get(list_alarm_url(), status=404)
+        aioclient_mock.get(alarm_url(), status=404)
+        aioclient_mock.get(stat_alarm_url(), status=200, json={"meta": {"rc": "ok"}, "data": []})
+        result = await client.fetch_alarms()
 
-            assert len(find_calls(m, "GET", list_alarm_url())) == 1
-            assert len(find_calls(m, "GET", alarm_url())) == 1
-            assert len(find_calls(m, "GET", stat_alarm_url())) == 1
-
+        assert len(find_calls("GET", list_alarm_url())) == 1
+        assert len(find_calls("GET", alarm_url())) == 1
+        assert len(find_calls("GET", stat_alarm_url())) == 1
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_next_path_on_404(self):
+    async def test_falls_back_to_next_path_on_404(self, aioclient_mock: AiohttpClientMocker):
         """fetch_alarms must try the next path when the current one returns 404.
 
         Verifies the basic fallback contract for any single-step transition in the
         chain. The first path returns 404, the second returns success.
         """
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=404)
-            m.get(alarm_url(), status=200, payload={"meta": {"rc": "ok"}, "data": []})
-            result = await client.fetch_alarms()
-            total = total_calls(m)
+        aioclient_mock.get(list_alarm_url(), status=404)
+        aioclient_mock.get(alarm_url(), status=200, json={"meta": {"rc": "ok"}, "data": []})
+        result = await client.fetch_alarms()
+        total = total_calls()
 
         assert total == 2, "Expected exactly two GET calls (primary + fallback)"
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_next_path_on_400_invalid_object(self):
+    async def test_falls_back_to_next_path_on_400_invalid_object(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """fetch_alarms must try the next path on 400 api.err.InvalidObject.
 
         Some firmware returns 400 + api.err.InvalidObject for endpoint paths that don't
         exist on that firmware version (instead of the more conventional 404).  The
         integration must treat this the same as 404 and try the next path.
         """
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         invalid_body = {"meta": {"rc": "error", "msg": "api.err.InvalidObject"}, "data": []}
 
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=400, payload=invalid_body)
-            m.get(alarm_url(), status=200, payload={"meta": {"rc": "ok"}, "data": []})
-            result = await client.fetch_alarms()
-            total = total_calls(m)
+        aioclient_mock.get(list_alarm_url(), status=400, json=invalid_body)
+        aioclient_mock.get(alarm_url(), status=200, json={"meta": {"rc": "ok"}, "data": []})
+        result = await client.fetch_alarms()
+        total = total_calls()
 
         assert total == 2, "Expected exactly two GET calls (primary + fallback)"
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_all_paths_404_raises_invalid_site_error(self):
+    async def test_all_paths_404_raises_invalid_site_error(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """When all alarm paths return 404, raise InvalidSiteError (subclass of CannotConnectError)."""
         from custom_components.unifi_alerts.unifi_client import InvalidSiteError
 
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=404)
-            m.get(alarm_url(), status=404)
-            m.get(stat_alarm_url(), status=404)
-            with pytest.raises(InvalidSiteError, match="not found on the controller"):
-                await client.fetch_alarms()
+        aioclient_mock.get(list_alarm_url(), status=404)
+        aioclient_mock.get(alarm_url(), status=404)
+        aioclient_mock.get(stat_alarm_url(), status=404)
+        with pytest.raises(InvalidSiteError, match="not found on the controller"):
+            await client.fetch_alarms()
 
     @pytest.mark.asyncio
-    async def test_http_400_raises_cannot_connect_with_site_hint(self):
+    async def test_http_400_raises_cannot_connect_with_site_hint(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """HTTP 400 (non-InvalidObject) from the alarm endpoint raises CannotConnectError.
 
         A 400 with any error other than api.err.InvalidObject means a genuine rejection
@@ -362,64 +361,66 @@ class TestFetchAlarms:
         what to check.  api.err.InvalidObject is treated as "path not found" (see separate
         test) and causes a fallback rather than an immediate error.
         """
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         # Return 400 with a non-InvalidObject body so the path isn't treated as "not found"
         bad_body = {"meta": {"rc": "error", "msg": "api.err.Invalid"}, "data": []}
 
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=400, payload=bad_body)
-            with pytest.raises(CannotConnectError) as exc_info:
-                await client.fetch_alarms()
+        aioclient_mock.get(list_alarm_url(), status=400, json=bad_body)
+        with pytest.raises(CannotConnectError) as exc_info:
+            await client.fetch_alarms()
 
         message = str(exc_info.value)
         assert "400" in message
         assert "default" in message  # site name is mentioned so user knows what to check
 
     @pytest.mark.asyncio
-    async def test_http_400_with_unparseable_body_still_raises_cannot_connect(self):
+    async def test_http_400_with_unparseable_body_still_raises_cannot_connect(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """A 400 response whose body isn't valid JSON must not crash — CannotConnectError still raises.
 
         _try_fetch_alarms tries to parse the 400 body to detect api.err.InvalidObject
         (path-not-found) vs. a genuine rejection. If the body itself can't be parsed
         as JSON, that lookup must fail closed (treated as a genuine 400, not silently
         swallowed) rather than propagating the JSONDecodeError. Registering a raw,
-        non-JSON ``body`` (rather than ``payload``) makes ``resp.json()`` raise
-        naturally via real aiohttp JSON parsing.
+        non-JSON ``text`` (rather than ``json``) makes ``resp.json()`` raise naturally.
         """
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=400, body="not valid json")
-            with pytest.raises(CannotConnectError) as exc_info:
-                await client.fetch_alarms()
+        aioclient_mock.get(list_alarm_url(), status=400, text="not valid json")
+        with pytest.raises(CannotConnectError) as exc_info:
+            await client.fetch_alarms()
 
         message = str(exc_info.value)
         assert "400" in message
         assert "default" in message
 
     @pytest.mark.asyncio
-    async def test_api_error_response_raises_cannot_connect(self):
+    async def test_api_error_response_raises_cannot_connect(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """HTTP 200 with meta.rc != 'ok' must raise CannotConnectError.
 
         The UniFi controller returns HTTP 200 even for API-level errors; only
         meta.rc distinguishes success from failure.  Silently returning [] would
         hide misconfigured site names and similar problems from the user.
         """
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         body = {"meta": {"rc": "error", "msg": "api.err.InvalidObject"}, "data": []}
 
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload=body)
-            with pytest.raises(CannotConnectError, match=r"api\.err\.InvalidObject"):
-                await client.fetch_alarms()
+        aioclient_mock.get(list_alarm_url(), status=200, json=body)
+        with pytest.raises(CannotConnectError, match=r"api\.err\.InvalidObject"):
+            await client.fetch_alarms()
 
     @pytest.mark.asyncio
-    async def test_not_authenticated_calls_authenticate_first(self):
+    async def test_not_authenticated_calls_authenticate_first(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """fetch_alarms must call authenticate() when not yet authenticated."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = False
         body = {"meta": {"rc": "ok"}, "data": [{"key": "EVT_GW_WANTransition", "archived": False}]}
 
@@ -432,39 +433,38 @@ class TestFetchAlarms:
 
         client.authenticate = _mock_authenticate
 
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload=body)
-            await client.fetch_alarms()
+        aioclient_mock.get(list_alarm_url(), status=200, json=body)
+        await client.fetch_alarms()
 
         assert len(authenticated_calls) == 1
 
     @pytest.mark.asyncio
-    async def test_redirect_raises_cannot_connect(self):
+    async def test_redirect_raises_cannot_connect(self, aioclient_mock: AiohttpClientMocker):
         """A 3xx on an authenticated alarm fetch must raise CannotConnectError (no redirect)."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=301)
-            with pytest.raises(CannotConnectError, match="redirect"):
-                await client.fetch_alarms()
+        aioclient_mock.get(list_alarm_url(), status=301)
+        with pytest.raises(CannotConnectError, match="redirect"):
+            await client.fetch_alarms()
 
     @pytest.mark.asyncio
-    async def test_sends_x_api_key_header_and_correct_url_method(self):
+    async def test_sends_x_api_key_header_and_correct_url_method(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """The outbound GET to /list/alarm must carry the X-API-Key header from apikey auth.
 
-        Asserts against aioresponses' recorded request history (method, URL,
-        headers) — i.e. the HTTP the client actually sent on the wire — rather
-        than a mock's internal call_args, so this catches regressions in the
-        real auth-header wiring, not just the client's internal call sequence.
+        Asserts against the recorded request history (method, URL, headers) —
+        i.e. the HTTP the client actually sent to aiohttp — rather than a
+        mock's internal call_args, so this catches regressions in the real
+        auth-header wiring, not just the client's internal call sequence.
         """
-        client = make_client({"api_key": "s3cr3t-key", "verify_ssl": False})
+        client = make_client(aioclient_mock, {"api_key": "s3cr3t-key", "verify_ssl": False})
         client._auth._method = "apikey"
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload={"meta": {"rc": "ok"}, "data": []})
-            await client.fetch_alarms()
-            calls = find_calls(m, "GET", list_alarm_url())
+        aioclient_mock.get(list_alarm_url(), status=200, json={"meta": {"rc": "ok"}, "data": []})
+        await client.fetch_alarms()
+        calls = find_calls("GET", list_alarm_url())
 
         assert len(calls) == 1, "Expected exactly one GET to /list/alarm"
         sent_headers = calls[0].kwargs.get("headers") or {}
@@ -476,8 +476,8 @@ class TestCategoriseAlarms:
     """Tests for UniFiClient.categorise_alarms."""
 
     @pytest.mark.asyncio
-    async def test_groups_alarms_by_category(self):
-        client = make_client()
+    async def test_groups_alarms_by_category(self, aioclient_mock: AiohttpClientMocker):
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         body = {
             "meta": {"rc": "ok"},
@@ -487,17 +487,16 @@ class TestCategoriseAlarms:
                 {"key": "EVT_GW_Failover", "msg": "Failover", "archived": False},
             ],
         }
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload=body)
-            result = await client.categorise_alarms()
+        aioclient_mock.get(list_alarm_url(), status=200, json=body)
+        result = await client.categorise_alarms()
 
         assert CATEGORY_NETWORK_WAN in result
         assert CATEGORY_SECURITY_THREAT in result
         assert len(result[CATEGORY_NETWORK_WAN]) == 2  # both WAN events
 
     @pytest.mark.asyncio
-    async def test_skips_unclassified_alarms(self):
-        client = make_client()
+    async def test_skips_unclassified_alarms(self, aioclient_mock: AiohttpClientMocker):
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         body = {
             "meta": {"rc": "ok"},
@@ -505,24 +504,24 @@ class TestCategoriseAlarms:
                 {"key": "EVT_UNKNOWN_THING", "msg": "who knows", "archived": False},
             ],
         }
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload=body)
-            result = await client.categorise_alarms()
+        aioclient_mock.get(list_alarm_url(), status=200, json=body)
+        result = await client.categorise_alarms()
         assert result == {}
 
     @pytest.mark.asyncio
-    async def test_empty_alarm_list_returns_empty_dict(self):
-        client = make_client()
+    async def test_empty_alarm_list_returns_empty_dict(self, aioclient_mock: AiohttpClientMocker):
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload={"meta": {"rc": "ok"}, "data": []})
-            result = await client.categorise_alarms()
+        aioclient_mock.get(list_alarm_url(), status=200, json={"meta": {"rc": "ok"}, "data": []})
+        result = await client.categorise_alarms()
         assert result == {}
 
     @pytest.mark.asyncio
-    async def test_unrecognised_keys_tracked_on_unclassified_alarm(self):
+    async def test_unrecognised_keys_tracked_on_unclassified_alarm(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """categorise_alarms() must record unclassified alarm keys in unrecognised_keys."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         body = {
             "meta": {"rc": "ok"},
@@ -532,9 +531,8 @@ class TestCategoriseAlarms:
                 {"key": "EVT_ANOTHER_UNKNOWN", "msg": "hmm", "archived": False},
             ],
         }
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload=body)
-            await client.categorise_alarms()
+        aioclient_mock.get(list_alarm_url(), status=200, json=body)
+        await client.categorise_alarms()
 
         assert client.unrecognised_keys == {
             "EVT_MYSTERY_DEVICE_FELL_OVER": 2,
@@ -542,36 +540,37 @@ class TestCategoriseAlarms:
         }
 
     @pytest.mark.asyncio
-    async def test_unrecognised_keys_reset_between_calls(self):
+    async def test_unrecognised_keys_reset_between_calls(self, aioclient_mock: AiohttpClientMocker):
         """unrecognised_keys reflects only the most recent categorise_alarms() call."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
 
         body1 = {
             "meta": {"rc": "ok"},
             "data": [{"key": "EVT_UNKNOWN_FIRST", "msg": ".", "archived": False}],
         }
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload=body1)
-            await client.categorise_alarms()
+        aioclient_mock.get(list_alarm_url(), status=200, json=body1)
+        await client.categorise_alarms()
         assert "EVT_UNKNOWN_FIRST" in client.unrecognised_keys
 
+        aioclient_mock.clear_requests()
         body2 = {
             "meta": {"rc": "ok"},
             "data": [{"key": "EVT_UNKNOWN_SECOND", "msg": ".", "archived": False}],
         }
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload=body2)
-            await client.categorise_alarms()
+        aioclient_mock.get(list_alarm_url(), status=200, json=body2)
+        await client.categorise_alarms()
 
         # Only the second call's keys remain
         assert "EVT_UNKNOWN_SECOND" in client.unrecognised_keys
         assert "EVT_UNKNOWN_FIRST" not in client.unrecognised_keys
 
     @pytest.mark.asyncio
-    async def test_unrecognised_keys_empty_when_all_classified(self):
+    async def test_unrecognised_keys_empty_when_all_classified(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """unrecognised_keys is empty when all alarms map to a category."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         body = {
             "meta": {"rc": "ok"},
@@ -579,9 +578,8 @@ class TestCategoriseAlarms:
                 {"key": "EVT_GW_WANTransition", "msg": "WAN down", "archived": False},
             ],
         }
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload=body)
-            await client.categorise_alarms()
+        aioclient_mock.get(list_alarm_url(), status=200, json=body)
+        await client.categorise_alarms()
 
         assert client.unrecognised_keys == {}
 
@@ -595,12 +593,14 @@ class TestAuthenticate:
     resetting probe-backoff state on every successful authentication.
 
     UniFiAuth is a composed collaborator here (not HTTP), so these stay on
-    MagicMock/AsyncMock — out of scope for the aioresponses conversion.
+    MagicMock/AsyncMock — out of scope for the aioclient_mock conversion.
     """
 
     @pytest.mark.asyncio
-    async def test_delegates_to_auth_and_returns_its_result(self):
-        client = make_client()
+    async def test_delegates_to_auth_and_returns_its_result(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
+        client = make_client(aioclient_mock)
         client._auth.authenticate = AsyncMock(return_value="apikey")
 
         result = await client.authenticate()
@@ -609,8 +609,8 @@ class TestAuthenticate:
         client._auth.authenticate.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_propagates_auth_failure(self):
-        client = make_client()
+    async def test_propagates_auth_failure(self, aioclient_mock: AiohttpClientMocker):
+        client = make_client(aioclient_mock)
         client._auth.authenticate = AsyncMock(side_effect=InvalidAuthError("bad creds"))
 
         with pytest.raises(InvalidAuthError):
@@ -621,43 +621,46 @@ class TestClose:
     """Tests for UniFiClient.close — logout behaviour."""
 
     @pytest.mark.asyncio
-    async def test_userpass_auth_posts_to_unifi_os_logout_path(self):
+    async def test_userpass_auth_posts_to_unifi_os_logout_path(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """close() must POST to /api/auth/logout (UniFi OS path only)."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._method = "userpass"
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            m.post(LOGOUT_URL, status=200)
-            await client.close()
-            calls = find_calls(m, "POST", LOGOUT_URL)
+        aioclient_mock.post(LOGOUT_URL, status=200)
+        await client.close()
+        calls = find_calls("POST", LOGOUT_URL)
 
         assert len(calls) == 1
 
     @pytest.mark.asyncio
-    async def test_apikey_auth_does_not_post_logout(self):
-        client = make_client({"api_key": "k", "verify_ssl": False})
+    async def test_apikey_auth_does_not_post_logout(self, aioclient_mock: AiohttpClientMocker):
+        client = make_client(aioclient_mock, {"api_key": "k", "verify_ssl": False})
         client._auth._method = "apikey"
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            # Nothing registered — if close() posted anywhere, aioresponses
-            # would raise for the unmatched request and fail this test.
-            await client.close()
-            assert total_calls(m) == 0
+        # Nothing registered — if close() posted anywhere, aioclient_mock
+        # would raise AssertionError for the unmatched request and fail this test.
+        await client.close()
+        assert total_calls() == 0
 
     @pytest.mark.asyncio
-    async def test_not_authenticated_does_not_post_logout(self):
-        client = make_client()
+    async def test_not_authenticated_does_not_post_logout(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
+        client = make_client(aioclient_mock)
         client._auth._method = "userpass"
         client._auth._authenticated = False
 
-        with aioresponses() as m:
-            await client.close()
-            assert total_calls(m) == 0
+        await client.close()
+        assert total_calls() == 0
 
     @pytest.mark.asyncio
-    async def test_logout_failure_logs_warning_with_class_name_only(self, caplog):
+    async def test_logout_failure_logs_warning_with_class_name_only(
+        self, aioclient_mock: AiohttpClientMocker, caplog
+    ):
         """A failed logout must log at WARNING with the exception class name only.
 
         The previous `contextlib.suppress(Exception)` swallowed the error silently,
@@ -667,40 +670,34 @@ class TestClose:
         """
         import logging
 
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._method = "userpass"
         client._auth._authenticated = True
         secret_marker = "controller.local: 401 Unauthorized — api_key=secret"
 
-        with aioresponses() as m:
-            m.post(LOGOUT_URL, exception=ConnectionResetError(secret_marker))
-            with caplog.at_level(
-                logging.WARNING, logger="custom_components.unifi_alerts.unifi_client"
-            ):
-                await client.close()
+        aioclient_mock.post(LOGOUT_URL, exc=ConnectionResetError(secret_marker))
+        with caplog.at_level(logging.WARNING, logger="custom_components.unifi_alerts.unifi_client"):
+            await client.close()
 
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
         assert any("ConnectionResetError" in r.getMessage() for r in warnings)
         assert all(secret_marker not in r.getMessage() for r in warnings)
 
     @pytest.mark.asyncio
-    async def test_logout_failure_does_not_propagate(self):
+    async def test_logout_failure_does_not_propagate(self, aioclient_mock: AiohttpClientMocker):
         """close() must never raise on a realistic logout failure — best-effort.
 
         Only network/connection failures (aiohttp.ClientError, OSError,
         TimeoutError) are absorbed; a genuine bug (e.g. RuntimeError from our
         own code) is intentionally allowed to propagate so it isn't hidden.
         """
-        import aiohttp
-
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._method = "userpass"
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            m.post(LOGOUT_URL, exception=aiohttp.ClientConnectionError("boom"))
-            # No pytest.raises — close() must absorb the failure.
-            await client.close()
+        aioclient_mock.post(LOGOUT_URL, exc=aiohttp.ClientConnectionError("boom"))
+        # No pytest.raises — close() must absorb the failure.
+        await client.close()
 
 
 class TestSslFailOpen:
@@ -712,24 +709,25 @@ class TestSslFailOpen:
     """
 
     @pytest.mark.asyncio
-    async def test_absent_verify_ssl_key_defaults_to_true_in_fetch_alarms(self):
+    async def test_absent_verify_ssl_key_defaults_to_true_in_fetch_alarms(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """When CONF_VERIFY_SSL is absent from config, _try_fetch_alarms must pass ssl=True.
 
-        Constructs a config dict with no verify_ssl key and asserts, via
-        aioresponses' request history, that the ssl kwarg forwarded on the
-        outbound request is DEFAULT_VERIFY_SSL (True), not False.
+        Constructs a config dict with no verify_ssl key and asserts, via the
+        recorded request history, that the ssl kwarg forwarded on the outbound
+        request is DEFAULT_VERIFY_SSL (True), not False.
         """
         from custom_components.unifi_alerts.const import DEFAULT_VERIFY_SSL
 
         # Config deliberately omits verify_ssl
         config = {"username": "admin", "password": "secret"}
-        client = make_client(config)
+        client = make_client(aioclient_mock, config)
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            m.get(list_alarm_url(), status=200, payload={"meta": {"rc": "ok"}, "data": []})
-            await client.fetch_alarms()
-            calls = find_calls(m, "GET", list_alarm_url())
+        aioclient_mock.get(list_alarm_url(), status=200, json={"meta": {"rc": "ok"}, "data": []})
+        await client.fetch_alarms()
+        calls = find_calls("GET", list_alarm_url())
 
         assert len(calls) == 1, "Expected exactly one GET call"
         sent_ssl = calls[0].kwargs.get("ssl")
@@ -749,34 +747,36 @@ class TestSslCertificateError:
     """
 
     @pytest.mark.asyncio
-    async def test_try_fetch_alarms_raises_ssl_cert_error(self):
+    async def test_try_fetch_alarms_raises_ssl_cert_error(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """aiohttp.ClientConnectorCertificateError in _try_fetch_alarms must raise SslCertificateError."""
         from custom_components.unifi_alerts.unifi_client import SslCertificateError
 
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         url = "https://192.168.1.1/api/alarm"
 
-        with aioresponses() as m:
-            m.get(
-                url,
-                exception=aiohttp.ClientConnectorCertificateError(MagicMock(), MagicMock()),
-            )
-            with pytest.raises(SslCertificateError):
-                await client._try_fetch_alarms(url, "default")
+        aioclient_mock.get(
+            url,
+            exc=aiohttp.ClientConnectorCertificateError(MagicMock(), MagicMock()),
+        )
+        with pytest.raises(SslCertificateError):
+            await client._try_fetch_alarms(url, "default")
 
     @pytest.mark.asyncio
-    async def test_fetch_system_log_alarms_raises_ssl_cert_error(self):
+    async def test_fetch_system_log_alarms_raises_ssl_cert_error(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """aiohttp.ClientConnectorCertificateError in fetch_system_log_alarms must raise SslCertificateError."""
         from custom_components.unifi_alerts.unifi_client import SslCertificateError
 
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            m.post(
-                system_log_url(),
-                exception=aiohttp.ClientConnectorCertificateError(MagicMock(), MagicMock()),
-            )
-            with pytest.raises(SslCertificateError):
-                await client.fetch_system_log_alarms()
+        aioclient_mock.post(
+            system_log_url(),
+            exc=aiohttp.ClientConnectorCertificateError(MagicMock(), MagicMock()),
+        )
+        with pytest.raises(SslCertificateError):
+            await client.fetch_system_log_alarms()

--- a/tests/unit/unifi_client/test_v2.py
+++ b/tests/unit/unifi_client/test_v2.py
@@ -10,12 +10,20 @@ from datetime import timedelta
 
 import aiohttp
 import pytest
-from aioresponses import aioresponses
+from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 
 from custom_components.unifi_alerts.unifi_auth import CannotConnectError, InvalidAuthError
 from custom_components.unifi_alerts.unifi_client import _PROBE_FAIL_LIMIT
 
-from .conftest import LOGIN_URL, find_calls, make_client, probe_url, system_log_url, total_calls
+from .conftest import (
+    LOGIN_URL,
+    find_calls,
+    make_client,
+    probe_url,
+    queue_responses,
+    system_log_url,
+    total_calls,
+)
 
 # Pinned business-rule value for the probe backoff window. Deliberately NOT
 # imported as `_PROBE_RETRY_AFTER` from unifi_client — importing the constant
@@ -29,143 +37,146 @@ class TestProbeSystemLogEndpoint:
     """Tests for UniFiClient.probe_system_log_endpoint."""
 
     @pytest.mark.asyncio
-    async def test_probe_returns_true_on_200(self):
+    async def test_probe_returns_true_on_200(self, aioclient_mock: AiohttpClientMocker):
         """HTTP 200 from /system-log/count must return True and set _has_system_log=True."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.post(probe_url(), status=200, payload={"categories": []})
-            result = await client.probe_system_log_endpoint()
+        aioclient_mock.post(probe_url(), status=200, json={"categories": []})
+        result = await client.probe_system_log_endpoint()
         assert result is True
         assert client._has_system_log is True
 
     @pytest.mark.asyncio
-    async def test_probe_returns_false_on_404(self):
+    async def test_probe_returns_false_on_404(self, aioclient_mock: AiohttpClientMocker):
         """HTTP 404 from /system-log/count must return False and set _has_system_log=False."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.post(probe_url(), status=404)
-            result = await client.probe_system_log_endpoint()
+        aioclient_mock.post(probe_url(), status=404)
+        result = await client.probe_system_log_endpoint()
         assert result is False
         assert client._has_system_log is False
 
     @pytest.mark.asyncio
-    async def test_probe_returns_false_on_403_does_not_cache(self):
+    async def test_probe_returns_false_on_403_does_not_cache(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """HTTP 403 (non-definitive) must return False this call but leave the cache None.
 
         Only 404 is treated as a definitive "endpoint not implemented" response.
         Other 4xx codes may be transient (e.g., temporary permission state) and
         re-probing on the next poll is preferable to pinning to legacy mode.
         """
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.post(probe_url(), status=403)
-            result = await client.probe_system_log_endpoint()
+        aioclient_mock.post(probe_url(), status=403)
+        result = await client.probe_system_log_endpoint()
         assert result is False
         assert client._has_system_log is None
 
     @pytest.mark.asyncio
-    async def test_probe_returns_false_on_500_does_not_cache(self):
+    async def test_probe_returns_false_on_500_does_not_cache(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """HTTP 5xx is treated as transient: returns False without caching."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.post(probe_url(), status=503)
-            result = await client.probe_system_log_endpoint()
+        aioclient_mock.post(probe_url(), status=503)
+        result = await client.probe_system_log_endpoint()
         assert result is False
         assert client._has_system_log is None
 
     @pytest.mark.asyncio
-    async def test_probe_returns_false_on_network_error_does_not_cache(self):
+    async def test_probe_returns_false_on_network_error_does_not_cache(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """aiohttp.ClientError during probe must return False, not raise, and not cache."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.post(probe_url(), exception=aiohttp.ClientConnectionError("unreachable"))
-            result = await client.probe_system_log_endpoint()
+        aioclient_mock.post(probe_url(), exc=aiohttp.ClientConnectionError("unreachable"))
+        result = await client.probe_system_log_endpoint()
         assert result is False
         assert client._has_system_log is None
 
     @pytest.mark.asyncio
-    async def test_probe_retries_after_transient_failure(self):
+    async def test_probe_retries_after_transient_failure(self, aioclient_mock: AiohttpClientMocker):
         """A 5xx followed by a 200 must end with cache=True (transient does not pin to legacy).
 
-        Registers two responses for the same URL without repeat=True: aioresponses
-        consumes them FIFO in call order, so the first probe gets 503 and the
-        second gets 200.
+        aioclient_mock never consumes a matched registration, so two plain
+        registrations at the same URL would both always answer with the
+        first one; queue_responses hands out one response per call instead.
         """
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            m.post(probe_url(), status=503)
-            m.post(probe_url(), status=200, payload={})
+        queue_responses(
+            aioclient_mock,
+            "post",
+            probe_url(),
+            [{"status": 503}, {"status": 200, "json": {}}],
+        )
 
-            first = await client.probe_system_log_endpoint()
-            assert first is False
-            assert client._has_system_log is None, "Transient failure must not cache"
+        first = await client.probe_system_log_endpoint()
+        assert first is False
+        assert client._has_system_log is None, "Transient failure must not cache"
 
-            second = await client.probe_system_log_endpoint()
-            assert second is True
-            assert client._has_system_log is True
+        second = await client.probe_system_log_endpoint()
+        assert second is True
+        assert client._has_system_log is True
 
     @pytest.mark.asyncio
-    async def test_probe_is_cached_after_true(self):
+    async def test_probe_is_cached_after_true(self, aioclient_mock: AiohttpClientMocker):
         """Second call must not hit the network when _has_system_log is True."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         client._has_system_log = True  # pre-set the cache
 
-        with aioresponses() as m:
-            # Nothing registered — a network hit here would raise and fail the test.
-            result = await client.probe_system_log_endpoint()
-            assert total_calls(m) == 0, "Network must not be hit when result is cached"
+        # Nothing registered — a network hit here would raise and fail the test.
+        result = await client.probe_system_log_endpoint()
+        assert total_calls() == 0, "Network must not be hit when result is cached"
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_probe_is_cached_after_false(self):
+    async def test_probe_is_cached_after_false(self, aioclient_mock: AiohttpClientMocker):
         """Second call must not hit the network when _has_system_log is False."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         client._has_system_log = False  # pre-set the cache
 
-        with aioresponses() as m:
-            result = await client.probe_system_log_endpoint()
-            assert total_calls(m) == 0, "Network must not be hit when result is cached"
+        result = await client.probe_system_log_endpoint()
+        assert total_calls() == 0, "Network must not be hit when result is cached"
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_probe_url_includes_v2_and_site(self):
+    async def test_probe_url_includes_v2_and_site(self, aioclient_mock: AiohttpClientMocker):
         """Probe URL must include /v2/api/site/{site}/system-log/count."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         expected_url = probe_url(site="mysite")
 
-        with aioresponses() as m:
-            m.post(expected_url, status=200, payload={})
-            await client.probe_system_log_endpoint(site="mysite")
-            calls = find_calls(m, "POST", expected_url)
+        aioclient_mock.post(expected_url, status=200, json={})
+        await client.probe_system_log_endpoint(site="mysite")
+        calls = find_calls("POST", expected_url)
 
         assert len(calls) == 1, "Expected one POST call"
         assert "v2/api/site/mysite/system-log/count" in expected_url
 
     @pytest.mark.asyncio
-    async def test_probe_backoff_triggers_after_fail_limit(self):
+    async def test_probe_backoff_triggers_after_fail_limit(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
         """After _PROBE_FAIL_LIMIT consecutive transient failures the probe caches False
         and sets a backoff deadline so subsequent polls skip the network entirely."""
         from datetime import UTC, datetime
 
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
 
+        aioclient_mock.post(probe_url(), status=503)
+
         before = datetime.now(UTC)
-        with aioresponses() as m:
-            m.post(probe_url(), status=503, repeat=True)
-            for _ in range(_PROBE_FAIL_LIMIT):
-                result = await client.probe_system_log_endpoint()
-                assert result is False
+        for _ in range(_PROBE_FAIL_LIMIT):
+            result = await client.probe_system_log_endpoint()
+            assert result is False
         after = datetime.now(UTC)
 
         # After the threshold the cache must be False and a backoff deadline set.
@@ -182,36 +193,34 @@ class TestProbeSystemLogEndpoint:
         )
 
     @pytest.mark.asyncio
-    async def test_probe_during_backoff_skips_network(self):
+    async def test_probe_during_backoff_skips_network(self, aioclient_mock: AiohttpClientMocker):
         """Once in backoff, probes must return False without making a network call."""
         from datetime import UTC, datetime, timedelta
 
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         client._has_system_log = False
         client._probe_backoff_until = datetime.now(UTC) + timedelta(hours=1)
 
-        with aioresponses() as m:
-            result = await client.probe_system_log_endpoint()
-            assert total_calls(m) == 0, "Network must not be hit during backoff"
+        result = await client.probe_system_log_endpoint()
+        assert total_calls() == 0, "Network must not be hit during backoff"
         assert result is False
 
     @pytest.mark.asyncio
-    async def test_probe_retries_after_backoff_expires(self):
+    async def test_probe_retries_after_backoff_expires(self, aioclient_mock: AiohttpClientMocker):
         """Once the backoff window expires, the next probe must hit the network
         and, if successful, set cache=True and clear backoff state."""
         from datetime import UTC, datetime, timedelta
 
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         # Simulate an expired backoff (deadline in the past).
         client._has_system_log = False
         client._probe_backoff_until = datetime.now(UTC) - timedelta(seconds=1)
         client._probe_fail_count = _PROBE_FAIL_LIMIT
 
-        with aioresponses() as m:
-            m.post(probe_url(), status=200, payload={})
-            result = await client.probe_system_log_endpoint()
+        aioclient_mock.post(probe_url(), status=200, json={})
+        result = await client.probe_system_log_endpoint()
 
         assert result is True
         assert client._has_system_log is True
@@ -219,39 +228,34 @@ class TestProbeSystemLogEndpoint:
         assert client._probe_fail_count == 0
 
     @pytest.mark.asyncio
-    async def test_probe_404_does_not_set_backoff(self):
+    async def test_probe_404_does_not_set_backoff(self, aioclient_mock: AiohttpClientMocker):
         """A definitive 404 must set cache=False without a backoff deadline
         (the endpoint will never appear on this controller)."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            m.post(probe_url(), status=404)
-            result = await client.probe_system_log_endpoint()
+        aioclient_mock.post(probe_url(), status=404)
+        result = await client.probe_system_log_endpoint()
 
         assert result is False
         assert client._has_system_log is False
         assert client._probe_backoff_until is None
 
     @pytest.mark.asyncio
-    async def test_probe_backoff_via_network_error(self):
+    async def test_probe_backoff_via_network_error(self, aioclient_mock: AiohttpClientMocker):
         """Repeated aiohttp.ClientError failures must also trigger the backoff
         after reaching _PROBE_FAIL_LIMIT."""
         from datetime import UTC, datetime
 
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
 
+        aioclient_mock.post(probe_url(), exc=aiohttp.ClientConnectionError("unreachable"))
+
         before = datetime.now(UTC)
-        with aioresponses() as m:
-            m.post(
-                probe_url(),
-                exception=aiohttp.ClientConnectionError("unreachable"),
-                repeat=True,
-            )
-            for _ in range(_PROBE_FAIL_LIMIT):
-                result = await client.probe_system_log_endpoint()
-                assert result is False
+        for _ in range(_PROBE_FAIL_LIMIT):
+            result = await client.probe_system_log_endpoint()
+            assert result is False
         after = datetime.now(UTC)
 
         assert client._has_system_log is False
@@ -263,21 +267,20 @@ class TestProbeSystemLogEndpoint:
         )
 
     @pytest.mark.asyncio
-    async def test_reauth_clears_probe_backoff(self):
+    async def test_reauth_clears_probe_backoff(self, aioclient_mock: AiohttpClientMocker):
         """A successful authenticate() must clear the probe-backoff state so the
         next probe call actually hits the network instead of returning the cached
         False from backoff."""
         from datetime import UTC, datetime, timedelta
 
-        client = make_client()
+        client = make_client(aioclient_mock)
         # Simulate an active backoff (e.g. credentials were bad, probe kept failing)
         client._has_system_log = False
         client._probe_fail_count = _PROBE_FAIL_LIMIT
         client._probe_backoff_until = datetime.now(UTC) + timedelta(hours=1)
 
-        with aioresponses() as m:
-            m.post(LOGIN_URL, status=200)
-            await client.authenticate()
+        aioclient_mock.post(LOGIN_URL, status=200)
+        await client.authenticate()
 
         # Backoff state must be cleared
         assert client._probe_backoff_until is None
@@ -285,17 +288,16 @@ class TestProbeSystemLogEndpoint:
         assert client._has_system_log is None  # re-probed on next poll
 
     @pytest.mark.asyncio
-    async def test_reauth_does_not_reset_confirmed_true(self):
+    async def test_reauth_does_not_reset_confirmed_true(self, aioclient_mock: AiohttpClientMocker):
         """If _has_system_log is True (v2 endpoint confirmed), re-auth must not
         reset it to None - there's nothing to re-probe."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._has_system_log = True
         client._probe_fail_count = 0
         client._probe_backoff_until = None
 
-        with aioresponses() as m:
-            m.post(LOGIN_URL, status=200)
-            await client.authenticate()
+        aioclient_mock.post(LOGIN_URL, status=200)
+        await client.authenticate()
 
         assert client._has_system_log is True
 
@@ -313,88 +315,99 @@ class TestFetchSystemLogAlarms:
         }
 
     @pytest.mark.asyncio
-    async def test_returns_new_events_only(self):
+    async def test_returns_new_events_only(self, aioclient_mock: AiohttpClientMocker):
         """Only events with status='NEW' must be returned; others are filtered."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         events = [
             {"key": "THREAT_BLOCKED", "status": "NEW", "timestamp": 1778025612345},
             {"key": "THREAT_BLOCKED", "status": "ARCHIVED", "timestamp": 1778025612000},
         ]
-        with aioresponses() as m:
-            m.post(system_log_url(), status=200, payload=self._page_body(events, total_pages=1))
-            result = await client.fetch_system_log_alarms()
+        aioclient_mock.post(
+            system_log_url(), status=200, json=self._page_body(events, total_pages=1)
+        )
+        result = await client.fetch_system_log_alarms()
         assert len(result) == 1
         assert result[0]["status"] == "NEW"
 
     @pytest.mark.asyncio
-    async def test_paginates_until_total_pages_exhausted(self):
+    async def test_paginates_until_total_pages_exhausted(self, aioclient_mock: AiohttpClientMocker):
         """Must fetch pages until total_page_count is reached."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         event = {"key": "K", "status": "NEW", "timestamp": 1000}
 
-        with aioresponses() as m:
-            m.post(system_log_url(), status=200, payload=self._page_body([event], 3, page=0))
-            m.post(system_log_url(), status=200, payload=self._page_body([event], 3, page=1))
-            m.post(system_log_url(), status=200, payload=self._page_body([event], 3, page=2))
-            result = await client.fetch_system_log_alarms()
-            total = total_calls(m)
+        queue_responses(
+            aioclient_mock,
+            "post",
+            system_log_url(),
+            [
+                {"status": 200, "json": self._page_body([event], 3, page=0)},
+                {"status": 200, "json": self._page_body([event], 3, page=1)},
+                {"status": 200, "json": self._page_body([event], 3, page=2)},
+            ],
+        )
+        result = await client.fetch_system_log_alarms()
+        total = total_calls()
 
         assert total == 3
         assert len(result) == 3  # one NEW event per page
 
     @pytest.mark.asyncio
-    async def test_stops_at_max_pages_cap(self):
+    async def test_stops_at_max_pages_cap(self, aioclient_mock: AiohttpClientMocker):
         """Must stop after MAX_SYSTEM_LOG_PAGES even if total_page_count is larger."""
         from custom_components.unifi_alerts.const import MAX_SYSTEM_LOG_PAGES
 
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         event = {"key": "K", "status": "NEW", "timestamp": 1000}
         # total_page_count is intentionally larger than MAX_SYSTEM_LOG_PAGES
         body = self._page_body([event], total_pages=9999, page=0)
 
-        with aioresponses() as m:
-            m.post(system_log_url(), status=200, payload=body, repeat=True)
-            await client.fetch_system_log_alarms()
-            total = total_calls(m)
+        aioclient_mock.post(system_log_url(), status=200, json=body)
+        await client.fetch_system_log_alarms()
+        total = total_calls()
 
         assert total == MAX_SYSTEM_LOG_PAGES, (
             f"Expected exactly {MAX_SYSTEM_LOG_PAGES} page fetches; got {total}"
         )
 
     @pytest.mark.asyncio
-    async def test_stops_on_empty_page(self):
+    async def test_stops_on_empty_page(self, aioclient_mock: AiohttpClientMocker):
         """Must stop when a page returns an empty data list."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
         event = {"key": "K", "status": "NEW", "timestamp": 1000}
 
-        with aioresponses() as m:
-            # large total_page_count — early stop must come from the empty page
-            m.post(system_log_url(), status=200, payload=self._page_body([event], 99, page=0))
-            m.post(system_log_url(), status=200, payload=self._page_body([], 99, page=1))
-            result = await client.fetch_system_log_alarms()
-            total = total_calls(m)
+        # large total_page_count — early stop must come from the empty page
+        queue_responses(
+            aioclient_mock,
+            "post",
+            system_log_url(),
+            [
+                {"status": 200, "json": self._page_body([event], 99, page=0)},
+                {"status": 200, "json": self._page_body([], 99, page=1)},
+            ],
+        )
+        result = await client.fetch_system_log_alarms()
+        total = total_calls()
 
         assert total == 2  # first page + one empty page
         assert len(result) == 1
 
     @pytest.mark.asyncio
-    async def test_passes_timestamp_from_as_epoch_ms(self):
+    async def test_passes_timestamp_from_as_epoch_ms(self, aioclient_mock: AiohttpClientMocker):
         """timestampFrom must be epoch milliseconds derived from the since datetime."""
         from datetime import UTC, datetime
 
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            m.post(system_log_url(), status=200, payload=self._page_body([], 1, page=0))
-            since = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
-            expected_ms = int(since.timestamp() * 1000)
-            await client.fetch_system_log_alarms(since=since)
-            calls = find_calls(m, "POST", system_log_url())
+        aioclient_mock.post(system_log_url(), status=200, json=self._page_body([], 1, page=0))
+        since = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+        expected_ms = int(since.timestamp() * 1000)
+        await client.fetch_system_log_alarms(since=since)
+        calls = find_calls("POST", system_log_url())
 
         assert len(calls) == 1, "Expected at least one POST call"
         sent_json = calls[0].kwargs.get("json") or {}
@@ -403,19 +416,18 @@ class TestFetchSystemLogAlarms:
         )
 
     @pytest.mark.asyncio
-    async def test_uses_default_lookback_when_no_since(self):
+    async def test_uses_default_lookback_when_no_since(self, aioclient_mock: AiohttpClientMocker):
         """When since=None, timestampFrom must be approximately now - DEFAULT lookback."""
         from datetime import UTC, datetime, timedelta
 
         from custom_components.unifi_alerts.const import DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS
 
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
 
-        with aioresponses() as m:
-            m.post(system_log_url(), status=200, payload=self._page_body([], 1, page=0))
-            await client.fetch_system_log_alarms(since=None)
-            calls = find_calls(m, "POST", system_log_url())
+        aioclient_mock.post(system_log_url(), status=200, json=self._page_body([], 1, page=0))
+        await client.fetch_system_log_alarms(since=None)
+        calls = find_calls("POST", system_log_url())
 
         expected_approx_ms = int(
             (datetime.now(UTC) - timedelta(hours=DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS)).timestamp()
@@ -428,31 +440,28 @@ class TestFetchSystemLogAlarms:
         )
 
     @pytest.mark.asyncio
-    async def test_401_raises_invalid_auth(self):
+    async def test_401_raises_invalid_auth(self, aioclient_mock: AiohttpClientMocker):
         """HTTP 401 during system-log fetch must raise InvalidAuthError."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.post(system_log_url(), status=401)
-            with pytest.raises(InvalidAuthError):
-                await client.fetch_system_log_alarms()
+        aioclient_mock.post(system_log_url(), status=401)
+        with pytest.raises(InvalidAuthError):
+            await client.fetch_system_log_alarms()
 
     @pytest.mark.asyncio
-    async def test_network_error_raises_cannot_connect(self):
+    async def test_network_error_raises_cannot_connect(self, aioclient_mock: AiohttpClientMocker):
         """aiohttp.ClientError during fetch must raise CannotConnectError."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.post(system_log_url(), exception=aiohttp.ClientConnectionError("unreachable"))
-            with pytest.raises(CannotConnectError):
-                await client.fetch_system_log_alarms()
+        aioclient_mock.post(system_log_url(), exc=aiohttp.ClientConnectionError("unreachable"))
+        with pytest.raises(CannotConnectError):
+            await client.fetch_system_log_alarms()
 
     @pytest.mark.asyncio
-    async def test_redirect_raises_cannot_connect(self):
+    async def test_redirect_raises_cannot_connect(self, aioclient_mock: AiohttpClientMocker):
         """3xx from the system-log endpoint must raise CannotConnectError."""
-        client = make_client()
+        client = make_client(aioclient_mock)
         client._auth._authenticated = True
-        with aioresponses() as m:
-            m.post(system_log_url(), status=301)
-            with pytest.raises(CannotConnectError, match="redirect"):
-                await client.fetch_system_log_alarms()
+        aioclient_mock.post(system_log_url(), status=301)
+        with pytest.raises(CannotConnectError, match="redirect"):
+            await client.fetch_system_log_alarms()


### PR DESCRIPTION
## Summary

Closes #312

- Replaces `aioresponses` with `pytest-homeassistant-custom-component`'s `aioclient_mock` fixture (`AiohttpClientMocker`) across `tests/unit/unifi_client/conftest.py`, `test_legacy.py`, and `test_v2.py` (~43 tests).
- Removes the signature-detected `stream_writer` compatibility shim that #311 added as a Python 3.14 / aiohttp≥3.14 stopgap, along with the `aioresponses`/`aioresponses.core` imports.
- Drops `aioresponses==0.7.9` from `requirements-dev.txt`.
- `make_client()` now builds its session via `aioclient_mock.create_session()`, so the manual `TCPConnector`/`ThreadedResolver` setup (which existed only so `aioresponses` had a real session to patch) is gone.
- Outbound requests are captured via a thin `_request` wrapper (`RecordedCall`) because `aioclient_mock.mock_calls` only records `(method, url, data, headers)` and drops kwargs like `ssl=` that several tests assert on.
- Added `queue_responses()` for the handful of tests where a URL must answer differently across successive calls (probe transient-failure-then-success, system-log pagination). `aioclient_mock` never consumes a matched registration — unlike `aioresponses`' FIFO behaviour — so a single mock's `side_effect` is used to hand out queued responses one per call.
- `exception=` → `exc=`, `payload=` → `json=`, raw `body=` → `text=` across all call sites.

Assertions are unchanged in substance: outbound URL, method, `X-API-Key` header, and JSON body are still asserted from the recorded request history, and success/401/404/malformed-body paths are all still covered. `unifi_client.py` coverage holds (98.86% overall per CI, unchanged vs. base).

## Verified

CI on this PR is green: `Run tests (latest HA)` — 684 passed, `Run tests (minimum HA)`, `Mypy type check`, `Ruff lint & format check`, `Validate with hassfest`, `Validate with HACS Action` all passed. Codecov reports project coverage unchanged at 98.58%/98.86% with no drop on modified lines.

## Test plan

- [x] `test_legacy.py` and `test_v2.py` use `aioclient_mock` exclusively; no `aioresponses` import remains
- [x] `stream_writer` compatibility shim removed from `conftest.py`
- [x] `aioresponses` removed from `requirements-dev.txt`
- [x] Assertions still cover outbound URL, method, auth header, and JSON body
- [x] `unifi_client.py` coverage does not drop
- [x] `make check` green (CI: lint, typecheck, HACS, hassfest, tests on both latest and minimum HA all passing)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRrKzYDXPV4hkr49BLU9GB)_