### PR TITLE
feat: remove username/password auth, API key only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **Breaking:** username and password authentication is being removed in favour of API keys. Config entries are migrated to a new version-4 schema on upgrade. Entries that already have an API key stored migrate silently and keep working. Entries set up with only a username and password are walked through re-authentication: a repair notice explains that an API key is now required and a single-field form accepts it. The entry is updated in place, so existing sensors, history, and Alarm Manager webhook URLs are preserved. Generate an API key in the UniFi OS web UI (**Settings > Admins & Users > API Keys**, **Integrations > New API Key**, or **Settings > Control Plane > API Keys**, depending on firmware). ([#278])
+- **Breaking:** username and password authentication has been removed; an API key is now the only supported credential. Config entries are migrated to a new version-4 schema on upgrade. Entries that already have an API key stored migrate silently and keep working. Entries set up with only a username and password are walked through re-authentication: a repair notice explains that an API key is now required and a single-field form accepts it. The entry is updated in place, so existing sensors, history, and Alarm Manager webhook URLs are preserved. The initial setup form now requires an API key, and the reconfigure form asks only for an API key. Generate one in the UniFi OS web UI (**Settings > Admins & Users > API Keys**, **Integrations > New API Key**, or **Settings > Control Plane > API Keys**, depending on firmware). ([#278], [#279])
 - Raised the tooling and CI baseline to Python 3.14 and the declared minimum supported Home Assistant version to 2026.3.1, the first HA release that requires Python 3.14. `DataUpdateCoordinator` now receives `config_entry` explicitly instead of a bare `entry_id` string, and SSDP discovery imports `SsdpServiceInfo` from its new `homeassistant.helpers.service_info.ssdp` location. ([#228], [#311])
 
 ### Fixed
@@ -339,6 +339,7 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#268]: https://github.com/PHeonix25/unifi_alerts/issues/268
 [#270]: https://github.com/PHeonix25/unifi_alerts/issues/270
 [#278]: https://github.com/PHeonix25/unifi_alerts/issues/278
+[#279]: https://github.com/PHeonix25/unifi_alerts/issues/279
 [#282]: https://github.com/PHeonix25/unifi_alerts/issues/282
 [#283]: https://github.com/PHeonix25/unifi_alerts/issues/283
 [#284]: https://github.com/PHeonix25/unifi_alerts/issues/284

--- a/custom_components/unifi_alerts/__init__.py
+++ b/custom_components/unifi_alerts/__init__.py
@@ -19,12 +19,8 @@ from homeassistant.helpers.storage import Store
 
 from .const import (
     ALL_CATEGORIES,
-    AUTH_METHOD_APIKEY,
     CONF_API_KEY,
-    CONF_AUTH_METHOD,
     CONF_CONTROLLER_URL,
-    CONF_PASSWORD,
-    CONF_USERNAME,
     CONF_VERIFY_SSL,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
@@ -99,9 +95,9 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 def _migrate_v3_to_v4(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Migrate a version-3 entry to the API-key-only version-4 schema.
 
-    Username/password auth is being removed (epic #277). Every version-3 entry
-    is moved to version 4 with any stored ``username``/``password`` dropped and
-    ``auth_method`` pinned to apikey:
+    Username/password auth has been removed (epic #277). Every version-3 entry
+    is moved to version 4 with any stored username/password (and the now-unused
+    auth_method marker) dropped:
 
     - Entries that already carry a non-empty ``api_key`` migrate silently and
       keep working with no user action.
@@ -118,9 +114,11 @@ def _migrate_v3_to_v4(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """
     new_data = dict(config_entry.data)
     had_api_key = bool(new_data.get(CONF_API_KEY))
-    new_data.pop(CONF_USERNAME, None)
-    new_data.pop(CONF_PASSWORD, None)
-    new_data[CONF_AUTH_METHOD] = AUTH_METHOD_APIKEY
+    # "username"/"password"/"auth_method" are legacy version-3 keys. The auth
+    # constants were removed with the userpass code (#279), so these are dropped
+    # by literal key; nothing reads auth_method any more.
+    for legacy_key in ("username", "password", "auth_method"):
+        new_data.pop(legacy_key, None)
     hass.config_entries.async_update_entry(config_entry, data=new_data, version=4)
     if had_api_key:
         _LOGGER.info(

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -23,15 +23,12 @@ from yarl import URL
 from .const import (
     ALL_CATEGORIES,
     CONF_API_KEY,
-    CONF_AUTH_METHOD,
     CONF_CLEAR_TIMEOUT,
     CONF_CONTROLLER_URL,
     CONF_ENABLED_CATEGORIES,
-    CONF_PASSWORD,
     CONF_POLL_INTERVAL,
     CONF_REGENERATE_WEBHOOK_SECRET,
     CONF_SITE,
-    CONF_USERNAME,
     CONF_VERIFY_SSL,
     CONF_WEBHOOK_ID_SUFFIX,
     CONF_WEBHOOK_SECRET,
@@ -102,12 +99,11 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         self._controller_url: str = ""
-        self._detected_auth_method: str | None = None
         self._credentials: dict[str, Any] = {}
         self._entry_data: dict[str, Any] = {}
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        """Step 1: controller URL + credentials."""
+        """Step 1: controller URL + API key."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
@@ -128,7 +124,7 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
                 client = UniFiClient(session, url, cast(UniFiClientConfig, user_input))
                 try:
-                    auth_method = await client.authenticate()
+                    await client.authenticate()
                     await client.fetch_alarms()  # validate alarm endpoint reachable
                 except InvalidAuthError:
                     errors["base"] = "invalid_auth"
@@ -139,7 +135,6 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                     errors["base"] = "cannot_connect"
                 else:
                     self._controller_url = url
-                    self._detected_auth_method = auth_method
                     # CONF_WEBHOOK_ID_SUFFIX is generated per-entry so two
                     # config entries can never collide on a webhook ID.
                     # 8 hex chars = 32 bits of entropy, plenty to avoid
@@ -151,44 +146,29 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                     }
                     return await self.async_step_categories()
 
-        _password_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
         _api_key_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
 
-        if user_input is not None:
-            # Rebuild schema with submitted values as defaults so the user
-            # doesn't have to re-enter everything on a validation error.
-            # Password/API key fields deliberately omit `default=` so HA does
-            # not pre-fill sensitive values — the user must re-enter them.
-            # Username uses a conditional default: omit entirely when empty so
-            # HA treats the field as truly blank rather than pre-filled.
-            _username = user_input.get(CONF_USERNAME, "")
-            schema = vol.Schema(
-                {
-                    vol.Required(CONF_CONTROLLER_URL, default=user_input[CONF_CONTROLLER_URL]): str,
-                    vol.Optional(
-                        CONF_USERNAME, **({"default": _username} if _username else {})
-                    ): str,
-                    vol.Optional(CONF_PASSWORD): _password_selector,
-                    vol.Optional(CONF_API_KEY): _api_key_selector,
-                    vol.Optional(
-                        CONF_VERIFY_SSL,
-                        default=user_input.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
-                    ): bool,
-                }
-            )
-        else:
-            # Use a pre-filled URL when arriving via SSDP discovery;
-            # fall back to the example placeholder for manual setup.
-            _url_default = self._controller_url or "https://192.168.1.1"
-            schema = vol.Schema(
-                {
-                    vol.Required(CONF_CONTROLLER_URL, default=_url_default): str,
-                    vol.Optional(CONF_USERNAME): str,
-                    vol.Optional(CONF_PASSWORD): _password_selector,
-                    vol.Optional(CONF_API_KEY): _api_key_selector,
-                    vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): bool,
-                }
-            )
+        # Use a pre-filled URL when arriving via SSDP discovery or re-showing the
+        # form after a validation error; fall back to the example placeholder.
+        # The API key field deliberately omits `default=` so HA does not pre-fill
+        # the secret — the user must re-enter it.
+        _url_default = (
+            user_input[CONF_CONTROLLER_URL]
+            if user_input is not None
+            else (self._controller_url or "https://192.168.1.1")
+        )
+        _verify_ssl_default = (
+            user_input.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
+            if user_input is not None
+            else DEFAULT_VERIFY_SSL
+        )
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_CONTROLLER_URL, default=_url_default): str,
+                vol.Required(CONF_API_KEY): _api_key_selector,
+                vol.Optional(CONF_VERIFY_SSL, default=_verify_ssl_default): bool,
+            }
+        )
         return self.async_show_form(
             step_id="user",
             data_schema=schema,
@@ -229,14 +209,10 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 site = user_input.get(CONF_SITE, DEFAULT_SITE)
                 if site != DEFAULT_SITE:
-                    creds_with_method = {
-                        **self._credentials,
-                        CONF_AUTH_METHOD: self._detected_auth_method,
-                    }
                     verify_ssl = self._credentials.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
                     session = async_get_clientsession(self.hass, verify_ssl=verify_ssl)
                     client = UniFiClient(
-                        session, self._controller_url, cast(UniFiClientConfig, creds_with_method)
+                        session, self._controller_url, cast(UniFiClientConfig, self._credentials)
                     )
                     try:
                         await client.authenticate()
@@ -257,7 +233,6 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                             CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT
                         ),
                         CONF_SITE: site,
-                        CONF_AUTH_METHOD: self._detected_auth_method,
                     }
                     return await self.async_step_finish()
 
@@ -341,7 +316,7 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
             )
             client = UniFiClient(session, url, cast(UniFiClientConfig, user_input))
             try:
-                auth_method = await client.authenticate()
+                await client.authenticate()
             except InvalidAuthError:
                 errors["base"] = "invalid_auth"
             except SslCertificateError:
@@ -357,7 +332,6 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                 new_data = {
                     **entry.data,
                     **user_input,
-                    CONF_AUTH_METHOD: auth_method,
                 }
                 self.hass.config_entries.async_update_entry(entry, data=new_data)
                 # Clear both possible repair issues now that auth is restored.
@@ -394,8 +368,6 @@ class _CredentialsFormInput:
     """Normalized values parsed from an options-flow credentials form submission."""
 
     new_url_raw: str
-    new_username: str
-    new_password: str
     new_api_key: str
     regenerate_secret: bool
     new_verify_ssl: bool
@@ -413,19 +385,15 @@ def _parse_credentials_form_input(
     without driving the full flow step.
     """
     new_url_raw = (user_input.get(CONF_CONTROLLER_URL) or "").strip()
-    new_username = (user_input.get(CONF_USERNAME) or "").strip()
-    new_password = (user_input.get(CONF_PASSWORD) or "").strip()
     new_api_key = (user_input.get(CONF_API_KEY) or "").strip()
     regenerate_secret = bool(user_input.get(CONF_REGENERATE_WEBHOOK_SECRET, False))
     current_verify_ssl = current_data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
     # verify_ssl always comes through as a bool (voluptuous default)
     new_verify_ssl = user_input.get(CONF_VERIFY_SSL, current_verify_ssl)
     verify_ssl_changed = new_verify_ssl != current_verify_ssl
-    credentials_changed = bool(new_url_raw or new_username or new_password or new_api_key)
+    credentials_changed = bool(new_url_raw or new_api_key)
     return _CredentialsFormInput(
         new_url_raw=new_url_raw,
-        new_username=new_username,
-        new_password=new_password,
         new_api_key=new_api_key,
         regenerate_secret=regenerate_secret,
         new_verify_ssl=new_verify_ssl,
@@ -466,10 +434,6 @@ def _credential_overrides(parsed: _CredentialsFormInput) -> dict[str, Any]:
     dict without clobbering unrelated stored values.
     """
     overrides: dict[str, Any] = {}
-    if parsed.new_username:
-        overrides[CONF_USERNAME] = parsed.new_username
-    if parsed.new_password:
-        overrides[CONF_PASSWORD] = parsed.new_password
     if parsed.new_api_key:
         overrides[CONF_API_KEY] = parsed.new_api_key
     return overrides
@@ -509,7 +473,6 @@ def _build_credentials_test_data(
 def _build_credentials_pending_data(
     current_data: Mapping[str, Any],
     effective_url: str,
-    auth_method: str,
     parsed: _CredentialsFormInput,
 ) -> dict[str, Any]:
     """Build the staged entry.data after new credentials validate successfully."""
@@ -517,7 +480,6 @@ def _build_credentials_pending_data(
         **current_data,
         CONF_CONTROLLER_URL: effective_url,
         CONF_VERIFY_SSL: parsed.new_verify_ssl,
-        CONF_AUTH_METHOD: auth_method,
         **_credential_overrides(parsed),
     }
     if parsed.regenerate_secret:
@@ -527,20 +489,17 @@ def _build_credentials_pending_data(
 
 async def _async_validate_controller_credentials(
     hass: Any, url: str, verify_ssl: bool, test_data: dict[str, Any]
-) -> str:
-    """Instantiate a UniFiClient and validate it can authenticate and reach
-    the alarm endpoint.
+) -> None:
+    """Instantiate a UniFiClient and validate the API key reaches the controller.
 
-    Returns the detected auth method on success. `InvalidAuthError`,
-    `SslCertificateError`, and `CannotConnectError` propagate unchanged so
-    the caller classifies them into its `errors` dict — this function does
-    not know about the options-flow error-key mapping.
+    `InvalidAuthError`, `SslCertificateError`, and `CannotConnectError`
+    propagate unchanged so the caller classifies them into its `errors` dict —
+    this function does not know about the options-flow error-key mapping.
     """
     session = async_get_clientsession(hass, verify_ssl=verify_ssl)
     client = UniFiClient(session, url, cast(UniFiClientConfig, test_data))
-    auth_method = await client.authenticate()
+    await client.authenticate()
     await client.fetch_alarms()
-    return auth_method
 
 
 class UniFiAlertsOptionsFlow(OptionsFlow):
@@ -604,7 +563,7 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
                     self._config_entry.data, effective_url, parsed
                 )
                 try:
-                    auth_method = await _async_validate_controller_credentials(
+                    await _async_validate_controller_credentials(
                         self.hass, effective_url, parsed.new_verify_ssl, test_data
                     )
                 except InvalidAuthError:
@@ -626,12 +585,11 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
                     # in the finish step, so abandoning the flow leaves nothing
                     # behind. async_update_entry is intentionally NOT called here.
                     self._pending_data = _build_credentials_pending_data(
-                        self._config_entry.data, effective_url, auth_method, parsed
+                        self._config_entry.data, effective_url, parsed
                     )
                     return await self.async_step_categories()
 
         # Build the credentials form — all fields optional with current values as hints
-        _password_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
         _api_key_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
         current_url: str = self._config_entry.data.get(CONF_CONTROLLER_URL, "")
         current_verify_ssl = self._config_entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
@@ -639,8 +597,6 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
         schema = vol.Schema(
             {
                 vol.Optional(CONF_CONTROLLER_URL): str,
-                vol.Optional(CONF_USERNAME): str,
-                vol.Optional(CONF_PASSWORD): _password_selector,
                 vol.Optional(CONF_API_KEY): _api_key_selector,
                 vol.Optional(CONF_VERIFY_SSL, default=current_verify_ssl): bool,
                 vol.Optional(CONF_REGENERATE_WEBHOOK_SECRET, default=False): bool,

--- a/custom_components/unifi_alerts/const.py
+++ b/custom_components/unifi_alerts/const.py
@@ -13,10 +13,7 @@ DOMAIN = "unifi_alerts"
 # UniFiClientConfig TypedDict keys; without this, `.get(key, default)`
 # returns `object` instead of the field's declared type.
 CONF_CONTROLLER_URL: Final = "controller_url"
-CONF_USERNAME: Final = "username"
-CONF_PASSWORD: Final = "password"
 CONF_API_KEY: Final = "api_key"
-CONF_AUTH_METHOD: Final = "auth_method"
 CONF_POLL_INTERVAL: Final = "poll_interval"
 CONF_CLEAR_TIMEOUT: Final = "clear_timeout"
 CONF_ENABLED_CATEGORIES: Final = "enabled_categories"
@@ -25,9 +22,6 @@ CONF_WEBHOOK_SECRET: Final = "webhook_secret"
 CONF_WEBHOOK_ID_SUFFIX: Final = "webhook_id_suffix"
 CONF_REGENERATE_WEBHOOK_SECRET: Final = "regenerate_webhook_secret"
 CONF_SITE: Final = "site"
-
-AUTH_METHOD_USERPASS = "userpass"
-AUTH_METHOD_APIKEY = "apikey"
 
 DEFAULT_POLL_INTERVAL = 60  # seconds
 DEFAULT_CLEAR_TIMEOUT = 30  # minutes

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -124,27 +124,11 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         try:
             categorised = await self._fetch_categorised()
         except InvalidAuthError as err:
-            # Re-authenticate once then retry
-            _LOGGER.warning("Auth expired, re-authenticating: %s", err)
-            try:
-                await self._client.authenticate()
-            except (InvalidAuthError, CannotConnectError) as reauth_err:
-                _LOGGER.error(
-                    "Re-authentication failed; credentials may have changed: %s", reauth_err
-                )
-                raise ConfigEntryAuthFailed(
-                    f"Re-authentication failed; credentials may have changed: {reauth_err}"
-                ) from reauth_err
-            try:
-                categorised = await self._fetch_categorised()
-            except InvalidAuthError as retry_err:
-                raise ConfigEntryAuthFailed(
-                    f"Re-authentication succeeded but the controller still returned 401: {retry_err}"
-                ) from retry_err
-            except CannotConnectError as retry_err:
-                raise UpdateFailed(
-                    f"Cannot reach UniFi controller after re-authentication: {retry_err}"
-                ) from retry_err
+            # The API key is a static credential with no session to refresh, so
+            # a 401 means the key was revoked or is otherwise no longer valid.
+            # Surface reauth directly instead of retrying.
+            _LOGGER.error("UniFi controller rejected the API key: %s", err)
+            raise ConfigEntryAuthFailed(f"UniFi controller rejected the API key: {err}") from err
         except CannotConnectError as err:
             raise UpdateFailed(f"Cannot reach UniFi controller: {err}") from err
 
@@ -215,9 +199,9 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
         try:
             has_v2 = await self._client.probe_system_log_endpoint(self._site)
         except (InvalidAuthError, CannotConnectError) as probe_err:
-            # probe_system_log_endpoint() only raises via its internal re-auth
-            # attempt (authenticate() when not yet authenticated); the HTTP probe
-            # itself catches aiohttp.ClientError internally and returns False.
+            # Defensive: the HTTP probe catches aiohttp.ClientError internally and
+            # returns False, so it should not raise. Guard anyway and fall back to
+            # the legacy path rather than failing the whole poll on a probe error.
             _LOGGER.debug(
                 "v2 system-log probe raised %s; falling back to legacy path",
                 type(probe_err).__name__,

--- a/custom_components/unifi_alerts/diagnostics.py
+++ b/custom_components/unifi_alerts/diagnostics.py
@@ -10,12 +10,10 @@ from homeassistant.core import HomeAssistant
 
 from .const import (
     CONF_API_KEY,
-    CONF_PASSWORD,
-    CONF_USERNAME,
     CONF_WEBHOOK_SECRET,
 )
 
-_TO_REDACT: set[str] = {CONF_PASSWORD, CONF_API_KEY, CONF_USERNAME, CONF_WEBHOOK_SECRET}
+_TO_REDACT: set[str] = {CONF_API_KEY, CONF_WEBHOOK_SECRET}
 
 
 async def async_get_config_entry_diagnostics(

--- a/custom_components/unifi_alerts/models.py
+++ b/custom_components/unifi_alerts/models.py
@@ -22,17 +22,10 @@ class UniFiClientConfig(TypedDict, total=False):
 
     total=False because legacy entries and credential subsets may omit fields;
     call sites use .get(key, default) for optional fields.
-
-    auth_method is typed as str (not Literal["userpass", "apikey"]) because the
-    value originates from user input and is validated in unifi_client.authenticate();
-    constraining the type here would force casts at the validation boundary.
     """
 
     controller_url: str
-    username: str
-    password: str
     api_key: str
-    auth_method: str
     verify_ssl: bool
     webhook_secret: str
     webhook_id_suffix: str

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -3,12 +3,10 @@
     "step": {
       "user": {
         "title": "Connect to UniFi Controller",
-        "description": "Enter your UniFi Network controller address and credentials. The integration will auto-detect which method to use.\n\n**API key** (UniFi OS consoles — UDM Pro, UCG Ultra, etc.): leave Username and Password blank. Generate an API key in the UniFi OS web UI — the exact location varies by firmware version. Common paths: **Settings → Admins & Users → API Keys** or **Integrations → New API Key**. See the integration README on GitHub for device-specific instructions.\n\n**Username / password** (older controllers or Cloud Key): fill in Username and Password, leave API Key blank.\n\nSSL verification is enabled by default. Disable it only if your controller uses a self-signed certificate.",
+        "description": "Enter your UniFi Network controller address and an API key.\n\nGenerate an API key in the UniFi OS web UI; the exact location varies by firmware version. Common paths: **Settings > Admins & Users > API Keys** or **Integrations > New API Key**. See the integration README on GitHub for device-specific instructions.\n\nSSL verification is enabled by default. Disable it only if your controller uses a self-signed certificate.",
         "data": {
           "controller_url": "Controller URL (e.g. https://192.168.1.1)",
-          "username": "Username (leave blank if using API key)",
-          "password": "Password",
-          "api_key": "API Key (UniFi OS only — leave blank if using username/password)",
+          "api_key": "API Key",
           "verify_ssl": "Verify SSL certificate"
         },
         "data_description": {
@@ -54,7 +52,7 @@
     },
     "error": {
       "cannot_connect": "Cannot reach the controller. Check the URL, port, and SSL settings. See Home Assistant logs for details.",
-      "invalid_auth": "Invalid credentials. Check your username/password or API key.",
+      "invalid_auth": "Invalid API key. Check the key and that it has not been revoked on the controller.",
       "invalid_ssl_cert": "SSL certificate verification failed. If this controller uses a self-signed certificate, untick \"Verify SSL certificate\" and try again.",
       "invalid_url_scheme": "Controller URL must start with http:// or https://.",
       "at_least_one_category": "Please enable at least one alert category.",
@@ -73,7 +71,7 @@
         "step": {
           "confirm": {
             "title": "Re-authenticate UniFi Alerts",
-            "description": "The credentials for **{name}** are no longer valid (e.g. the password or API key was changed). Enter new credentials to restore the connection."
+            "description": "The API key for **{name}** is no longer valid (for example it was revoked or regenerated on the controller). Enter a new API key to restore the connection."
           }
         }
       }
@@ -186,7 +184,7 @@
   "options": {
     "error": {
       "cannot_connect": "Cannot reach the controller. Check the URL, port, and SSL settings. See Home Assistant logs for details.",
-      "invalid_auth": "Invalid credentials. Check your username/password or API key.",
+      "invalid_auth": "Invalid API key. Check the key and that it has not been revoked on the controller.",
       "invalid_ssl_cert": "SSL certificate verification failed. If this controller uses a self-signed certificate, untick \"Verify SSL certificate\" and try again.",
       "invalid_url_scheme": "Controller URL must start with http:// or https://.",
       "at_least_one_category": "Please enable at least one alert category.",
@@ -195,11 +193,9 @@
     "step": {
       "credentials": {
         "title": "Update Controller Credentials",
-        "description": "Optionally update the controller URL or credentials. Leave all fields blank to skip this step and go straight to alert category settings.\n\nCurrent controller: {current_url}\n\nTick **Regenerate webhook secret** if you suspect the current token has been exposed (e.g. pasted into logs or shared issues). New webhook URLs will be shown on the final step — copy them into UniFi Alarm Manager before clicking Submit, or webhook delivery will start failing immediately.",
+        "description": "Optionally update the controller URL or API key. Leave the fields blank to skip this step and go straight to alert category settings.\n\nCurrent controller: {current_url}\n\nTick **Regenerate webhook secret** if you suspect the current token has been exposed (e.g. pasted into logs or shared issues). New webhook URLs will be shown on the final step; copy them into UniFi Alarm Manager before clicking Submit, or webhook delivery will start failing immediately.",
         "data": {
           "controller_url": "New Controller URL (leave blank to keep current)",
-          "username": "New Username (leave blank to keep current)",
-          "password": "New Password (leave blank to keep current)",
           "api_key": "New API Key (leave blank to keep current)",
           "verify_ssl": "Verify SSL certificate",
           "regenerate_webhook_secret": "Regenerate webhook secret"

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -3,12 +3,10 @@
     "step": {
       "user": {
         "title": "Connect to UniFi Controller",
-        "description": "Enter your UniFi Network controller address and credentials. The integration will auto-detect which method to use.\n\n**API key** (UniFi OS consoles — UDM Pro, UCG Ultra, etc.): leave Username and Password blank. Generate an API key in the UniFi OS web UI — the exact location varies by firmware version. Common paths: **Settings → Admins & Users → API Keys** or **Integrations → New API Key**. See the integration README on GitHub for device-specific instructions.\n\n**Username / password** (older controllers or Cloud Key): fill in Username and Password, leave API Key blank.\n\nSSL verification is enabled by default. Disable it only if your controller uses a self-signed certificate.",
+        "description": "Enter your UniFi Network controller address and an API key.\n\nGenerate an API key in the UniFi OS web UI; the exact location varies by firmware version. Common paths: **Settings > Admins & Users > API Keys** or **Integrations > New API Key**. See the integration README on GitHub for device-specific instructions.\n\nSSL verification is enabled by default. Disable it only if your controller uses a self-signed certificate.",
         "data": {
           "controller_url": "Controller URL (e.g. https://192.168.1.1)",
-          "username": "Username (leave blank if using API key)",
-          "password": "Password",
-          "api_key": "API Key (UniFi OS only — leave blank if using username/password)",
+          "api_key": "API Key",
           "verify_ssl": "Verify SSL certificate"
         },
         "data_description": {
@@ -54,7 +52,7 @@
     },
     "error": {
       "cannot_connect": "Cannot reach the controller. Check the URL, port, and SSL settings. See Home Assistant logs for details.",
-      "invalid_auth": "Invalid credentials. Check your username/password or API key.",
+      "invalid_auth": "Invalid API key. Check the key and that it has not been revoked on the controller.",
       "invalid_ssl_cert": "SSL certificate verification failed. If this controller uses a self-signed certificate, untick \"Verify SSL certificate\" and try again.",
       "invalid_url_scheme": "Controller URL must start with http:// or https://.",
       "at_least_one_category": "Please enable at least one alert category.",
@@ -73,7 +71,7 @@
         "step": {
           "confirm": {
             "title": "Re-authenticate UniFi Alerts",
-            "description": "The credentials for **{name}** are no longer valid (e.g. the password or API key was changed). Enter new credentials to restore the connection."
+            "description": "The API key for **{name}** is no longer valid (for example it was revoked or regenerated on the controller). Enter a new API key to restore the connection."
           }
         }
       }
@@ -186,7 +184,7 @@
   "options": {
     "error": {
       "cannot_connect": "Cannot reach the controller. Check the URL, port, and SSL settings. See Home Assistant logs for details.",
-      "invalid_auth": "Invalid credentials. Check your username/password or API key.",
+      "invalid_auth": "Invalid API key. Check the key and that it has not been revoked on the controller.",
       "invalid_ssl_cert": "SSL certificate verification failed. If this controller uses a self-signed certificate, untick \"Verify SSL certificate\" and try again.",
       "invalid_url_scheme": "Controller URL must start with http:// or https://.",
       "at_least_one_category": "Please enable at least one alert category.",
@@ -195,11 +193,9 @@
     "step": {
       "credentials": {
         "title": "Update Controller Credentials",
-        "description": "Optionally update the controller URL or credentials. Leave all fields blank to skip this step and go straight to alert category settings.\n\nCurrent controller: {current_url}\n\nTick **Regenerate webhook secret** if you suspect the current token has been exposed (e.g. pasted into logs or shared issues). New webhook URLs will be shown on the final step — copy them into UniFi Alarm Manager before clicking Submit, or webhook delivery will start failing immediately.",
+        "description": "Optionally update the controller URL or API key. Leave the fields blank to skip this step and go straight to alert category settings.\n\nCurrent controller: {current_url}\n\nTick **Regenerate webhook secret** if you suspect the current token has been exposed (e.g. pasted into logs or shared issues). New webhook URLs will be shown on the final step; copy them into UniFi Alarm Manager before clicking Submit, or webhook delivery will start failing immediately.",
         "data": {
           "controller_url": "New Controller URL (leave blank to keep current)",
-          "username": "New Username (leave blank to keep current)",
-          "password": "New Password (leave blank to keep current)",
           "api_key": "New API Key (leave blank to keep current)",
           "verify_ssl": "Verify SSL certificate",
           "regenerate_webhook_secret": "Regenerate webhook secret"

--- a/custom_components/unifi_alerts/unifi_auth.py
+++ b/custom_components/unifi_alerts/unifi_auth.py
@@ -1,9 +1,16 @@
 """Authentication seam for the UniFi Network controller.
 
-Holds the exceptions and the UniFiAuth class that UniFiClient composes for all
-credential verification, session state, and header construction. Kept in its
-own module so auth logic is unit-testable independently of transport,
-pagination, or alarm parsing.
+Holds the shared auth exceptions and the UniFiAuth class that UniFiClient
+composes for API-key verification and header construction. Kept in its own
+module so auth logic is unit-testable independently of transport, pagination,
+or alarm parsing.
+
+Decision (#279): this module is retained rather than folded into
+``unifi_client.py``. Even reduced to API-key verification plus header
+construction it owns the shared auth exceptions (``CannotConnectError``,
+``SslCertificateError``, ``InvalidAuthError``) imported across the integration
+(config flow, coordinator, client); inlining it would churn those imports for
+no real gain and lose the isolated test surface in ``test_unifi_auth.py``.
 """
 
 from __future__ import annotations
@@ -13,12 +20,7 @@ import logging
 import aiohttp
 
 from .const import (
-    AUTH_METHOD_APIKEY,
-    AUTH_METHOD_USERPASS,
     CONF_API_KEY,
-    CONF_AUTH_METHOD,
-    CONF_PASSWORD,
-    CONF_USERNAME,
     CONF_VERIFY_SSL,
     DEFAULT_VERIFY_SSL,
 )
@@ -56,15 +58,11 @@ class InvalidAuthError(Exception):
 
 
 class UniFiAuth:
-    """Authentication seam for UniFi OS controllers.
+    """Authentication seam for UniFi OS controllers using API-key auth.
 
-    Handles auth-method auto-detection, credential verification, session state,
-    and header construction.
-
-    Supports:
-      - API key auth (X-API-Key header)
-      - Username/password auth (session cookie)
-      - Auto-detection: tries API key first, falls back to username/password
+    Verifies the configured API key against the controller and builds the
+    ``X-API-Key`` request header. API keys are stateless: there is no session,
+    cookie, or login/logout to manage, so this class holds no auth state.
     """
 
     def __init__(
@@ -76,49 +74,22 @@ class UniFiAuth:
         self._session = session
         self._base = base_url
         self._config = config
-        self._method: str | None = None
-        self._authenticated: bool = False
-
-    @property
-    def authenticated(self) -> bool:
-        return self._authenticated
-
-    @property
-    def method(self) -> str | None:
-        return self._method
-
-    def invalidate(self) -> None:
-        """Mark the current session as expired (call on 401 responses)."""
-        self._authenticated = False
 
     def headers(self) -> dict[str, str]:
         """Return HTTP headers for an authenticated request."""
-        hdrs: dict[str, str] = {"Accept": "application/json"}
-        if self._method == AUTH_METHOD_APIKEY:
-            hdrs["X-API-Key"] = self._config.get(CONF_API_KEY, "")
-        return hdrs
+        return {
+            "Accept": "application/json",
+            "X-API-Key": self._config.get(CONF_API_KEY, ""),
+        }
 
-    async def authenticate(self) -> str:
-        """Authenticate to the UniFi OS controller. Returns the auth method used."""
-        method = self._config.get(CONF_AUTH_METHOD)
+    async def authenticate(self) -> None:
+        """Verify the configured API key against the UniFi OS controller.
 
-        if method == AUTH_METHOD_APIKEY or (method is None and self._config.get(CONF_API_KEY)):
-            try:
-                await self._verify_api_key()
-                self._method = AUTH_METHOD_APIKEY
-                self._authenticated = True
-                _LOGGER.debug("Authenticated via API key")
-                return AUTH_METHOD_APIKEY
-            except InvalidAuthError:
-                if method == AUTH_METHOD_APIKEY:
-                    raise
-                _LOGGER.debug("API key failed, falling back to username/password")
-
-        await self._login_userpass()
-        self._method = AUTH_METHOD_USERPASS
-        self._authenticated = True
-        _LOGGER.debug("Authenticated via username/password")
-        return AUTH_METHOD_USERPASS
+        Raises InvalidAuthError if the key is missing or rejected, or a
+        CannotConnectError subclass if the controller is unreachable.
+        """
+        await self._verify_api_key()
+        _LOGGER.debug("Authenticated via API key")
 
     async def _verify_api_key(self) -> None:
         api_key = self._config.get(CONF_API_KEY, "")
@@ -153,58 +124,5 @@ class UniFiAuth:
             raise
         except aiohttp.ClientConnectorCertificateError as err:
             raise SslCertificateError(type(err).__name__) from err
-        except aiohttp.ClientError as err:
-            raise CannotConnectError(type(err).__name__) from err
-
-    async def _login_userpass(self) -> None:
-        """Attempt username/password login via the UniFi OS path."""
-        paths = [f"{self._base}/api/auth/login"]
-
-        payload = {
-            "username": self._config.get(CONF_USERNAME, ""),
-            "password": self._config.get(CONF_PASSWORD, ""),
-        }
-        try:
-            for login_url in paths:
-                async with self._session.post(
-                    login_url,
-                    json=payload,
-                    ssl=self._config.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
-                    timeout=aiohttp.ClientTimeout(total=10),
-                    allow_redirects=False,
-                ) as resp:
-                    if 300 <= resp.status < 400:
-                        raise CannotConnectError(
-                            f"Controller login endpoint issued a redirect (HTTP {resp.status}); "
-                            "check the controller URL"
-                        )
-                    if resp.status == 400:
-                        _LOGGER.warning(
-                            "Controller rejected login request at %s (HTTP 400). "
-                            "Check the controller URL and that the controller version "
-                            "supports this integration.",
-                            login_url,
-                        )
-                        raise CannotConnectError(
-                            "Controller rejected login request (HTTP 400). "
-                            "Check the controller URL and that the controller version "
-                            "supports this integration."
-                        )
-                    if resp.status in (401, 403):
-                        _LOGGER.debug(
-                            "Authentication failed at %s (HTTP %d)",
-                            login_url,
-                            resp.status,
-                        )
-                        continue
-                    resp.raise_for_status()
-                    return  # success
-            last_url = paths[-1]
-            _LOGGER.warning("Authentication failed at login path (last: %s)", last_url)
-            raise InvalidAuthError("Invalid username or password", login_url=last_url)
-        except aiohttp.ClientConnectorCertificateError as err:
-            raise SslCertificateError(type(err).__name__) from err
-        except aiohttp.ClientResponseError as err:
-            raise CannotConnectError(f"{type(err).__name__} {err.status}") from err
         except aiohttp.ClientError as err:
             raise CannotConnectError(type(err).__name__) from err

--- a/custom_components/unifi_alerts/unifi_client.py
+++ b/custom_components/unifi_alerts/unifi_client.py
@@ -10,7 +10,6 @@ from typing import Any
 import aiohttp
 
 from .const import (
-    AUTH_METHOD_USERPASS,
     CONF_VERIFY_SSL,
     DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS,
     DEFAULT_VERIFY_SSL,
@@ -46,16 +45,14 @@ class InvalidSiteError(CannotConnectError):
 class UniFiClient:
     """Minimal async client for fetching alarms from a UniFi controller.
 
-    Supports:
-      - Username/password auth (session cookie)
-      - API key auth (X-API-Key header)
-      - Auto-detection: tries API key first, falls back to user/pass
+    Authenticates with an API key (X-API-Key header). API keys are stateless,
+    so there is no session bootstrap, cookie, or logout to manage.
 
-    Requires UniFi OS (UDM, UDM-Pro, UDM-SE, UCG-Ultra, UCG-Max, Cloud Key Gen2+).
-    Classic self-hosted Network Application controllers are not supported.
+    Requires UniFi OS (UDM, UDM-Pro, UDM-SE, UCG-Ultra, UCG-Max, Cloud Key Gen2+)
+    running Network Application 8.x+ (for API key support). Classic self-hosted
+    Network Application controllers are not supported.
 
-    Auth concerns are composed via a UniFiAuth instance (self._auth); this
-    class does not duplicate or proxy its state.
+    Auth concerns are composed via a UniFiAuth instance (self._auth).
     """
 
     def __init__(
@@ -81,16 +78,15 @@ class UniFiClient:
 
     # ── Public interface ──────────────────────────────────────────────────
 
-    async def authenticate(self) -> str:
-        """Authenticate to the UniFi OS controller. Returns the auth method used.
+    async def authenticate(self) -> None:
+        """Verify the configured API key against the UniFi OS controller.
 
         Auth itself is delegated to UniFiAuth; the probe-backoff reset is a
         client concern (probe state lives on the client, not on the auth seam),
-        so it runs here on every successful authentication.
+        so it runs here on every successful verification.
         """
-        method = await self._auth.authenticate()
+        await self._auth.authenticate()
         self._clear_probe_backoff()
-        return method
 
     def _clear_probe_backoff(self) -> None:
         """Reset probe-backoff state after successful authentication.
@@ -106,10 +102,11 @@ class UniFiClient:
             self._has_system_log = None
 
     async def fetch_alarms(self, site: str = "default") -> list[dict[str, Any]]:
-        """Return all unarchived alarms from the controller."""
-        if not self._auth.authenticated:
-            await self.authenticate()
+        """Return all unarchived alarms from the controller.
 
+        The API key is a stateless header (see UniFiAuth), so there is no
+        session to bootstrap here; the key is verified once at setup.
+        """
         # Different firmware versions expose the alarm endpoint at different paths.
         # Try the newest path first so modern firmware succeeds in one call; fall
         # back to older variants for backwards compatibility. Order matters —
@@ -149,8 +146,7 @@ class UniFiClient:
                         "request; refusing to follow to protect credentials"
                     )
                 if resp.status == 401:
-                    self._auth.invalidate()
-                    raise InvalidAuthError("Session expired")
+                    raise InvalidAuthError("API key rejected (HTTP 401)")
                 if resp.status == 404:
                     _LOGGER.debug("Alarm URL %s returned 404 — trying next URL", url)
                     return None
@@ -225,9 +221,6 @@ class UniFiClient:
                     return False
             else:
                 return self._has_system_log
-
-        if not self._auth.authenticated:
-            await self.authenticate()
 
         url = f"{self._base}{UNIFI_OS_NETWORK_PREFIX}/v2/api/site/{site}/system-log/count"
         _LOGGER.debug("Probing v2 system-log endpoint: %s", url)
@@ -310,9 +303,6 @@ class UniFiClient:
         Only events with status="NEW" are returned (equivalent to the legacy
         archived=False filter). Events with any other status are skipped.
         """
-        if not self._auth.authenticated:
-            await self.authenticate()
-
         now = datetime.now(UTC)
         if since is not None:
             from_dt = since
@@ -352,8 +342,9 @@ class UniFiClient:
                             "request; refusing to follow to protect credentials"
                         )
                     if resp.status == 401:
-                        self._auth.invalidate()
-                        raise InvalidAuthError("Session expired during system-log fetch")
+                        raise InvalidAuthError(
+                            "API key rejected during system-log fetch (HTTP 401)"
+                        )
                     resp.raise_for_status()
                     data = await resp.json()
             except aiohttp.ClientConnectorCertificateError as err:
@@ -414,16 +405,13 @@ class UniFiClient:
         return result
 
     async def close(self) -> None:
-        if self._auth.method == AUTH_METHOD_USERPASS and self._auth.authenticated:
-            try:
-                await self._session.post(
-                    f"{self._base}/api/auth/logout",
-                    ssl=self._config.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
-                    timeout=aiohttp.ClientTimeout(total=5),
-                    allow_redirects=False,
-                )
-            except (aiohttp.ClientError, OSError, TimeoutError) as err:
-                _LOGGER.warning("UniFi logout failed: %s", type(err).__name__)
+        """Release client resources.
+
+        API-key auth is stateless (no session to log out) and the aiohttp
+        session is owned by Home Assistant, so there is nothing to tear down.
+        Kept as an awaitable no-op so call sites (setup teardown, unload) need
+        no special-casing.
+        """
 
     # ── Private helpers ───────────────────────────────────────────────────
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,6 +16,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.unifi_alerts.const import (
     ALL_CATEGORIES,
+    CONF_API_KEY,
     CONF_CLEAR_TIMEOUT,
     CONF_CONTROLLER_URL,
     CONF_ENABLED_CATEGORIES,
@@ -67,15 +68,13 @@ HA_TEST_URL = "http://homeassistant.test:8123"
 
 BASE_CONFIG: dict = {
     CONF_CONTROLLER_URL: "https://192.168.1.1",
-    "username": "admin",
-    "password": "password",
+    CONF_API_KEY: "test-api-key",
     CONF_ENABLED_CATEGORIES: list(ALL_CATEGORIES),
     CONF_POLL_INTERVAL: DEFAULT_POLL_INTERVAL,
     CONF_CLEAR_TIMEOUT: DEFAULT_CLEAR_TIMEOUT,
     CONF_VERIFY_SSL: False,
     CONF_WEBHOOK_SECRET: WEBHOOK_SECRET,
     CONF_WEBHOOK_ID_SUFFIX: WEBHOOK_ID_SUFFIX,
-    "auth_method": "userpass",
     CONF_SITE: "default",
 }
 
@@ -99,7 +98,7 @@ def mock_unifi_client():
     """
     with patch("custom_components.unifi_alerts.UniFiClient") as mock_cls:
         instance = MagicMock()
-        instance.authenticate = AsyncMock(return_value="userpass")
+        instance.authenticate = AsyncMock(return_value=None)
         instance.categorise_alarms = AsyncMock(return_value={})
         instance.probe_system_log_endpoint = AsyncMock(return_value=False)
         instance.close = AsyncMock()
@@ -127,7 +126,7 @@ async def entry(hass, mock_unifi_client):
         domain=DOMAIN,
         data=dict(BASE_CONFIG),
         entry_id=ENTRY_ID,
-        version=3,
+        version=4,
     )
     config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/integration/test_apikey_migration.py
+++ b/tests/integration/test_apikey_migration.py
@@ -28,16 +28,12 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.unifi_alerts.const import (
     ALL_CATEGORIES,
-    AUTH_METHOD_APIKEY,
     CONF_API_KEY,
-    CONF_AUTH_METHOD,
     CONF_CLEAR_TIMEOUT,
     CONF_CONTROLLER_URL,
     CONF_ENABLED_CATEGORIES,
-    CONF_PASSWORD,
     CONF_POLL_INTERVAL,
     CONF_SITE,
-    CONF_USERNAME,
     CONF_VERIFY_SSL,
     CONF_WEBHOOK_ID_SUFFIX,
     CONF_WEBHOOK_SECRET,
@@ -58,7 +54,7 @@ WEBHOOK_ID_SUFFIX = "abadcafe"
 def _make_client_mock() -> MagicMock:
     """Return a mock UniFiClient wired for the coordinator's first refresh."""
     instance = MagicMock()
-    instance.authenticate = AsyncMock(return_value=AUTH_METHOD_APIKEY)
+    instance.authenticate = AsyncMock(return_value=None)
     instance.categorise_alarms = AsyncMock(return_value={})
     instance.probe_system_log_endpoint = AsyncMock(return_value=False)
     instance.close = AsyncMock()
@@ -101,8 +97,8 @@ async def test_apikey_entry_migrates_silently_to_v4(hass):
 
     entry = _v3_entry(
         {
-            CONF_USERNAME: "admin",
-            CONF_PASSWORD: "password",
+            "username": "admin",
+            "password": "password",
             CONF_API_KEY: "existing-api-key",
         }
     )
@@ -117,9 +113,9 @@ async def test_apikey_entry_migrates_silently_to_v4(hass):
         assert entry.state is ConfigEntryState.LOADED
         assert entry.version == 4
         assert entry.data[CONF_API_KEY] == "existing-api-key"
-        assert entry.data[CONF_AUTH_METHOD] == AUTH_METHOD_APIKEY
-        assert CONF_USERNAME not in entry.data
-        assert CONF_PASSWORD not in entry.data
+        assert "auth_method" not in entry.data
+        assert "username" not in entry.data
+        assert "password" not in entry.data
 
         # Identity-preserving fields untouched.
         assert entry.entry_id == "migration-test-entry"
@@ -149,7 +145,7 @@ async def test_userpass_entry_migrates_and_is_restored_via_reauth(hass):
     """A v3 userpass-only entry migrates to v4, lands in reauth, and is restored by an API key."""
     await _prepare_hass(hass)
 
-    entry = _v3_entry({CONF_USERNAME: "admin", CONF_PASSWORD: "password"})
+    entry = _v3_entry({"username": "admin", "password": "password"})
     entry.add_to_hass(hass)
 
     client = _make_client_mock()
@@ -166,10 +162,10 @@ async def test_userpass_entry_migrates_and_is_restored_via_reauth(hass):
 
         # Migrated to v4 with credentials removed, but not loaded (awaiting reauth).
         assert entry.version == 4
-        assert CONF_USERNAME not in entry.data
-        assert CONF_PASSWORD not in entry.data
+        assert "username" not in entry.data
+        assert "password" not in entry.data
         assert CONF_API_KEY not in entry.data
-        assert entry.data[CONF_AUTH_METHOD] == AUTH_METHOD_APIKEY
+        assert "auth_method" not in entry.data
         assert entry.state is not ConfigEntryState.LOADED
 
         # The explanatory migration repair issue is raised (not a generic auth failure).
@@ -188,7 +184,7 @@ async def test_userpass_entry_migrates_and_is_restored_via_reauth(hass):
         flow_id = reauth_flows[0]["flow_id"]
 
         # Supplying a valid API key restores the connection.
-        client.authenticate = AsyncMock(return_value=AUTH_METHOD_APIKEY)
+        client.authenticate = AsyncMock(return_value=None)
         result = await hass.config_entries.flow.async_configure(
             flow_id, {CONF_API_KEY: "new-api-key"}
         )
@@ -200,7 +196,7 @@ async def test_userpass_entry_migrates_and_is_restored_via_reauth(hass):
         # Entry reloaded and now carries the API key.
         assert entry.state is ConfigEntryState.LOADED
         assert entry.data[CONF_API_KEY] == "new-api-key"
-        assert entry.data[CONF_AUTH_METHOD] == AUTH_METHOD_APIKEY
+        assert "auth_method" not in entry.data
 
         # Identity-preserving fields survived the whole journey.
         assert entry.entry_id == "migration-test-entry"

--- a/tests/unit/config_flow/conftest.py
+++ b/tests/unit/config_flow/conftest.py
@@ -10,16 +10,13 @@ from custom_components.unifi_alerts.const import (
     CONF_API_KEY,
     CONF_CONTROLLER_URL,
     CONF_ENABLED_CATEGORIES,
-    CONF_PASSWORD,
-    CONF_USERNAME,
     CONF_VERIFY_SSL,
     CONF_WEBHOOK_SECRET,
 )
 
 _VALID_INPUT = {
     CONF_CONTROLLER_URL: "https://192.168.1.1",
-    CONF_USERNAME: "admin",
-    CONF_PASSWORD: "secret",
+    CONF_API_KEY: "test-api-key",
 }
 
 
@@ -54,8 +51,7 @@ def make_reauth_flow(entry_id: str = "entry-test") -> UniFiAlertsConfigFlow:
     mock_entry.title = "UniFi Alerts (https://192.168.1.1)"
     mock_entry.data = {
         CONF_CONTROLLER_URL: "https://192.168.1.1",
-        CONF_USERNAME: "admin",
-        CONF_PASSWORD: "oldpassword",
+        CONF_API_KEY: "old-api-key",
         CONF_WEBHOOK_SECRET: "secret",
     }
 
@@ -77,9 +73,7 @@ def make_options_flow(
     config_entry.entry_id = "entry-options-creds"
     config_entry.data = {
         CONF_CONTROLLER_URL: url,
-        CONF_USERNAME: "admin",
-        CONF_PASSWORD: "secret",
-        CONF_API_KEY: "",
+        CONF_API_KEY: "existing-api-key",
         CONF_VERIFY_SSL: True,
         CONF_WEBHOOK_SECRET: "fixed-secret",
         CONF_ENABLED_CATEGORIES: enabled_categories or ALL_CATEGORIES,

--- a/tests/unit/config_flow/test_options_credentials.py
+++ b/tests/unit/config_flow/test_options_credentials.py
@@ -16,8 +16,6 @@ from custom_components.unifi_alerts.const import (
     CONF_API_KEY,
     CONF_CONTROLLER_URL,
     CONF_ENABLED_CATEGORIES,
-    CONF_PASSWORD,
-    CONF_USERNAME,
     CONF_VERIFY_SSL,
     CONF_WEBHOOK_SECRET,
 )
@@ -140,8 +138,6 @@ async def test_options_flow_full_cycle() -> None:
     # Step 1: blank credentials -> skip to categories
     blank_creds = {
         CONF_CONTROLLER_URL: "",
-        CONF_USERNAME: "",
-        CONF_PASSWORD: "",
         CONF_API_KEY: "",
         CONF_VERIFY_SSL: True,
     }
@@ -268,7 +264,7 @@ async def test_options_flow_saves_submitted_values() -> None:
         ),
     ):
         instance = mock_cls.return_value
-        instance.authenticate = AsyncMock(return_value="apikey")
+        instance.authenticate = AsyncMock(return_value=None)
         instance.fetch_alarms = AsyncMock(return_value=[])
         await flow.async_step_categories(user_input)
 
@@ -337,8 +333,6 @@ class TestOptionsFlowCredentials:
 
         blank_input = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: True,
         }
@@ -362,9 +356,7 @@ class TestOptionsFlowCredentials:
 
         new_creds = {
             CONF_CONTROLLER_URL: "https://10.0.0.1",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "newpass",
-            CONF_API_KEY: "",
+            CONF_API_KEY: "new-key",
             CONF_VERIFY_SSL: True,
         }
 
@@ -376,9 +368,8 @@ class TestOptionsFlowCredentials:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
-            instance._is_unifi_os = False
 
             result = await flow.async_step_credentials(new_creds)
 
@@ -387,7 +378,7 @@ class TestOptionsFlowCredentials:
 
         # The pending values must be staged, ready for async_step_finish to commit
         assert flow._pending_data[CONF_CONTROLLER_URL] == "https://10.0.0.1"
-        assert flow._pending_data[CONF_PASSWORD] == "newpass"
+        assert flow._pending_data[CONF_API_KEY] == "new-key"
 
         # Should have continued to categories
         assert result["step_id"] == "categories"
@@ -402,9 +393,7 @@ class TestOptionsFlowCredentials:
 
         new_creds = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "baduser",
-            CONF_PASSWORD: "wrongpass",
-            CONF_API_KEY: "",
+            CONF_API_KEY: "bad-key",
             CONF_VERIFY_SSL: True,
         }
 
@@ -435,8 +424,6 @@ class TestOptionsFlowCredentials:
 
         bad_url_input = {
             CONF_CONTROLLER_URL: "ftp://192.168.1.1",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: True,
         }
@@ -468,8 +455,6 @@ class TestOptionsFlowCredentials:
 
         new_creds = {
             CONF_CONTROLLER_URL: "https://10.0.0.1",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: True,
         }
@@ -482,7 +467,7 @@ class TestOptionsFlowCredentials:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
             instance._is_unifi_os = False
 
@@ -504,9 +489,7 @@ class TestOptionsFlowCredentials:
         # First: update credentials
         new_creds = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "newadmin",
-            CONF_PASSWORD: "",
-            CONF_API_KEY: "",
+            CONF_API_KEY: "new-key",
             CONF_VERIFY_SSL: False,
         }
 
@@ -518,7 +501,7 @@ class TestOptionsFlowCredentials:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
             instance._is_unifi_os = True
 
@@ -527,7 +510,7 @@ class TestOptionsFlowCredentials:
         # The credentials step must NOT persist eagerly -- the staged data is
         # only committed once async_step_finish runs.
         flow.hass.config_entries.async_update_entry.assert_not_called()
-        assert flow._pending_data[CONF_USERNAME] == "newadmin"
+        assert flow._pending_data[CONF_API_KEY] == "new-key"
 
         # Now: submit the categories step (stores in _pending_options, routes to finish)
         first_cat = ALL_CATEGORIES[0]
@@ -551,7 +534,7 @@ class TestOptionsFlowCredentials:
         assert result["type"] == "create_entry"
         flow.hass.config_entries.async_update_entry.assert_called_once()
         committed = flow.hass.config_entries.async_update_entry.call_args.kwargs["data"]
-        assert committed[CONF_USERNAME] == "newadmin"
+        assert committed[CONF_API_KEY] == "new-key"
         saved = flow.async_create_entry.call_args.kwargs["data"]
         assert saved[CONF_ENABLED_CATEGORIES] == [first_cat]
         assert saved[CONF_POLL_INTERVAL] == 90
@@ -571,9 +554,7 @@ class TestOptionsFlowCredentials:
 
         new_creds = {
             CONF_CONTROLLER_URL: "https://10.0.0.1",
-            CONF_USERNAME: "newadmin",
-            CONF_PASSWORD: "newpass",
-            CONF_API_KEY: "",
+            CONF_API_KEY: "new-key",
             CONF_VERIFY_SSL: True,
         }
 
@@ -585,7 +566,7 @@ class TestOptionsFlowCredentials:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
             instance._is_unifi_os = False
             await flow.async_step_credentials(new_creds)
@@ -594,7 +575,7 @@ class TestOptionsFlowCredentials:
         # entry.data must NOT have been written. The staged dict holds the
         # change that *would* have been committed if the user had finished.
         flow.hass.config_entries.async_update_entry.assert_not_called()
-        assert flow._pending_data[CONF_PASSWORD] == "newpass"
+        assert flow._pending_data[CONF_API_KEY] == "new-key"
 
     @pytest.mark.asyncio
     async def test_verify_ssl_only_toggle_stages_and_skips_auth(self) -> None:
@@ -609,8 +590,6 @@ class TestOptionsFlowCredentials:
         # Fixture default is verify_ssl=True; flip to False
         ssl_only = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: False,
         }
@@ -624,7 +603,7 @@ class TestOptionsFlowCredentials:
         flow.hass.config_entries.async_update_entry.assert_not_called()
         assert flow._pending_data[CONF_VERIFY_SSL] is False
         # Other entry-data keys must be carried over unchanged
-        assert flow._pending_data[CONF_USERNAME] == "admin"
+        assert flow._pending_data[CONF_API_KEY] == "existing-api-key"
         assert flow._pending_data[CONF_WEBHOOK_SECRET] == "fixed-secret"
 
     @pytest.mark.asyncio
@@ -642,8 +621,6 @@ class TestOptionsFlowCredentials:
         await flow.async_step_credentials(
             {
                 CONF_CONTROLLER_URL: "",
-                CONF_USERNAME: "",
-                CONF_PASSWORD: "",
                 CONF_API_KEY: "",
                 CONF_VERIFY_SSL: False,
             }
@@ -672,8 +649,6 @@ class TestOptionsFlowCredentials:
 
         same_input = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: True,
         }
@@ -697,9 +672,7 @@ class TestOptionsCredentialsErrorsAndStaging:
         flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "credentials"})
         user_input = {
             CONF_CONTROLLER_URL: "https://10.0.0.1",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "newpass",
-            CONF_API_KEY: "",
+            CONF_API_KEY: "new-key",
             CONF_VERIFY_SSL: True,
         }
 
@@ -725,9 +698,7 @@ class TestOptionsCredentialsErrorsAndStaging:
         flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "credentials"})
         user_input = {
             CONF_CONTROLLER_URL: "https://10.0.0.1",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "newpass",
-            CONF_API_KEY: "",
+            CONF_API_KEY: "new-key",
             CONF_VERIFY_SSL: True,
         }
 
@@ -751,8 +722,6 @@ class TestOptionsCredentialsErrorsAndStaging:
         flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
         user_input = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "new-api-key",
             CONF_VERIFY_SSL: True,
         }
@@ -765,7 +734,7 @@ class TestOptionsCredentialsErrorsAndStaging:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="apikey")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
             result = await flow.async_step_credentials(user_input)
 

--- a/tests/unit/config_flow/test_options_helpers.py
+++ b/tests/unit/config_flow/test_options_helpers.py
@@ -2,7 +2,8 @@
 
 Split out of test_options.py (#283) by behaviour area. See
 test_options_credentials.py and test_options_rotation_validation.py for the
-other pieces.
+other pieces. API-key only (#279): username/password fields are gone, so the
+credential a user can change here is the API key.
 """
 
 from __future__ import annotations
@@ -14,8 +15,6 @@ import pytest
 from custom_components.unifi_alerts.const import (
     CONF_API_KEY,
     CONF_CONTROLLER_URL,
-    CONF_PASSWORD,
-    CONF_USERNAME,
     CONF_VERIFY_SSL,
     CONF_WEBHOOK_SECRET,
 )
@@ -32,8 +31,6 @@ class TestParseCredentialsFormInput:
         current_data = {CONF_VERIFY_SSL: True}
         blank_input = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: True,
         }
@@ -50,17 +47,14 @@ class TestParseCredentialsFormInput:
         current_data = {CONF_VERIFY_SSL: True}
         whitespace_input = {
             CONF_CONTROLLER_URL: "   ",
-            CONF_USERNAME: "  ",
-            CONF_PASSWORD: " ",
-            CONF_API_KEY: "",
+            CONF_API_KEY: "  ",
             CONF_VERIFY_SSL: True,
         }
 
         parsed = _parse_credentials_form_input(whitespace_input, current_data)
 
         assert parsed.new_url_raw == ""
-        assert parsed.new_username == ""
-        assert parsed.new_password == ""
+        assert parsed.new_api_key == ""
         assert parsed.credentials_changed is False
 
     def test_url_change_marks_credentials_changed(self) -> None:
@@ -69,8 +63,6 @@ class TestParseCredentialsFormInput:
         current_data = {CONF_VERIFY_SSL: True}
         user_input = {
             CONF_CONTROLLER_URL: "https://10.0.0.5",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: True,
         }
@@ -80,14 +72,27 @@ class TestParseCredentialsFormInput:
         assert parsed.credentials_changed is True
         assert parsed.new_url_raw == "https://10.0.0.5"
 
+    def test_api_key_change_marks_credentials_changed(self) -> None:
+        from custom_components.unifi_alerts.config_flow import _parse_credentials_form_input
+
+        current_data = {CONF_VERIFY_SSL: True}
+        user_input = {
+            CONF_CONTROLLER_URL: "",
+            CONF_API_KEY: "new-key",
+            CONF_VERIFY_SSL: True,
+        }
+
+        parsed = _parse_credentials_form_input(user_input, current_data)
+
+        assert parsed.credentials_changed is True
+        assert parsed.new_api_key == "new-key"
+
     def test_verify_ssl_change_is_detected_against_current_data(self) -> None:
         from custom_components.unifi_alerts.config_flow import _parse_credentials_form_input
 
         current_data = {CONF_VERIFY_SSL: True}
         user_input = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: False,
         }
@@ -104,8 +109,6 @@ class TestParseCredentialsFormInput:
         current_data = {CONF_VERIFY_SSL: False}
         user_input = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
         }
 
@@ -121,8 +124,6 @@ class TestParseCredentialsFormInput:
         current_data = {CONF_VERIFY_SSL: True}
         user_input = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: True,
             CONF_REGENERATE_WEBHOOK_SECRET: True,
@@ -225,8 +226,6 @@ class TestCredentialOverrides:
         parsed = _parse_credentials_form_input(
             {
                 CONF_CONTROLLER_URL: "",
-                CONF_USERNAME: "",
-                CONF_PASSWORD: "",
                 CONF_API_KEY: "",
                 CONF_VERIFY_SSL: True,
             },
@@ -244,15 +243,13 @@ class TestCredentialOverrides:
         parsed = _parse_credentials_form_input(
             {
                 CONF_CONTROLLER_URL: "",
-                CONF_USERNAME: "",
-                CONF_PASSWORD: "newpass",
-                CONF_API_KEY: "",
+                CONF_API_KEY: "new-key",
                 CONF_VERIFY_SSL: True,
             },
             {CONF_VERIFY_SSL: True},
         )
 
-        assert _credential_overrides(parsed) == {CONF_PASSWORD: "newpass"}
+        assert _credential_overrides(parsed) == {CONF_API_KEY: "new-key"}
 
 
 class TestBuildVerifySslAndSecretOnlyPending:
@@ -266,15 +263,13 @@ class TestBuildVerifySslAndSecretOnlyPending:
 
         current_data = {
             CONF_CONTROLLER_URL: "https://192.168.1.1",
-            CONF_USERNAME: "admin",
+            CONF_API_KEY: "existing-key",
             CONF_VERIFY_SSL: True,
             CONF_WEBHOOK_SECRET: "fixed-secret",
         }
         parsed = _parse_credentials_form_input(
             {
                 CONF_CONTROLLER_URL: "",
-                CONF_USERNAME: "",
-                CONF_PASSWORD: "",
                 CONF_API_KEY: "",
                 CONF_VERIFY_SSL: False,
             },
@@ -284,7 +279,7 @@ class TestBuildVerifySslAndSecretOnlyPending:
         pending = _build_verify_ssl_and_secret_only_pending(current_data, parsed)
 
         assert pending[CONF_VERIFY_SSL] is False
-        assert pending[CONF_USERNAME] == "admin"
+        assert pending[CONF_API_KEY] == "existing-key"
         assert pending[CONF_WEBHOOK_SECRET] == "fixed-secret"
 
     def test_regenerate_secret_replaces_webhook_secret(self) -> None:
@@ -298,8 +293,6 @@ class TestBuildVerifySslAndSecretOnlyPending:
         parsed = _parse_credentials_form_input(
             {
                 CONF_CONTROLLER_URL: "",
-                CONF_USERNAME: "",
-                CONF_PASSWORD: "",
                 CONF_API_KEY: "",
                 CONF_VERIFY_SSL: True,
                 CONF_REGENERATE_WEBHOOK_SECRET: True,
@@ -324,16 +317,13 @@ class TestBuildCredentialsTestData:
 
         current_data = {
             CONF_CONTROLLER_URL: "https://192.168.1.1",
-            CONF_USERNAME: "admin",
-            CONF_PASSWORD: "oldpass",
+            CONF_API_KEY: "old-key",
             CONF_VERIFY_SSL: True,
         }
         parsed = _parse_credentials_form_input(
             {
                 CONF_CONTROLLER_URL: "https://10.0.0.1",
-                CONF_USERNAME: "",
-                CONF_PASSWORD: "newpass",
-                CONF_API_KEY: "",
+                CONF_API_KEY: "new-key",
                 CONF_VERIFY_SSL: True,
             },
             current_data,
@@ -342,21 +332,18 @@ class TestBuildCredentialsTestData:
         test_data = _build_credentials_test_data(current_data, "https://10.0.0.1", parsed)
 
         assert test_data[CONF_CONTROLLER_URL] == "https://10.0.0.1"
-        assert test_data[CONF_PASSWORD] == "newpass"
-        # Username was left blank, so the stored value carries over unchanged
-        assert test_data[CONF_USERNAME] == "admin"
+        assert test_data[CONF_API_KEY] == "new-key"
 
 
 class TestBuildCredentialsPendingData:
     """Tests for _build_credentials_pending_data, used to stage entry.data
     after new credentials validate successfully."""
 
-    def test_includes_auth_method_and_overrides(self) -> None:
+    def test_includes_overrides(self) -> None:
         from custom_components.unifi_alerts.config_flow import (
             _build_credentials_pending_data,
             _parse_credentials_form_input,
         )
-        from custom_components.unifi_alerts.const import CONF_AUTH_METHOD
 
         current_data = {
             CONF_CONTROLLER_URL: "https://192.168.1.1",
@@ -366,21 +353,16 @@ class TestBuildCredentialsPendingData:
         parsed = _parse_credentials_form_input(
             {
                 CONF_CONTROLLER_URL: "https://10.0.0.1",
-                CONF_USERNAME: "",
-                CONF_PASSWORD: "newpass",
-                CONF_API_KEY: "",
+                CONF_API_KEY: "new-key",
                 CONF_VERIFY_SSL: True,
             },
             current_data,
         )
 
-        pending = _build_credentials_pending_data(
-            current_data, "https://10.0.0.1", "userpass", parsed
-        )
+        pending = _build_credentials_pending_data(current_data, "https://10.0.0.1", parsed)
 
         assert pending[CONF_CONTROLLER_URL] == "https://10.0.0.1"
-        assert pending[CONF_AUTH_METHOD] == "userpass"
-        assert pending[CONF_PASSWORD] == "newpass"
+        assert pending[CONF_API_KEY] == "new-key"
         # No rotation requested, so the secret carries over unchanged
         assert pending[CONF_WEBHOOK_SECRET] == "fixed-secret"
 
@@ -399,18 +381,14 @@ class TestBuildCredentialsPendingData:
         parsed = _parse_credentials_form_input(
             {
                 CONF_CONTROLLER_URL: "https://10.0.0.1",
-                CONF_USERNAME: "",
-                CONF_PASSWORD: "newpass",
-                CONF_API_KEY: "",
+                CONF_API_KEY: "new-key",
                 CONF_VERIFY_SSL: True,
                 CONF_REGENERATE_WEBHOOK_SECRET: True,
             },
             current_data,
         )
 
-        pending = _build_credentials_pending_data(
-            current_data, "https://10.0.0.1", "userpass", parsed
-        )
+        pending = _build_credentials_pending_data(current_data, "https://10.0.0.1", parsed)
 
         assert pending[CONF_WEBHOOK_SECRET] != "fixed-secret"
 
@@ -419,7 +397,7 @@ class TestAsyncValidateControllerCredentials:
     """Tests for _async_validate_controller_credentials, the extracted API-validation helper."""
 
     @pytest.mark.asyncio
-    async def test_returns_auth_method_on_success(self) -> None:
+    async def test_validates_successfully(self) -> None:
         from custom_components.unifi_alerts.config_flow import (
             _async_validate_controller_credentials,
         )
@@ -432,14 +410,14 @@ class TestAsyncValidateControllerCredentials:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="apikey")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
 
-            auth_method = await _async_validate_controller_credentials(
+            result = await _async_validate_controller_credentials(
                 MagicMock(), "https://10.0.0.1", True, {CONF_API_KEY: "key"}
             )
 
-        assert auth_method == "apikey"
+        assert result is None
         mock_get_session.assert_called_once()
         instance.authenticate.assert_awaited_once()
         instance.fetch_alarms.assert_awaited_once()
@@ -503,7 +481,7 @@ class TestAsyncValidateControllerCredentials:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(side_effect=CannotConnectError("down"))
 
             with pytest.raises(CannotConnectError):

--- a/tests/unit/config_flow/test_options_rotation_validation.py
+++ b/tests/unit/config_flow/test_options_rotation_validation.py
@@ -16,8 +16,6 @@ from custom_components.unifi_alerts.const import (
     CONF_API_KEY,
     CONF_CONTROLLER_URL,
     CONF_ENABLED_CATEGORIES,
-    CONF_PASSWORD,
-    CONF_USERNAME,
     CONF_VERIFY_SSL,
     CONF_WEBHOOK_SECRET,
 )
@@ -47,8 +45,6 @@ class TestWebhookSecretRotation:
 
         rotate_only = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: True,
             CONF_REGENERATE_WEBHOOK_SECRET: True,
@@ -77,9 +73,7 @@ class TestWebhookSecretRotation:
 
         new_input = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "newpass",
-            CONF_API_KEY: "",
+            CONF_API_KEY: "new-key",
             CONF_VERIFY_SSL: True,
             CONF_REGENERATE_WEBHOOK_SECRET: True,
         }
@@ -92,14 +86,13 @@ class TestWebhookSecretRotation:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
-            instance._is_unifi_os = False
             await flow.async_step_credentials(new_input)
 
         # No eager persistence; staged for finish.
         flow.hass.config_entries.async_update_entry.assert_not_called()
-        assert flow._pending_data[CONF_PASSWORD] == "newpass"
+        assert flow._pending_data[CONF_API_KEY] == "new-key"
         assert flow._pending_data[CONF_WEBHOOK_SECRET] != "fixed-secret"
 
     @pytest.mark.asyncio
@@ -112,8 +105,6 @@ class TestWebhookSecretRotation:
 
         no_rotate = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: True,
             CONF_REGENERATE_WEBHOOK_SECRET: False,
@@ -156,8 +147,6 @@ class TestWebhookSecretRotation:
         await flow.async_step_credentials(
             {
                 CONF_CONTROLLER_URL: "",
-                CONF_USERNAME: "",
-                CONF_PASSWORD: "",
                 CONF_API_KEY: "",
                 CONF_VERIFY_SSL: True,
                 CONF_REGENERATE_WEBHOOK_SECRET: True,
@@ -219,8 +208,6 @@ class TestWebhookSecretRotationRepairIssue:
         await flow.async_step_credentials(
             {
                 CONF_CONTROLLER_URL: "",
-                CONF_USERNAME: "",
-                CONF_PASSWORD: "",
                 CONF_API_KEY: "",
                 CONF_VERIFY_SSL: True,
                 CONF_REGENERATE_WEBHOOK_SECRET: True,
@@ -291,9 +278,9 @@ class TestWebhookSecretRotationRepairIssue:
             CONF_CLEAR_TIMEOUT: 5,
             CONF_SITE: "default",
         }
-        # _pending_data has a new username but the SAME secret
+        # _pending_data has a new API key but the SAME secret
         flow._pending_data = {
-            CONF_USERNAME: "new-admin",
+            CONF_API_KEY: "new-key",
             CONF_WEBHOOK_SECRET: "fixed-secret",
         }
 
@@ -326,8 +313,6 @@ class TestOptionsFlowUniqueIdFollowsUrl:
 
         new_creds = {
             CONF_CONTROLLER_URL: "https://10.0.0.1",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: True,
         }
@@ -340,7 +325,7 @@ class TestOptionsFlowUniqueIdFollowsUrl:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
             instance._is_unifi_os = False
             await flow.async_step_credentials(new_creds)
@@ -371,8 +356,6 @@ class TestOptionsFlowUniqueIdFollowsUrl:
 
         ssl_only = {
             CONF_CONTROLLER_URL: "",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: False,
         }
@@ -417,8 +400,6 @@ class TestOptionsFlowUniqueIdFollowsUrl:
 
         new_creds = {
             CONF_CONTROLLER_URL: "https://10.0.0.1",
-            CONF_USERNAME: "",
-            CONF_PASSWORD: "",
             CONF_API_KEY: "",
             CONF_VERIFY_SSL: True,
         }
@@ -431,7 +412,7 @@ class TestOptionsFlowUniqueIdFollowsUrl:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
             instance._is_unifi_os = False
             result = await flow.async_step_credentials(new_creds)
@@ -478,7 +459,7 @@ class TestOptionsFlowSiteValidation:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="apikey")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(
                 side_effect=InvalidSiteError("Site 'bogus-site' not found")
             )
@@ -524,7 +505,7 @@ class TestOptionsFlowSiteValidation:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="apikey")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
             result = await flow.async_step_categories(cat_input)
 
@@ -554,7 +535,7 @@ class TestOptionsFlowSiteValidation:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="apikey")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
             result = await flow.async_step_categories(cat_input)
 
@@ -583,7 +564,7 @@ class TestOptionsFlowSiteValidation:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="apikey")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(side_effect=CannotConnectError("Connection refused"))
             result = await flow.async_step_categories(cat_input)
 

--- a/tests/unit/config_flow/test_reauth.py
+++ b/tests/unit/config_flow/test_reauth.py
@@ -9,8 +9,6 @@ import pytest
 from custom_components.unifi_alerts.config_flow import UniFiAlertsConfigFlow
 from custom_components.unifi_alerts.const import (
     CONF_API_KEY,
-    CONF_PASSWORD,
-    CONF_USERNAME,
 )
 
 from .conftest import make_reauth_flow, make_session_mock
@@ -229,7 +227,7 @@ class TestReauthConfirmStep:
         flow = make_reauth_flow()
         flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reauth_confirm"})
 
-        new_creds = {CONF_USERNAME: "admin", CONF_PASSWORD: "wrongpassword"}
+        new_creds = {CONF_API_KEY: "bad-key"}
 
         with (
             patch(
@@ -265,9 +263,7 @@ class TestReauthConfirmStep:
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(side_effect=CannotConnectError("down"))
 
-            result = await flow.async_step_reauth_confirm(
-                user_input={CONF_USERNAME: "admin", CONF_PASSWORD: "pass"}
-            )
+            result = await flow.async_step_reauth_confirm(user_input={CONF_API_KEY: "some-key"})
 
         assert result["step_id"] == "reauth_confirm"
         call_kwargs = flow.async_show_form.call_args.kwargs
@@ -291,9 +287,7 @@ class TestReauthConfirmStep:
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(side_effect=SslCertificateError("cert"))
 
-            result = await flow.async_step_reauth_confirm(
-                user_input={CONF_USERNAME: "admin", CONF_PASSWORD: "pass"}
-            )
+            result = await flow.async_step_reauth_confirm(user_input={CONF_API_KEY: "some-key"})
 
         assert result["step_id"] == "reauth_confirm"
         call_kwargs = flow.async_show_form.call_args.kwargs
@@ -318,9 +312,7 @@ class TestReauthConfirmStep:
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(side_effect=InvalidAuthError("bad"))
 
-            await flow.async_step_reauth_confirm(
-                user_input={CONF_USERNAME: "admin", CONF_PASSWORD: "wrong"}
-            )
+            await flow.async_step_reauth_confirm(user_input={CONF_API_KEY: "bad-key"})
 
         mock_del.assert_not_called()
 

--- a/tests/unit/config_flow/test_setup.py
+++ b/tests/unit/config_flow/test_setup.py
@@ -14,8 +14,6 @@ from custom_components.unifi_alerts.const import (
     CONF_API_KEY,
     CONF_CONTROLLER_URL,
     CONF_ENABLED_CATEGORIES,
-    CONF_PASSWORD,
-    CONF_USERNAME,
     CONF_VERIFY_SSL,
     CONF_WEBHOOK_SECRET,
     DEFAULT_VERIFY_SSL,
@@ -52,7 +50,7 @@ class TestUserStep:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
 
             await flow.async_step_user(
@@ -117,7 +115,7 @@ class TestUserStep:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
 
             result = await flow.async_step_user(_VALID_INPUT)
@@ -138,9 +136,7 @@ class TestUserStep:
 
         submitted = {
             CONF_CONTROLLER_URL: "https://10.0.0.1",
-            CONF_USERNAME: "myuser",
-            CONF_PASSWORD: "mypassword",
-            CONF_API_KEY: "",
+            CONF_API_KEY: "bad-key",
             CONF_VERIFY_SSL: False,
         }
 
@@ -169,9 +165,7 @@ class TestUserStep:
             str(k): k.default() for k in schema.schema if k.default is not vol.UNDEFINED
         }
         assert schema_defaults.get(CONF_CONTROLLER_URL) == "https://10.0.0.1"
-        assert schema_defaults.get(CONF_USERNAME) == "myuser"
-        # Password and API key fields must NOT be pre-filled — they have no default
-        assert CONF_PASSWORD not in schema_defaults
+        # The API key field must NOT be pre-filled — it has no default
         assert CONF_API_KEY not in schema_defaults
         assert schema_defaults.get(CONF_VERIFY_SSL) is False
 
@@ -194,7 +188,7 @@ class TestUserStep:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
 
             await flow.async_step_user({**_VALID_INPUT, CONF_VERIFY_SSL: False})
@@ -240,7 +234,7 @@ class TestUserStep:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(
                 side_effect=CannotConnectError("UniFi API error: api.err.InvalidObject")
             )
@@ -291,7 +285,7 @@ class TestUserStep:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(side_effect=SslCertificateError("cert error"))
 
             result = await flow.async_step_user(_VALID_INPUT)
@@ -325,7 +319,7 @@ class TestUserStep:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(return_value=[])
             instance._is_unifi_os = False
 
@@ -355,7 +349,7 @@ class TestUserStep:
                 patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
             ):
                 instance = mock_cls.return_value
-                instance.authenticate = AsyncMock(return_value="userpass")
+                instance.authenticate = AsyncMock(return_value=None)
                 instance.fetch_alarms = AsyncMock(return_value=[])
                 instance._is_unifi_os = False
                 await flow.async_step_user(_VALID_INPUT)
@@ -371,7 +365,6 @@ class TestCategoriesStep:
         """Submitting categories with nothing selected must show an error, not proceed."""
         flow = make_flow()
         flow._controller_url = "https://192.168.1.1"
-        flow._detected_auth_method = "userpass"
         flow._credentials = dict(_VALID_INPUT)
         flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
 
@@ -387,7 +380,6 @@ class TestCategoriesStep:
         """Submitting categories should proceed to the finish step, not create the entry."""
         flow = make_flow()
         flow._controller_url = "https://192.168.1.1"
-        flow._detected_auth_method = "userpass"
         flow._credentials = dict(_VALID_INPUT)
 
         finish_result = {"type": "form", "step_id": "finish"}
@@ -406,7 +398,6 @@ class TestCategoriesStep:
 
         flow = make_flow()
         flow._controller_url = "https://192.168.1.1"
-        flow._detected_auth_method = "userpass"
         flow._credentials = {CONF_WEBHOOK_SECRET: "s"}
         flow.async_step_finish = AsyncMock(return_value={"type": "form", "step_id": "finish"})
 
@@ -427,7 +418,6 @@ class TestCategoriesStep:
 
         flow = make_flow()
         flow._controller_url = "https://192.168.1.1"
-        flow._detected_auth_method = "userpass"
         flow._credentials = {CONF_WEBHOOK_SECRET: "s"}
         flow.async_step_finish = AsyncMock(return_value={"type": "form", "step_id": "finish"})
 
@@ -446,7 +436,6 @@ class TestCategoriesStep:
 
         flow = make_flow()
         flow._controller_url = "https://192.168.1.1"
-        flow._detected_auth_method = "userpass"
         flow._credentials = {CONF_WEBHOOK_SECRET: "s"}
         flow.async_step_finish = AsyncMock(return_value={"type": "form", "step_id": "finish"})
 
@@ -465,7 +454,6 @@ class TestCategoriesStep:
 
         flow = make_flow()
         flow._controller_url = "https://192.168.1.1"
-        flow._detected_auth_method = "apikey"
         flow._credentials = {**_VALID_INPUT}
         flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
 
@@ -500,7 +488,6 @@ class TestCategoriesStep:
 
         flow = make_flow()
         flow._controller_url = "https://192.168.1.1"
-        flow._detected_auth_method = "apikey"
         flow._credentials = {**_VALID_INPUT}
         flow.async_step_finish = AsyncMock(return_value={"type": "form", "step_id": "finish"})
 
@@ -522,7 +509,6 @@ class TestCategoriesStep:
 
         flow = make_flow()
         flow._controller_url = "https://192.168.1.1"
-        flow._detected_auth_method = "userpass"
         flow._credentials = {**_VALID_INPUT}
         flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
 
@@ -537,7 +523,7 @@ class TestCategoriesStep:
             patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
         ):
             instance = mock_cls.return_value
-            instance.authenticate = AsyncMock(return_value="userpass")
+            instance.authenticate = AsyncMock(return_value=None)
             instance.fetch_alarms = AsyncMock(side_effect=CannotConnectError("Network timeout"))
 
             result = await flow.async_step_categories(cat_input)
@@ -614,8 +600,8 @@ class TestMigration:
         entry.version = 1
         entry.data = {
             CONF_CONTROLLER_URL: "https://192.168.1.1",
-            CONF_USERNAME: "admin",
-            CONF_PASSWORD: "secret",
+            "username": "admin",
+            "password": "secret",
             CONF_VERIFY_SSL: True,
             "is_unifi_os": True,  # stale key from v1
         }
@@ -638,6 +624,6 @@ class TestMigration:
         assert "is_unifi_os" not in entry.data
         # Remaining fields must be preserved
         assert entry.data[CONF_CONTROLLER_URL] == "https://192.168.1.1"
-        # v3->4 dropped the legacy userpass credentials and pinned apikey auth
-        assert CONF_USERNAME not in entry.data
-        assert CONF_PASSWORD not in entry.data
+        # v3->4 dropped the legacy userpass credentials
+        assert "username" not in entry.data
+        assert "password" not in entry.data

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -11,12 +11,11 @@ import pytest
 
 from custom_components.unifi_alerts.const import (
     ALL_CATEGORIES,
+    CONF_API_KEY,
     CONF_CLEAR_TIMEOUT,
     CONF_CONTROLLER_URL,
     CONF_ENABLED_CATEGORIES,
-    CONF_PASSWORD,
     CONF_POLL_INTERVAL,
-    CONF_USERNAME,
     CONF_VERIFY_SSL,
     DEFAULT_CLEAR_TIMEOUT,
     DEFAULT_POLL_INTERVAL,
@@ -24,8 +23,7 @@ from custom_components.unifi_alerts.const import (
 
 MOCK_CONFIG = {
     CONF_CONTROLLER_URL: "https://192.168.1.1",
-    CONF_USERNAME: "admin",
-    CONF_PASSWORD: "password",
+    CONF_API_KEY: "test-api-key",
     CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
     CONF_POLL_INTERVAL: DEFAULT_POLL_INTERVAL,
     CONF_CLEAR_TIMEOUT: DEFAULT_CLEAR_TIMEOUT,
@@ -38,7 +36,7 @@ def mock_unifi_client() -> Generator[MagicMock]:
     """Mock UniFiClient so tests never make real HTTP calls."""
     with patch("custom_components.unifi_alerts.unifi_client.UniFiClient") as mock_cls:
         instance = mock_cls.return_value
-        instance.authenticate = AsyncMock(return_value="userpass")
+        instance.authenticate = AsyncMock(return_value=None)
         instance.categorise_alarms = AsyncMock(return_value={})
         instance.probe_system_log_endpoint = AsyncMock(return_value=False)
         instance.close = AsyncMock()
@@ -98,8 +96,7 @@ def make_entry(
     entry.entry_id = entry_id
     entry.data = data or {
         CONF_CONTROLLER_URL: "https://192.168.1.1",
-        CONF_USERNAME: "admin",
-        CONF_PASSWORD: "password",
+        CONF_API_KEY: "test-api-key",
         CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
         CONF_POLL_INTERVAL: DEFAULT_POLL_INTERVAL,
         CONF_CLEAR_TIMEOUT: DEFAULT_CLEAR_TIMEOUT,

--- a/tests/unit/coordinator/test_polling.py
+++ b/tests/unit/coordinator/test_polling.py
@@ -75,95 +75,26 @@ class TestPollingErrorPaths:
     """Tests for _async_update_data error handling."""
 
     @pytest.mark.asyncio
-    async def test_invalid_auth_triggers_re_auth_and_retries(self):
-        """On InvalidAuthError the coordinator re-authenticates once and retries."""
-        from custom_components.unifi_alerts.unifi_client import InvalidAuthError
+    async def test_invalid_auth_raises_config_entry_auth_failed(self):
+        """A 401 on a static API key must raise ConfigEntryAuthFailed directly, no retry.
 
-        hass, client = make_hass_and_client()
-        # First call raises InvalidAuthError; after re-auth the second call succeeds
-        client.categorise_alarms = AsyncMock(side_effect=[InvalidAuthError("expired"), {}])
-        client.authenticate = AsyncMock()
-        coord = make_full_coordinator(hass, client)
-
-        # Should not raise
-        await coord._async_update_data()
-        client.authenticate.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("categorise_side_effect", "authenticate_side_effect"),
-        [
-            pytest.param(
-                "auth_error",
-                "auth_error",
-                id="reauth-itself-raises-invalid-auth",
-            ),
-            pytest.param(
-                "auth_error",
-                "cannot_connect",
-                id="reauth-itself-raises-cannot-connect",
-            ),
-            pytest.param(
-                "auth_error_twice",
-                None,
-                id="reauth-succeeds-but-retry-still-401",
-            ),
-        ],
-    )
-    async def test_reauth_failure_paths_raise_config_entry_auth_failed(
-        self, categorise_side_effect, authenticate_side_effect
-    ):
-        """Every path that ends without a valid session must raise ConfigEntryAuthFailed.
-
-        Covers: re-auth itself raising InvalidAuthError, re-auth itself raising
-        CannotConnectError, and re-auth succeeding but the retried fetch still
-        returning 401.
+        The API key has no session to refresh, so a rejected key means it was
+        revoked/regenerated: surface reauth immediately rather than re-attempting.
         """
         from homeassistant.exceptions import ConfigEntryAuthFailed
 
-        from custom_components.unifi_alerts.unifi_client import CannotConnectError, InvalidAuthError
-
-        categorise_effects = {
-            "auth_error": InvalidAuthError("expired"),
-            "auth_error_twice": [InvalidAuthError("expired"), InvalidAuthError("still 401")],
-        }
-        authenticate_effects = {
-            None: None,
-            "auth_error": InvalidAuthError("still bad"),
-            "cannot_connect": CannotConnectError("unreachable during reauth"),
-        }
+        from custom_components.unifi_alerts.unifi_client import InvalidAuthError
 
         hass, client = make_hass_and_client()
-        client.categorise_alarms = AsyncMock(side_effect=categorise_effects[categorise_side_effect])
-        client.authenticate = AsyncMock(side_effect=authenticate_effects[authenticate_side_effect])
+        client.categorise_alarms = AsyncMock(side_effect=InvalidAuthError("revoked"))
+        client.authenticate = AsyncMock()
         coord = make_full_coordinator(hass, client)
 
         with pytest.raises(ConfigEntryAuthFailed):
             await coord._async_update_data()
 
-        client.authenticate.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_reauth_succeeds_but_retry_fails_raises_update_failed_with_distinctive_message(
-        self,
-    ):
-        """Re-auth succeeds but retried categorise_alarms fails → UpdateFailed with 'after re-authentication'."""
-        from homeassistant.helpers.update_coordinator import UpdateFailed
-
-        from custom_components.unifi_alerts.unifi_client import CannotConnectError, InvalidAuthError
-
-        hass, client = make_hass_and_client()
-        # First categorise_alarms call fails with auth error; re-auth succeeds; second call fails
-        client.categorise_alarms = AsyncMock(
-            side_effect=[InvalidAuthError("expired"), CannotConnectError("controller 500")]
-        )
-        client.authenticate = AsyncMock()  # re-auth succeeds
-        coord = make_full_coordinator(hass, client)
-
-        with pytest.raises(UpdateFailed) as exc_info:
-            await coord._async_update_data()
-
-        assert "after re-authentication" in str(exc_info.value)
+        # No re-authentication is attempted for a static key.
+        client.authenticate.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_cannot_connect_raises_update_failed(self):

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -11,7 +11,7 @@ from conftest import MOCK_CONFIG
 from custom_components.unifi_alerts.const import (
     ALL_CATEGORIES,
     CONF_API_KEY,
-    CONF_PASSWORD,
+    CONF_WEBHOOK_SECRET,
 )
 from custom_components.unifi_alerts.diagnostics import async_get_config_entry_diagnostics
 from custom_components.unifi_alerts.models import CategoryState
@@ -65,13 +65,15 @@ class TestDiagnosticsRedaction:
     """Tests that sensitive config fields are redacted and non-sensitive fields are preserved."""
 
     @pytest.mark.asyncio
-    async def test_redacts_password(self) -> None:
-        entry = _make_entry_with_runtime(_make_coordinator())
+    async def test_redacts_webhook_secret(self) -> None:
+        entry = _make_entry_with_runtime(
+            _make_coordinator(), extra_data={CONF_WEBHOOK_SECRET: "super-secret-token"}
+        )
         hass = MagicMock()
 
         result = await async_get_config_entry_diagnostics(hass, entry)
 
-        assert result["config_entry"][CONF_PASSWORD] == "**REDACTED**"
+        assert result["config_entry"][CONF_WEBHOOK_SECRET] == "**REDACTED**"
 
     @pytest.mark.asyncio
     async def test_redacts_api_key(self) -> None:
@@ -92,7 +94,6 @@ class TestDiagnosticsRedaction:
         result = await async_get_config_entry_diagnostics(hass, entry)
 
         assert result["config_entry"]["controller_url"] == "https://192.168.1.1"
-        assert result["config_entry"]["username"] == "**REDACTED**"
 
 
 class TestDiagnosticsContent:

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -9,15 +9,11 @@ from conftest import make_entry, make_hass, patch_setup_entry_collaborators
 
 from custom_components.unifi_alerts.const import (
     ALL_CATEGORIES,
-    AUTH_METHOD_APIKEY,
     CONF_API_KEY,
-    CONF_AUTH_METHOD,
     CONF_CLEAR_TIMEOUT,
     CONF_CONTROLLER_URL,
     CONF_ENABLED_CATEGORIES,
-    CONF_PASSWORD,
     CONF_POLL_INTERVAL,
-    CONF_USERNAME,
     CONF_VERIFY_SSL,
     CONF_WEBHOOK_ID_SUFFIX,
     CONF_WEBHOOK_SECRET,
@@ -657,8 +653,8 @@ class TestAsyncMigrateEntry:
             data={
                 CONF_CONTROLLER_URL: "https://192.168.1.1",
                 CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
-                CONF_USERNAME: "admin",
-                CONF_PASSWORD: "password",
+                "username": "admin",
+                "password": "password",
                 "is_unifi_os": True,  # legacy field to be stripped in v1->2
             }
         )
@@ -681,7 +677,7 @@ class TestAsyncMigrateEntry:
 
     @pytest.mark.asyncio
     async def test_v3_with_api_key_migrates_silently_to_v4(self):
-        """A v3 entry with an API key drops userpass, pins apikey, and bumps to v4."""
+        """A v3 entry with an API key drops legacy userpass keys and bumps to v4."""
         from custom_components.unifi_alerts import async_migrate_entry
 
         hass = make_hass()
@@ -689,8 +685,9 @@ class TestAsyncMigrateEntry:
             data={
                 CONF_CONTROLLER_URL: "https://192.168.1.1",
                 CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
-                CONF_USERNAME: "admin",
-                CONF_PASSWORD: "password",
+                "username": "admin",
+                "password": "password",
+                "auth_method": "apikey",
                 CONF_API_KEY: "existing-api-key",
                 CONF_WEBHOOK_SECRET: "fake-secret",
                 CONF_WEBHOOK_ID_SUFFIX: "deadbeef",
@@ -705,16 +702,17 @@ class TestAsyncMigrateEntry:
         assert result is True
         assert entry.version == 4
         assert entry.data[CONF_API_KEY] == "existing-api-key"
-        assert entry.data[CONF_AUTH_METHOD] == AUTH_METHOD_APIKEY
-        assert CONF_USERNAME not in entry.data
-        assert CONF_PASSWORD not in entry.data
+        # Legacy userpass keys (and the now-unused auth_method marker) are dropped.
+        assert "username" not in entry.data
+        assert "password" not in entry.data
+        assert "auth_method" not in entry.data
         # Identity-preserving fields untouched.
         assert entry.data[CONF_WEBHOOK_SECRET] == "fake-secret"
         assert entry.data[CONF_WEBHOOK_ID_SUFFIX] == "deadbeef"
 
     @pytest.mark.asyncio
     async def test_v3_userpass_only_migrates_to_v4_without_credentials(self):
-        """A v3 userpass-only entry loses its credentials and is pinned to apikey for reauth."""
+        """A v3 userpass-only entry loses its credentials, leaving no api_key for reauth."""
         from custom_components.unifi_alerts import async_migrate_entry
 
         hass = make_hass()
@@ -722,8 +720,8 @@ class TestAsyncMigrateEntry:
             data={
                 CONF_CONTROLLER_URL: "https://192.168.1.1",
                 CONF_ENABLED_CATEGORIES: ALL_CATEGORIES,
-                CONF_USERNAME: "admin",
-                CONF_PASSWORD: "password",
+                "username": "admin",
+                "password": "password",
                 CONF_WEBHOOK_SECRET: "fake-secret",
                 CONF_WEBHOOK_ID_SUFFIX: "deadbeef",
             }
@@ -736,10 +734,9 @@ class TestAsyncMigrateEntry:
 
         assert result is True
         assert entry.version == 4
-        assert CONF_USERNAME not in entry.data
-        assert CONF_PASSWORD not in entry.data
+        assert "username" not in entry.data
+        assert "password" not in entry.data
         assert CONF_API_KEY not in entry.data
-        assert entry.data[CONF_AUTH_METHOD] == AUTH_METHOD_APIKEY
         # Identity-preserving fields untouched, so entities/history/webhooks survive.
         assert entry.data[CONF_WEBHOOK_SECRET] == "fake-secret"
         assert entry.data[CONF_WEBHOOK_ID_SUFFIX] == "deadbeef"
@@ -754,7 +751,6 @@ class TestAsyncMigrateEntry:
             data={
                 CONF_CONTROLLER_URL: "https://192.168.1.1",
                 CONF_API_KEY: "key",
-                CONF_AUTH_METHOD: AUTH_METHOD_APIKEY,
             }
         )
         entry.version = 4

--- a/tests/unit/test_unifi_auth.py
+++ b/tests/unit/test_unifi_auth.py
@@ -1,4 +1,9 @@
-"""Tests for the UniFi authentication seam (UniFiAuth)."""
+"""Tests for the UniFi authentication seam (UniFiAuth).
+
+API-key auth only (#279): username/password login and method auto-detection
+were removed, so UniFiAuth verifies the configured key and builds the
+X-API-Key header, with no session state.
+"""
 
 from __future__ import annotations
 
@@ -19,8 +24,7 @@ def make_auth(config: dict | None = None) -> UniFiAuth:
     """Create a standalone UniFiAuth for unit-testing auth logic in isolation."""
     session = MagicMock()
     cfg = config or {
-        "username": "admin",
-        "password": "password",
+        "api_key": "test-key",
         "verify_ssl": False,
     }
     return UniFiAuth(session, "https://192.168.1.1", cfg)
@@ -41,125 +45,29 @@ def _make_response(status: int, headers: dict | None = None):
 
 
 class TestHeaders:
-    """Tests for UniFiAuth.headers() — auth header construction in isolation."""
+    """Tests for UniFiAuth.headers() — header construction in isolation."""
 
-    def test_userpass_auth_no_api_key_header(self):
-        auth = make_auth()
-        auth._method = "userpass"
-        headers = auth.headers()
-        assert "X-API-Key" not in headers
-
-    def test_apikey_auth_adds_header(self):
+    def test_headers_always_include_api_key(self):
         auth = make_auth({"api_key": "test-key-123", "verify_ssl": False})
-        auth._method = "apikey"
         headers = auth.headers()
-        assert headers.get("X-API-Key") == "test-key-123"
+        assert headers["X-API-Key"] == "test-key-123"
+        assert headers["Accept"] == "application/json"
 
-
-class TestLoginUserpass:
-    """Tests for UniFiAuth._login_userpass - tested in isolation via make_auth()."""
-
-    @pytest.mark.asyncio
-    async def test_http_400_raises_cannot_connect(self):
-        """HTTP 400 from the controller must raise CannotConnectError, not InvalidAuthError.
-
-        UCG-Ultra returns 400 for request format / endpoint mismatch — this is
-        NOT a credentials problem, so we must not show 'invalid credentials'.
-        """
-        auth = make_auth()
-        ctx = _make_response(400)
-        auth._session.post = ctx
-        with pytest.raises(CannotConnectError):
-            await auth._login_userpass()
-
-    @pytest.mark.asyncio
-    async def test_login_client_error_message_is_class_name_not_url(self):
-        """CannotConnectError from _login_userpass must use class name, not str(err).
-
-        Same credential-leak prevention as fetch_alarms: aiohttp errors can embed
-        the login URL (which may contain the password) in their string representation.
-        """
-        import aiohttp
-
-        auth = make_auth()
-
-        @asynccontextmanager
-        async def _raise(*args, **kwargs):
-            raise aiohttp.ClientConnectionError("https://admin:hunter2@192.168.1.1/api/login")
-            yield
-
-        auth._session.post = _raise
-        with pytest.raises(CannotConnectError) as exc_info:
-            await auth._login_userpass()
-        assert "hunter2" not in str(exc_info.value)
-        assert exc_info.value.args[0] == "ClientConnectionError"
-
-    @pytest.mark.asyncio
-    async def test_http_401_raises_invalid_auth(self):
-        """HTTP 401 should still raise InvalidAuthError (bad credentials)."""
-        auth = make_auth()
-        ctx = _make_response(401)
-        auth._session.post = ctx
-        with pytest.raises(InvalidAuthError):
-            await auth._login_userpass()
-
-    @pytest.mark.asyncio
-    async def test_http_403_raises_invalid_auth(self):
-        """HTTP 403 should still raise InvalidAuthError (bad credentials)."""
-        auth = make_auth()
-        ctx = _make_response(403)
-        auth._session.post = ctx
-        with pytest.raises(InvalidAuthError):
-            await auth._login_userpass()
-
-    @pytest.mark.asyncio
-    async def test_invalid_auth_error_carries_login_url(self):
-        """InvalidAuthError raised must carry login_url attribute pointing to /api/auth/login."""
-        auth = make_auth()
-        ctx = _make_response(401)
-        auth._session.post = ctx
-        with pytest.raises(InvalidAuthError) as exc_info:
-            await auth._login_userpass()
-        # UniFi OS path is the only path now.
-        assert exc_info.value.login_url.endswith("/api/auth/login")
-
-    @pytest.mark.asyncio
-    async def test_success_returns_without_error(self):
-        """HTTP 200 from the UniFi OS login path must succeed without raising."""
-        auth = make_auth()
-        ctx = _make_response(200)
-        auth._session.post = ctx
-        # Should not raise
-        await auth._login_userpass()
-
-    @pytest.mark.asyncio
-    async def test_redirect_raises_cannot_connect(self):
-        """3xx from the login endpoint must raise CannotConnectError, not follow the redirect."""
-        auth = make_auth()
-        ctx = _make_response(302)
-        auth._session.post = ctx
-        with pytest.raises(CannotConnectError, match="redirect"):
-            await auth._login_userpass()
-
-    @pytest.mark.asyncio
-    async def test_login_userpass_raises_ssl_cert_error(self):
-        """aiohttp.ClientConnectorCertificateError in _login_userpass must raise SslCertificateError."""
-        import aiohttp
-
-        auth = make_auth()
-
-        @asynccontextmanager
-        async def _raise(*args, **kwargs):
-            raise aiohttp.ClientConnectorCertificateError(MagicMock(), MagicMock())
-            yield  # type: ignore[misc]
-
-        auth._session.post = _raise
-        with pytest.raises(SslCertificateError):
-            await auth._login_userpass()
+    def test_headers_empty_api_key_when_missing(self):
+        auth = make_auth({"verify_ssl": False})
+        headers = auth.headers()
+        assert headers["X-API-Key"] == ""
 
 
 class TestVerifyApiKey:
     """Tests for UniFiAuth._verify_api_key - tested in isolation via make_auth()."""
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_raises_invalid_auth(self):
+        """No API key configured must raise InvalidAuthError before any request."""
+        auth = make_auth({"verify_ssl": False})
+        with pytest.raises(InvalidAuthError, match="No API key provided"):
+            await auth._verify_api_key()
 
     @pytest.mark.asyncio
     async def test_always_uses_proxy_network_prefix(self):
@@ -206,6 +114,26 @@ class TestVerifyApiKey:
             await auth._verify_api_key()
 
     @pytest.mark.asyncio
+    async def test_403_raises_invalid_auth(self):
+        """HTTP 403 from the API key endpoint must raise InvalidAuthError."""
+        auth = make_auth({"api_key": "bad-key", "verify_ssl": False})
+        ctx = _make_response(403)
+        auth._session.get = ctx
+
+        with pytest.raises(InvalidAuthError):
+            await auth._verify_api_key()
+
+    @pytest.mark.asyncio
+    async def test_invalid_auth_error_carries_login_url(self):
+        """InvalidAuthError raised on 401 must carry the verify endpoint as login_url."""
+        auth = make_auth({"api_key": "bad-key", "verify_ssl": False})
+        ctx = _make_response(401)
+        auth._session.get = ctx
+        with pytest.raises(InvalidAuthError) as exc_info:
+            await auth._verify_api_key()
+        assert exc_info.value.login_url.endswith("/api/s/default/self")
+
+    @pytest.mark.asyncio
     async def test_redirect_raises_cannot_connect(self):
         """A 3xx from the API key endpoint must raise CannotConnectError (no redirect)."""
         auth = make_auth({"api_key": "my-key", "verify_ssl": False})
@@ -233,65 +161,57 @@ class TestVerifyApiKey:
 
     @pytest.mark.asyncio
     async def test_verify_api_key_generic_client_error_raises_cannot_connect(self):
-        """A generic aiohttp.ClientError in _verify_api_key must raise CannotConnectError."""
+        """A generic aiohttp.ClientError in _verify_api_key must raise CannotConnectError.
+
+        The message must be the exception class name, not str(err), so a URL that
+        might embed the key is never surfaced.
+        """
         import aiohttp
 
         auth = make_auth({"api_key": "test-key", "verify_ssl": True})
 
         @asynccontextmanager
         async def _raise(*args, **kwargs):
-            raise aiohttp.ClientConnectionError("connection refused")
+            raise aiohttp.ClientConnectionError("https://10.0.0.1/proxy/network?api_key=leaked")
             yield  # type: ignore[misc]
 
         auth._session.get = _raise
-        with pytest.raises(CannotConnectError):
+        with pytest.raises(CannotConnectError) as exc_info:
             await auth._verify_api_key()
+        assert "leaked" not in str(exc_info.value)
+        assert exc_info.value.args[0] == "ClientConnectionError"
 
 
 class TestAuthenticate:
-    """Tests for UniFiAuth.authenticate — method auto-detection and fallback.
+    """Tests for UniFiAuth.authenticate — API-key verification.
 
-    Exercised entirely at the HTTP layer (mocked session responses), not by
-    monkeypatching the private _verify_api_key/_login_userpass methods, so
-    these tests fail if the real request/response handling breaks.
+    Exercised at the HTTP layer (mocked session responses), not by
+    monkeypatching _verify_api_key, so these fail if the real request/response
+    handling breaks.
     """
 
     @pytest.mark.asyncio
-    async def test_apikey_method_used_when_configured(self):
-        auth = make_auth({"api_key": "my-key", "auth_method": "apikey", "verify_ssl": False})
+    async def test_valid_key_authenticates(self):
+        auth = make_auth({"api_key": "my-key", "verify_ssl": False})
         auth._session.get = _make_response(200)
 
-        result = await auth.authenticate()
-
-        assert result == "apikey"
-        assert auth.method == "apikey"
-        assert auth.authenticated is True
+        # Verification succeeds and returns nothing.
+        assert await auth.authenticate() is None
 
     @pytest.mark.asyncio
-    async def test_apikey_fallback_to_userpass_when_key_invalid(self):
-        """If api_key present but method not explicitly set to apikey, fall back to userpass on InvalidAuthError."""
+    async def test_invalid_key_raises_invalid_auth(self):
         auth = make_auth({"api_key": "bad-key", "verify_ssl": False})
         auth._session.get = _make_response(401)
-        auth._session.post = _make_response(200)
-
-        result = await auth.authenticate()
-
-        assert result == "userpass"
-        assert auth.method == "userpass"
-        assert auth.authenticated is True
-
-    @pytest.mark.asyncio
-    async def test_explicit_apikey_method_does_not_fallback(self):
-        """If auth_method=apikey is explicit, InvalidAuthError must propagate (no fallback)."""
-        auth = make_auth({"api_key": "bad-key", "auth_method": "apikey", "verify_ssl": False})
-        auth._session.get = _make_response(401)
-
-        post_calls = []
-        auth._session.post = lambda *a, **k: post_calls.append(1)
 
         with pytest.raises(InvalidAuthError):
             await auth.authenticate()
-        assert post_calls == [], "userpass login must not be attempted"
+
+    @pytest.mark.asyncio
+    async def test_missing_key_raises_invalid_auth(self):
+        auth = make_auth({"verify_ssl": False})
+
+        with pytest.raises(InvalidAuthError, match="No API key provided"):
+            await auth.authenticate()
 
 
 class TestSslCertificateError:

--- a/tests/unit/unifi_client/conftest.py
+++ b/tests/unit/unifi_client/conftest.py
@@ -27,8 +27,6 @@ from pytest_homeassistant_custom_component.test_util.aiohttp import (
 from custom_components.unifi_alerts.unifi_client import UNIFI_OS_NETWORK_PREFIX, UniFiClient
 
 BASE_URL = "https://192.168.1.1"
-LOGIN_URL = f"{BASE_URL}/api/auth/login"
-LOGOUT_URL = f"{BASE_URL}/api/auth/logout"
 
 
 @dataclass
@@ -74,8 +72,7 @@ def make_client(aioclient_mock: AiohttpClientMocker, config: dict | None = None)
     object.__setattr__(session, "_request", _recording_request)
     _created_sessions.append(session)
     cfg = config or {
-        "username": "admin",
-        "password": "password",
+        "api_key": "test-api-key",
         "verify_ssl": False,
     }
     return UniFiClient(session, BASE_URL, cfg)
@@ -109,6 +106,11 @@ def alarm_url(site: str = "default") -> str:
 
 def stat_alarm_url(site: str = "default") -> str:
     return f"{BASE_URL}{UNIFI_OS_NETWORK_PREFIX}/api/s/{site}/stat/alarm"
+
+
+def self_url() -> str:
+    """The API-key verification endpoint hit by UniFiAuth.authenticate()."""
+    return f"{BASE_URL}{UNIFI_OS_NETWORK_PREFIX}/api/s/default/self"
 
 
 def probe_url(site: str = "default") -> str:

--- a/tests/unit/unifi_client/test_legacy.py
+++ b/tests/unit/unifi_client/test_legacy.py
@@ -25,7 +25,6 @@ from custom_components.unifi_alerts.unifi_auth import CannotConnectError, Invali
 from custom_components.unifi_alerts.unifi_client import UniFiClient
 
 from .conftest import (
-    LOGOUT_URL,
     alarm_url,
     find_calls,
     list_alarm_url,
@@ -176,15 +175,12 @@ class TestFetchAlarms:
         assert alarms == []
 
     @pytest.mark.asyncio
-    async def test_401_raises_invalid_auth_and_clears_authenticated(
-        self, aioclient_mock: AiohttpClientMocker
-    ):
+    async def test_401_raises_invalid_auth(self, aioclient_mock: AiohttpClientMocker):
+        """A 401 on the alarm fetch (revoked API key) must raise InvalidAuthError."""
         client = make_client(aioclient_mock)
-        client._auth._authenticated = True
         aioclient_mock.get(list_alarm_url(), status=401)
         with pytest.raises(InvalidAuthError):
             await client.fetch_alarms()
-        assert client._auth._authenticated is False
 
     @pytest.mark.asyncio
     async def test_client_error_raises_cannot_connect(self, aioclient_mock: AiohttpClientMocker):
@@ -416,29 +412,6 @@ class TestFetchAlarms:
             await client.fetch_alarms()
 
     @pytest.mark.asyncio
-    async def test_not_authenticated_calls_authenticate_first(
-        self, aioclient_mock: AiohttpClientMocker
-    ):
-        """fetch_alarms must call authenticate() when not yet authenticated."""
-        client = make_client(aioclient_mock)
-        client._auth._authenticated = False
-        body = {"meta": {"rc": "ok"}, "data": [{"key": "EVT_GW_WANTransition", "archived": False}]}
-
-        authenticated_calls = []
-
-        async def _mock_authenticate():
-            client._auth._authenticated = True
-            client._auth._method = "userpass"
-            authenticated_calls.append(1)
-
-        client.authenticate = _mock_authenticate
-
-        aioclient_mock.get(list_alarm_url(), status=200, json=body)
-        await client.fetch_alarms()
-
-        assert len(authenticated_calls) == 1
-
-    @pytest.mark.asyncio
     async def test_redirect_raises_cannot_connect(self, aioclient_mock: AiohttpClientMocker):
         """A 3xx on an authenticated alarm fetch must raise CannotConnectError (no redirect)."""
         client = make_client(aioclient_mock)
@@ -587,25 +560,23 @@ class TestCategoriseAlarms:
 class TestAuthenticate:
     """Tests for UniFiClient.authenticate — delegates to UniFiAuth.authenticate().
 
-    Method auto-detection and fallback are UniFiAuth's own behaviour and are
-    covered by tests/unit/test_unifi_auth.py. These tests only cover what
-    UniFiClient itself is responsible for: delegating to self._auth and
-    resetting probe-backoff state on every successful authentication.
+    API-key verification is UniFiAuth's own behaviour and is covered by
+    tests/unit/test_unifi_auth.py. These tests only cover what UniFiClient
+    itself is responsible for: delegating to self._auth and resetting
+    probe-backoff state on every successful verification.
 
     UniFiAuth is a composed collaborator here (not HTTP), so these stay on
     MagicMock/AsyncMock — out of scope for the aioclient_mock conversion.
     """
 
     @pytest.mark.asyncio
-    async def test_delegates_to_auth_and_returns_its_result(
-        self, aioclient_mock: AiohttpClientMocker
-    ):
+    async def test_delegates_to_auth(self, aioclient_mock: AiohttpClientMocker):
         client = make_client(aioclient_mock)
-        client._auth.authenticate = AsyncMock(return_value="apikey")
+        client._auth.authenticate = AsyncMock(return_value=None)
 
         result = await client.authenticate()
 
-        assert result == "apikey"
+        assert result is None
         client._auth.authenticate.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -618,85 +589,21 @@ class TestAuthenticate:
 
 
 class TestClose:
-    """Tests for UniFiClient.close — logout behaviour."""
+    """close() is a stateless no-op: API-key auth has no session to log out."""
 
     @pytest.mark.asyncio
-    async def test_userpass_auth_posts_to_unifi_os_logout_path(
-        self, aioclient_mock: AiohttpClientMocker
-    ):
-        """close() must POST to /api/auth/logout (UniFi OS path only)."""
-        client = make_client(aioclient_mock)
-        client._auth._method = "userpass"
-        client._auth._authenticated = True
-
-        aioclient_mock.post(LOGOUT_URL, status=200)
-        await client.close()
-        calls = find_calls("POST", LOGOUT_URL)
-
-        assert len(calls) == 1
-
-    @pytest.mark.asyncio
-    async def test_apikey_auth_does_not_post_logout(self, aioclient_mock: AiohttpClientMocker):
+    async def test_close_makes_no_requests(self, aioclient_mock: AiohttpClientMocker):
         client = make_client(aioclient_mock, {"api_key": "k", "verify_ssl": False})
-        client._auth._method = "apikey"
-        client._auth._authenticated = True
 
-        # Nothing registered — if close() posted anywhere, aioclient_mock
-        # would raise AssertionError for the unmatched request and fail this test.
+        # Nothing is registered on the mock — if close() made any request,
+        # aioclient_mock would raise AssertionError for the unmatched call.
         await client.close()
         assert total_calls() == 0
 
     @pytest.mark.asyncio
-    async def test_not_authenticated_does_not_post_logout(
-        self, aioclient_mock: AiohttpClientMocker
-    ):
-        client = make_client(aioclient_mock)
-        client._auth._method = "userpass"
-        client._auth._authenticated = False
-
-        await client.close()
-        assert total_calls() == 0
-
-    @pytest.mark.asyncio
-    async def test_logout_failure_logs_warning_with_class_name_only(
-        self, aioclient_mock: AiohttpClientMocker, caplog
-    ):
-        """A failed logout must log at WARNING with the exception class name only.
-
-        The previous `contextlib.suppress(Exception)` swallowed the error silently,
-        leaving operators no diagnostic and the session token live on the controller.
-        We log the class name (not str(err)) to avoid surfacing controller response
-        bodies that may include sensitive fragments.
-        """
-        import logging
-
-        client = make_client(aioclient_mock)
-        client._auth._method = "userpass"
-        client._auth._authenticated = True
-        secret_marker = "controller.local: 401 Unauthorized — api_key=secret"
-
-        aioclient_mock.post(LOGOUT_URL, exc=ConnectionResetError(secret_marker))
-        with caplog.at_level(logging.WARNING, logger="custom_components.unifi_alerts.unifi_client"):
-            await client.close()
-
-        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert any("ConnectionResetError" in r.getMessage() for r in warnings)
-        assert all(secret_marker not in r.getMessage() for r in warnings)
-
-    @pytest.mark.asyncio
-    async def test_logout_failure_does_not_propagate(self, aioclient_mock: AiohttpClientMocker):
-        """close() must never raise on a realistic logout failure — best-effort.
-
-        Only network/connection failures (aiohttp.ClientError, OSError,
-        TimeoutError) are absorbed; a genuine bug (e.g. RuntimeError from our
-        own code) is intentionally allowed to propagate so it isn't hidden.
-        """
-        client = make_client(aioclient_mock)
-        client._auth._method = "userpass"
-        client._auth._authenticated = True
-
-        aioclient_mock.post(LOGOUT_URL, exc=aiohttp.ClientConnectionError("boom"))
-        # No pytest.raises — close() must absorb the failure.
+    async def test_close_does_not_raise(self, aioclient_mock: AiohttpClientMocker):
+        client = make_client(aioclient_mock, {"api_key": "k", "verify_ssl": False})
+        # No pytest.raises — close() must always be safe to await.
         await client.close()
 
 
@@ -741,8 +648,8 @@ class TestSslFailOpen:
 class TestSslCertificateError:
     """SslCertificateError is raised on TLS certificate failures, not CannotConnectError.
 
-    Auth-layer certificate handling (_verify_api_key, _login_userpass) is
-    UniFiAuth's own behaviour and is covered by tests/unit/test_unifi_auth.py.
+    Auth-layer certificate handling (_verify_api_key) is UniFiAuth's own
+    behaviour and is covered by tests/unit/test_unifi_auth.py.
     These tests cover UniFiClient's own request paths.
     """
 

--- a/tests/unit/unifi_client/test_v2.py
+++ b/tests/unit/unifi_client/test_v2.py
@@ -16,11 +16,11 @@ from custom_components.unifi_alerts.unifi_auth import CannotConnectError, Invali
 from custom_components.unifi_alerts.unifi_client import _PROBE_FAIL_LIMIT
 
 from .conftest import (
-    LOGIN_URL,
     find_calls,
     make_client,
     probe_url,
     queue_responses,
+    self_url,
     system_log_url,
     total_calls,
 )
@@ -279,7 +279,7 @@ class TestProbeSystemLogEndpoint:
         client._probe_fail_count = _PROBE_FAIL_LIMIT
         client._probe_backoff_until = datetime.now(UTC) + timedelta(hours=1)
 
-        aioclient_mock.post(LOGIN_URL, status=200)
+        aioclient_mock.get(self_url(), status=200)
         await client.authenticate()
 
         # Backoff state must be cleared
@@ -296,7 +296,7 @@ class TestProbeSystemLogEndpoint:
         client._probe_fail_count = 0
         client._probe_backoff_until = None
 
-        aioclient_mock.post(LOGIN_URL, status=200)
+        aioclient_mock.get(self_url(), status=200)
         await client.authenticate()
 
         assert client._has_system_log is True


### PR DESCRIPTION
## Summary

Second stage of the API-key epic (#277), building on the migration/reauth path from #278 (now merged). With API keys the only supported credential, the username/password machinery was dead code carrying a latent CSRF risk and a large test surface. This deletes it and simplifies everything that existed to serve it.

Closes #279

## Changes

- **`unifi_auth.py`**: dropped `_login_userpass`, the auth-method auto-detection in `authenticate()`, and all session state (`_authenticated`, `_method`, `invalidate()`). `UniFiAuth` now verifies the API key and builds the `X-API-Key` header; `authenticate()` returns `None`. The module is **retained** rather than folded into `unifi_client.py` (decision recorded in its docstring): it still owns the shared auth exceptions imported across the integration and keeps that surface testable in isolation.
- **`unifi_client.py`**: dropped the logout call in `close()` (now a stateless no-op) and the "authenticate if not authenticated" preambles; a static key needs no session bootstrap. A 401 raises `InvalidAuthError` directly.
- **`coordinator.py`**: removed the re-authenticate-once-and-retry branch in `_async_update_data`; a 401 on a static key means the key was revoked, so it raises `ConfigEntryAuthFailed` directly.
- **`config_flow.py`**: removed username/password from the setup, reauth, and options credentials steps; the API key is required in initial setup and is the only credential the options flow can change. The parse/build helpers shed their username/password branches.
- **`const.py` / `models.py`**: removed `CONF_USERNAME`, `CONF_PASSWORD`, `CONF_AUTH_METHOD`, `AUTH_METHOD_USERPASS`, `AUTH_METHOD_APIKEY` and the matching `UniFiClientConfig` fields. The version-4 migration now drops the legacy keys by literal name and no longer writes `auth_method` (nothing reads it).
- **`diagnostics.py`**: trimmed username/password from the redaction set.
- **`strings.json` / `translations/en.json`**: removed the userpass field labels and reworded the setup, reauth, and error copy for API-key-only auth (kept byte-identical).
- **Tests**: deleted/rewrote the userpass cases across `test_unifi_auth.py`, the `unifi_client` tests (including the logout tests), config-flow tests, and the coordinator re-auth test; updated the migration tests for the leaner schema. Net ~-530 lines.

## How to test

```bash
make check   # lint + typecheck + validate + all tests (95% coverage gate)
```

## Checklist

- [x] Linked the issue this PR resolves (`Closes #279`)
- [x] `make check` legs pass locally: ruff (check + format), mypy (14 files), HACS/docs/translation validators, and the full suite (681 passed, 99% coverage). Note: run against HA 2025.12.1 on Python 3.13 because 3.14 is not installable in this container; CI runs the pinned py3.14 stack.
- [x] `CHANGELOG.md` `[Unreleased]` updated (breaking-change entry)
- [x] PR title starts with a Conventional Commit prefix (`feat:`)
- [x] PR expects the `enhancement` label (via pr-labeler)
- [x] `strings.json` and `translations/en.json` are still identical
- [ ] New category fully registered (n/a)
- [x] No blocking I/O introduced (all network/disk calls are `async`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PhJNZDVbiZQ9uf8euQjrDu)_