### PR TITLE
docs: native-Windows pytest unsupported; add Dev Container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "unifi_alerts",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.14",
+  "postCreateCommand": "make setup",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff"
+      ]
+    }
+  }
+}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -73,13 +73,34 @@ If the hook blocks your push, fix the reported issue - do not use `git push --no
 
 ## Windows
 
-`make check` works on Windows out of the box, but two Windows-specific things to know:
+**Native-Windows `pytest` is unsupported** as of the HA 2026.7 / `pytest-homeassistant-custom-component` 0.13.345 bump. `make test` / `make check` fail at collection with:
 
-- `tests/conftest.py` applies two Windows-only workarounds. Both are no-ops on Linux/macOS.
-  - **Event-loop type.** `aiodns` (transitive via `aiohttp`/HA) requires `SelectorEventLoop` but Python's default on Windows since 3.8 is `ProactorEventLoop`. The conftest both calls `asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())` and rebinds `asyncio.WindowsProactorEventLoopPolicy._loop_factory = SelectorEventLoop`. The second patch is essential because HA's `HassEventLoopPolicy(asyncio.DefaultEventLoopPolicy)` is installed per test by the `hass` fixture and would otherwise produce Proactor loops via its inherited `super().new_event_loop()`. `_loop_factory` is resolved via MRO at call time, so the rebind affects HA's subclass too. See [aiodns#86](https://github.com/saghul/aiodns/issues/86).
-  - **Socket disable.** It rebinds `pytest_socket.disable_socket` to a no-op via `pytest_configure`. HA core's test conftest (pulled in via `pytest-homeassistant-custom-component`) calls `socket_allow_hosts(["127.0.0.1"])` followed by `disable_socket(allow_unix_socket=True)` in a `pytest_runtest_setup` hook. The second call swaps `socket.socket` for a `GuardedSocket` whose `__new__` raises `SocketBlockedError` unless family is `AF_UNIX`. Linux/macOS asyncio uses `os.pipe()` for its event-loop self-pipe so the swap is invisible; on Windows both `ProactorEventLoop` and `SelectorEventLoop` call `socket.socketpair()` (loopback TCP) and hit `SocketBlockedError`, with a follow-up `'ProactorEventLoop' object has no attribute '_ssock'` from the half-initialised loop's `__del__`. Neutralising `disable_socket` leaves the earlier `socket_allow_hosts` restriction in place, so external network egress is still blocked, only loopback creation is permitted.
-- The Makefile uses `.venv/Scripts/<tool>.exe` paths on Windows. If `make check` reports "command not found", confirm `.venv` was built with `py -3.14 -m venv .venv` rather than a different interpreter.
-- After a green run on Windows you may see a flood of `DEBUG:asyncio:...` and `DEBUG:homeassistant.*` lines printed *after* the `Results` summary. This is captured log output from HA's test fixtures being flushed out-of-order by `pytest-sugar` on Windows console buffers. It is harmless: scroll up to the `NNN passed` line and ignore the trailing dump.
+```
+ModuleNotFoundError: No module named 'fcntl'
+```
+
+`fcntl` wraps POSIX-only `fcntl()`/`ioctl()` syscalls and is compiled only into POSIX CPython builds; it cannot be installed or built on Windows. `homeassistant/runner.py` has imported it unconditionally for years, but nothing on the test import path used to reach it. A recent `pytest-homeassistant-custom-component` release added `from homeassistant import runner` to `patch_time.py`, which the plugin imports at startup, so `runner` (and its `fcntl` import) is now dragged into every pytest run. This is an upstream change, not a regression in this repo, and matches HA's own [WSL-only dev-environment guidance](https://developers.home-assistant.io/docs/development_environment).
+
+The `tests/conftest.py` Windows workarounds (Selector event-loop rebind, `disable_socket` no-op) **cannot** catch this: the crash happens inside `load_setuptools_entrypoints("pytest11")` during pytest's `_prepareconfig`, which runs before pytest imports any `conftest.py`. Those workarounds are left in place (see the module docstring) in case a future dependency bump removes the `fcntl` import and native-Windows collection becomes viable again, but on their own they no longer unblock the pytest leg.
+
+**What still runs natively on Windows:**
+
+- Lint, typecheck, and the HACS/docs validators never import Home Assistant, so they are unaffected:
+  ```powershell
+  make setup-lint
+  make lint
+  make typecheck
+  make validate
+  make doc-check
+  ```
+- The Makefile uses `.venv/Scripts/<tool>.exe` paths on Windows. If a target reports "command not found", confirm `.venv` was built with `py -3.14 -m venv .venv` rather than a different interpreter.
+
+**For the pytest leg, use one of:**
+
+- The repo's [Dev Container](../.devcontainer/devcontainer.json) (`.devcontainer/devcontainer.json`) - opens in VS Code Dev Containers (Docker Desktop / WSL2 backend) or GitHub Codespaces and runs `make setup` on create.
+- WSL2 directly.
+- GitHub Codespaces.
+- CI, which runs the full suite on every push and PR.
 
 ---
 


### PR DESCRIPTION
## Summary

Native-Windows `pytest` now fails at collection (`ModuleNotFoundError: No module named 'fcntl'`) after the HA 2026.7 / `pytest-homeassistant-custom-component` 0.13.345 bump. This PR updates the Windows section of `docs/TESTING.md` to reflect that, and adds a Dev Container so Windows contributors can still run the full suite in a Linux environment matching CI.

## Changes

- `docs/TESTING.md`: replaced the "works on Windows out of the box" claim with an explanation that native-Windows `pytest` is unsupported. `pytest-homeassistant-custom-component`'s `patch_time.py` now imports `homeassistant.runner`, which unconditionally imports the POSIX-only `fcntl` module. The existing `tests/conftest.py` Windows workarounds (Selector event-loop rebind, `disable_socket` no-op) can't intercept this because the crash happens during `pytest11` entry-point loading, before any `conftest.py` is imported. Kept documenting that lint/typecheck/validate/doc-check run natively via `make setup-lint`, and pointed Windows users at the Dev Container, WSL2, Codespaces, or CI for the pytest leg.
- `.devcontainer/devcontainer.json` (new): Python 3.14 base image, runs `make setup` on create. Python version and setup command cross-checked against `.github/workflows/ci.yml`.

## Rejected alternative

Injecting a fake `fcntl` into `sys.modules` before plugin load (via a `.pth` file or `sitecustomize.py`) was considered and rejected: it fights HA's explicit Linux-only stance, adds a Windows-only install-time step, and would break again the moment `patch_time`/`runner` touches a different POSIX-only symbol.

## Out of scope

- Any `custom_components/` change.
- The `fcntl` stub shim (see rejected alternative above).
- Changing the supported-Python or minimum-HA policy.

## How to test

```bash
make doc-check   # prose linter + translation drift (no venv needed)
```

Opening the repo in a Dev Container or GitHub Codespace should yield a working `make test`.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #322`)
- [x] `make doc-check` passes locally (doc-only PR; full `make check` not required per CLAUDE.md)
- [x] `CHANGELOG.md` not updated — docs/tooling-only change with no `custom_components/` edits, so `changelog-guard` does not require it
- [x] PR title starts with a Conventional Commit prefix (`docs:`) — done
- [x] PR has a label recognised by `.github/release.yml` — will apply `documentation`/`ci` manually
- [x] `strings.json` and `translations/en.json` untouched
- [x] No `custom_components/` changes
- [x] No blocking I/O introduced

Closes #322


---
_Generated by [Claude Code](https://claude.ai/code/session_01CydHjSyBADh2whk1puFyBi)_