### PR TITLE
chore: remove redundant button overrides, add PARALLEL_UPDATES, move icons to icons.json

### DIFF
--- a/custom_components/unifi_alerts/binary_sensor.py
+++ b/custom_components/unifi_alerts/binary_sensor.py
@@ -16,13 +16,13 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ALL_CATEGORIES,
-    CATEGORY_ICONS,
-    CATEGORY_ICONS_OK,
     CONF_CONTROLLER_URL,
     DOMAIN,
 )
 from .coordinator import UniFiAlertsCoordinator
 from .models import CategoryState
+
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
@@ -69,12 +69,6 @@ class UniFiCategoryBinarySensor(CoordinatorEntity[UniFiAlertsCoordinator], Binar
     def available(self) -> bool:
         state = self.coordinator.get_category_state(self._category)
         return state is not None and state.enabled
-
-    @property
-    def icon(self) -> str:
-        if self.is_on:
-            return CATEGORY_ICONS[self._category]
-        return CATEGORY_ICONS_OK[self._category]
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -124,10 +118,6 @@ class UniFiRollupBinarySensor(CoordinatorEntity[UniFiAlertsCoordinator], BinaryS
     @property
     def is_on(self) -> bool:
         return self.coordinator.any_alerting
-
-    @property
-    def icon(self) -> str:
-        return "mdi:shield-alert" if self.is_on else "mdi:shield-check"
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/unifi_alerts/button.py
+++ b/custom_components/unifi_alerts/button.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -16,6 +16,8 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import UniFiAlertsCoordinator
+
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
@@ -38,7 +40,6 @@ class UniFiClearCategoryButton(CoordinatorEntity[UniFiAlertsCoordinator], Button
     """Button that manually clears the alert state for one category."""
 
     _attr_has_entity_name = True
-    _attr_icon = "mdi:bell-off"
     _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
@@ -52,10 +53,6 @@ class UniFiClearCategoryButton(CoordinatorEntity[UniFiAlertsCoordinator], Button
         self._attr_unique_id = f"{entry.entry_id}_{category}_clear"
         self._attr_translation_key = f"clear_{category}"
         self._attr_device_info = _device_info(entry)
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        self.async_write_ha_state()
 
     @property
     def available(self) -> bool:
@@ -73,7 +70,6 @@ class UniFiClearAllButton(CoordinatorEntity[UniFiAlertsCoordinator], ButtonEntit
 
     _attr_has_entity_name = True
     _attr_translation_key = "clear_all"
-    _attr_icon = "mdi:shield-off"
     _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
@@ -84,10 +80,6 @@ class UniFiClearAllButton(CoordinatorEntity[UniFiAlertsCoordinator], ButtonEntit
         super().__init__(coordinator)
         self._attr_unique_id = f"{entry.entry_id}_clear_all"
         self._attr_device_info = _device_info(entry)
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        self.async_write_ha_state()
 
     @property
     def available(self) -> bool:

--- a/custom_components/unifi_alerts/event.py
+++ b/custom_components/unifi_alerts/event.py
@@ -15,12 +15,13 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ALL_CATEGORIES,
-    CATEGORY_ICONS,
     CONF_CONTROLLER_URL,
     DOMAIN,
 )
 from .coordinator import UniFiAlertsCoordinator
 from .models import CategoryState, UniFiAlert
+
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
@@ -61,7 +62,6 @@ class UniFiAlertEventEntity(CoordinatorEntity[UniFiAlertsCoordinator], EventEnti
         self._category = category
         self._attr_unique_id = f"{entry.entry_id}_{category}_event"
         self._attr_translation_key = f"event_{category}"
-        self._attr_icon = CATEGORY_ICONS[category]
         self._attr_device_info = _device_info(entry)
         # Track alert_count to detect new alerts on coordinator update
         self._last_seen_count: int = 0

--- a/custom_components/unifi_alerts/icons.json
+++ b/custom_components/unifi_alerts/icons.json
@@ -1,0 +1,67 @@
+{
+  "entity": {
+    "binary_sensor": {
+      "network_device": {
+        "default": "mdi:lan-check",
+        "state": {"on": "mdi:lan-disconnect", "off": "mdi:lan-check"}
+      },
+      "network_wan": {
+        "default": "mdi:web-check",
+        "state": {"on": "mdi:wan", "off": "mdi:web-check"}
+      },
+      "network_client": {
+        "default": "mdi:account-check",
+        "state": {"on": "mdi:account-network", "off": "mdi:account-check"}
+      },
+      "security_threat": {
+        "default": "mdi:shield-check",
+        "state": {"on": "mdi:shield-bug", "off": "mdi:shield-check"}
+      },
+      "security_honeypot": {
+        "default": "mdi:shield-check",
+        "state": {"on": "mdi:bee", "off": "mdi:shield-check"}
+      },
+      "security_firewall": {
+        "default": "mdi:shield-check",
+        "state": {"on": "mdi:firewall", "off": "mdi:shield-check"}
+      },
+      "power": {
+        "default": "mdi:power-plug",
+        "state": {"on": "mdi:lightning-bolt", "off": "mdi:power-plug"}
+      },
+      "any_alert": {
+        "default": "mdi:shield-check",
+        "state": {"on": "mdi:shield-alert", "off": "mdi:shield-check"}
+      }
+    },
+    "sensor": {
+      "open_count_network_device": {"default": "mdi:counter"},
+      "open_count_network_wan": {"default": "mdi:counter"},
+      "open_count_network_client": {"default": "mdi:counter"},
+      "open_count_security_threat": {"default": "mdi:counter"},
+      "open_count_security_honeypot": {"default": "mdi:counter"},
+      "open_count_security_firewall": {"default": "mdi:counter"},
+      "open_count_power": {"default": "mdi:counter"},
+      "total_open": {"default": "mdi:bell-alert"}
+    },
+    "event": {
+      "event_network_device": {"default": "mdi:lan-disconnect"},
+      "event_network_wan": {"default": "mdi:wan"},
+      "event_network_client": {"default": "mdi:account-network"},
+      "event_security_threat": {"default": "mdi:shield-bug"},
+      "event_security_honeypot": {"default": "mdi:bee"},
+      "event_security_firewall": {"default": "mdi:firewall"},
+      "event_power": {"default": "mdi:lightning-bolt"}
+    },
+    "button": {
+      "clear_network_device": {"default": "mdi:bell-off"},
+      "clear_network_wan": {"default": "mdi:bell-off"},
+      "clear_network_client": {"default": "mdi:bell-off"},
+      "clear_security_threat": {"default": "mdi:bell-off"},
+      "clear_security_honeypot": {"default": "mdi:bell-off"},
+      "clear_security_firewall": {"default": "mdi:bell-off"},
+      "clear_power": {"default": "mdi:bell-off"},
+      "clear_all": {"default": "mdi:shield-off"}
+    }
+  }
+}

--- a/custom_components/unifi_alerts/sensor.py
+++ b/custom_components/unifi_alerts/sensor.py
@@ -25,6 +25,8 @@ from .const import (
 from .coordinator import UniFiAlertsCoordinator
 from .models import CategoryState
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -103,7 +105,6 @@ class UniFiCategoryCountSensor(CoordinatorEntity[UniFiAlertsCoordinator], Sensor
     # No SensorDeviceClass fits an alert counter; MEASUREMENT suits a resettable integer.
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "alerts"
-    _attr_icon = "mdi:counter"
 
     def __init__(
         self,
@@ -185,7 +186,6 @@ class UniFiRollupCountSensor(CoordinatorEntity[UniFiAlertsCoordinator], SensorEn
     # No SensorDeviceClass fits an alert counter; MEASUREMENT suits a resettable integer.
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "alerts"
-    _attr_icon = "mdi:bell-alert"
 
     def __init__(
         self,

--- a/docs/REPO_LAYOUT.md
+++ b/docs/REPO_LAYOUT.md
@@ -14,14 +14,15 @@ custom_components/unifi_alerts/   # integration source
   webhook_handler.py              # registers HA webhooks (POST-only), dispatches to coordinator; rejects requests missing/wrong Authorization: Bearer header or legacy ?token= with HTTP 401; bearer secret from CONF_WEBHOOK_SECRET; raises webhook_legacy_query_auth repair issue on query-param auth
   config_flow.py                  # three-step UI setup (credentials > categories > webhook URLs, secret shown separately for the Authorization header) + options flow; generates CONF_WEBHOOK_SECRET via secrets.token_urlsafe(32) on first auth; network_device and network_client default OFF; options flow reads entry.options first, falls back to entry.data
   diagnostics.py                  # HA diagnostics platform; redacts api_key/webhook_secret, exposes webhook URLs + coordinator state
-  binary_sensor.py                # per-category + rollup binary sensors
-  sensor.py                       # message, count, and rollup count sensors
-  event.py                        # event entities, fire per alert
-  button.py                       # manual clear buttons
+  binary_sensor.py                # per-category + rollup binary sensors; PARALLEL_UPDATES = 0 (coordinator-based, no per-entity throttling needed); on/off icons come from icons.json state mapping, not a property (the entity's own state IS the alerting/ok discriminator)
+  sensor.py                       # message, count, and rollup count sensors; PARALLEL_UPDATES = 0; UniFiCategoryMessageSensor.icon stays a property (native_value is the alert message text, not a valid icons.json discriminator) - the count sensors' static icons moved to icons.json
+  event.py                        # event entities, fire per alert; PARALLEL_UPDATES = 0; static per-category icon moved to icons.json
+  button.py                       # manual clear buttons; PARALLEL_UPDATES = 0; static icons moved to icons.json; no _handle_coordinator_update override - CoordinatorEntity's default (async_write_ha_state()) is exactly what both button classes need
   services.py                     # registers unifi_alerts.clear_category and unifi_alerts.clear_all HA service calls; delegates to coordinator
   services.yaml                   # HA service schema definition (clear_category: category field, clear_all: no fields)
   strings.json                    # UI copy for config flow; must be identical to translations/en.json - CI enforces this
   translations/en.json            # runtime translation file loaded by HA; must be identical to strings.json - CI enforces this
+  icons.json                      # per-entity icon overrides keyed by translation_key; binary_sensor entries use "state": {"on": ..., "off": ...} since is_on is the icon discriminator; button/sensor(count)/event entries use a flat "default" (static, no state discriminator)
 tests/
   conftest.py                     # root shared fixtures; Windows-only event-loop and socket workarounds (no-op on Linux/macOS)
   unit/                           # plain-mock unit tests - no real HA instance

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -118,18 +118,6 @@ class TestUniFiCategoryBinarySensor:
         entity = self._make(state)
         assert entity.available is expected
 
-    @pytest.mark.parametrize(
-        ("is_alerting", "expected_icon"),
-        [
-            pytest.param(True, CATEGORY_ICONS[CATEGORY_NETWORK_WAN], id="alerting"),
-            pytest.param(False, CATEGORY_ICONS_OK[CATEGORY_NETWORK_WAN], id="not-alerting"),
-        ],
-    )
-    def test_icon(self, is_alerting, expected_icon):
-        state = make_state(is_alerting=is_alerting)
-        entity = self._make(state)
-        assert entity.icon == expected_icon
-
     def test_extra_attrs_with_alert(self):
         alert = make_alert()
         state = make_state(is_alerting=True, alert_count=2, open_count=1, last_alert=alert)
@@ -203,21 +191,6 @@ class TestUniFiRollupBinarySensor:
         states = {CATEGORY_NETWORK_WAN: make_state(is_alerting=is_alerting)}
         entity = self._make(states)
         assert entity.is_on is expected
-
-    @pytest.mark.parametrize(
-        ("states", "expected_icon"),
-        [
-            pytest.param(
-                {CATEGORY_NETWORK_WAN: make_state(is_alerting=True)},
-                "mdi:shield-alert",
-                id="alerting",
-            ),
-            pytest.param({}, "mdi:shield-check", id="not-alerting"),
-        ],
-    )
-    def test_icon(self, states, expected_icon):
-        entity = self._make(states)
-        assert entity.icon == expected_icon
 
     def test_extra_attrs_with_last_alert(self):
         alert = make_alert()


### PR DESCRIPTION
## Summary

Closes #271. Three of the four listed cleanups (the `_login_userpass` single-path-loop flatten was already superseded — the API-key epic (#277/#279) deleted `_login_userpass` entirely, confirmed by checking current `unifi_auth.py`, which only has `_verify_api_key`; skipped per the [issue's own re-scoping comment](https://github.com/PHeonix25/unifi_alerts/issues/271#issuecomment-4871980386)).

## Changes

- **`button.py`**: removed the `_handle_coordinator_update` overrides on `UniFiClearCategoryButton` and `UniFiClearAllButton` — both only called `self.async_write_ha_state()`, which is exactly what `CoordinatorEntity`'s own default implementation does. Dropped the now-unused `callback` import.
- **`PARALLEL_UPDATES = 0`** declared in `binary_sensor.py`, `sensor.py`, `event.py`, and `button.py`, documenting that these coordinator-based platforms need no per-entity request throttling (current HA convention).
- **`icons.json`** (new file): moved every icon that isn't derived from the entity's own state out of Python:
  - Button clear icons (`clear_*` → `mdi:bell-off`, `clear_all` → `mdi:shield-off`).
  - The count sensors (`open_count_*` → `mdi:counter`, `total_open` → `mdi:bell-alert`).
  - The per-category event icons (`event_*`, previously set once in `__init__` regardless of state).
  - The category and rollup binary sensors' `icon` properties, since `is_on` directly discriminates the two icon variants (alerting vs ok) — this is exactly what `icons.json`'s `state: {"on": ..., "off": ...}` mapping is for, so these move to a state mapping rather than staying a Python property.
  - `UniFiCategoryMessageSensor.icon` **stays a property** (not moved): its own reported state is the alert message text, which isn't a valid `icons.json` discriminator, so the icon still needs to be derived from `is_alerting` in code.
  - All icon *values* are unchanged — this is a relocation, not a visual change, so there's no user-visible effect.
- Removed two `test_icon` tests in `tests/unit/test_entities.py` for the binary sensor classes, since their icon now comes from `icons.json` (not testable via direct entity construction — icon translation is resolved by HA's entity platform at runtime).

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

**Note:** as with #240/#261, this environment has no Python 3.14 interpreter available. I ran what's runnable without it: `ruff check`/`ruff format --check` (clean across the repo), `python3 scripts/validate_docs.py` (pass), `python3 scripts/check_translations.py` (pass, unaffected — no `strings.json`/`translations/en.json` changes), `python3 scripts/validate_hacs.py` (pass), and confirmed `icons.json` is valid JSON. Treating CI as authoritative for the mypy/pytest legs.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #271`)
- [ ] `make check` passes locally — not runnable in this environment (see note above); relying on CI
- [x] `CHANGELOG.md` `[Unreleased]` — not updated; mechanical cleanup with no user-visible effect (icon values unchanged), `skip-changelog` applies per the issue's own scope note
- [x] PR title starts with a Conventional Commit prefix (`chore:`)
- [ ] PR has a label recognised by `.github/release.yml` — `chore:` isn't auto-mapped by `pr-release-label.yml`; will apply `enhancement` + `skip-changelog` by hand
- [x] `strings.json` and `translations/en.json` untouched (and still identical)
- [x] No new category added
- [x] No blocking I/O introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_01GNwNXjfHXRCP7w2iDcjKD6)_