### PR TITLE
feat: audit the HA integration quality scale ahead of HACS submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ All data stays on your local network; the integration does not communicate with 
 
 ---
 
+## Quality scale
+
+This integration is audited against Home Assistant's [integration quality scale](https://www.home-assistant.io/docs/quality_scale/). See [quality_scale.yaml](quality_scale.yaml) for the full rule-by-rule status (done, exempt, or open, with linked issues for remaining gaps). The `quality_scale` manifest key is not set yet: one Bronze-tier rule (`brands`, tracked by [#143](https://github.com/PHeonix25/unifi_alerts/issues/143)) is still open, so no tier is fully achieved.
+
+---
+
 ## Uninstall
 
 **Settings > Devices & Services > UniFi Alerts > three-dot menu > Delete.**

--- a/quality_scale.yaml
+++ b/quality_scale.yaml
@@ -1,0 +1,289 @@
+rules:
+  # Bronze
+  action-setup:
+    status: done
+    comment: |
+      Services are registered in async_setup_entry via async_register_services
+      (idempotent) and unregistered in async_unload_entry once the last entry
+      is gone (services.py).
+  appropriate-polling:
+    status: done
+    comment: |
+      DataUpdateCoordinator with a user-configurable poll interval
+      (CONF_POLL_INTERVAL, 10 to 3600 seconds, coordinator.py). Webhook push
+      is the primary path; polling is a backstop.
+  brands:
+    status: todo
+    comment: |
+      Not yet submitted to home-assistant/brands. Tracked as an acceptance
+      item on #143 (HACS default catalogue umbrella), not duplicated here.
+  common-modules:
+    status: done
+    comment: |
+      Standard DataUpdateCoordinator, ConfigEntry.runtime_data, CoordinatorEntity
+      base classes throughout; no bespoke reinvention of core patterns.
+  config-flow:
+    status: done
+    comment: |
+      config_flow.py implements the full setup flow (user, categories, finish
+      steps) plus SSDP discovery, reauth, and an options flow.
+  config-flow-test-coverage:
+    status: done
+    comment: |
+      tests/unit/config_flow/ covers setup, discovery, reauth, options
+      credentials, options rotation validation, and options helpers.
+  dependency-transparency:
+    status: done
+    comment: |
+      manifest.json requirements is empty; the only third-party import
+      (yarl) is an existing aiohttp/HA core transitive dependency, not a
+      vendored or hidden package.
+  docs-actions:
+    status: done
+    comment: |
+      services.yaml and the strings.json/translations/en.json services
+      section fully describe clear_category and clear_all (name,
+      description, fields) for HA's Developer Tools > Actions UI.
+  docs-conditions:
+    status: exempt
+    comment: This integration does not provide any device conditions.
+  docs-high-level-description:
+    status: done
+    comment: README.md opening paragraph and Features section.
+  docs-installation-instructions:
+    status: done
+    comment: README.md "Installation" and "Setup" sections (HACS and manual).
+  docs-removal-instructions:
+    status: done
+    comment: README.md "Uninstall" section.
+  docs-triggers:
+    status: exempt
+    comment: This integration does not provide any device triggers.
+  entity-event-setup:
+    status: exempt
+    comment: |
+      Entities use the standard CoordinatorEntity update pattern
+      (_handle_coordinator_update); none subscribe to the HA event bus
+      directly, so there is no explicit subscribe/unsubscribe lifecycle
+      to manage.
+  entity-unique-id:
+    status: done
+    comment: |
+      "{entry.entry_id}_{category}_{suffix}" format, stable across restarts
+      (based on entry_id, not mutable config). See docs/HOMEASSISTANT.md
+      "Entity unique IDs".
+  has-entity-name:
+    status: done
+    comment: _attr_has_entity_name = True set on every entity class.
+  runtime-data:
+    status: done
+    comment: |
+      entry.runtime_data holds a typed RuntimeData dataclass (models.py),
+      assigned in async_setup_entry.
+  test-before-configure:
+    status: done
+    comment: |
+      async_step_user and the options-flow credentials step both call
+      client.authenticate() and client.fetch_alarms() before accepting
+      input.
+  test-before-setup:
+    status: done
+    comment: |
+      async_setup_entry authenticates before creating any entity and raises
+      ConfigEntryNotReady/ConfigEntryAuthFailed on failure.
+  unique-config-entry:
+    status: done
+    comment: |
+      async_set_unique_id(url) plus _abort_if_unique_id_configured() in both
+      async_step_user and async_step_ssdp.
+
+  # Silver
+  action-exceptions:
+    status: todo
+    comment: |
+      services.py logs a warning and silently no-ops when entry_id is
+      unknown or the entry is not loaded, instead of raising a translatable
+      error the caller can see. Filed as #340.
+  config-entry-unloading:
+    status: done
+    comment: |
+      async_unload_entry unloads platforms, shuts down the coordinator,
+      unregisters webhooks, and closes the client; async_remove_entry also
+      cleans up persisted storage and repair issues.
+  docs-configuration-parameters:
+    status: done
+    comment: |
+      README "Setup" step 2 to 4 and "Multiple controllers or sites"
+      document poll interval, clear timeout, categories, and site.
+  docs-installation-parameters:
+    status: done
+    comment: README "Requirements" and "Setup" sections.
+  entity-unavailable:
+    status: done
+    comment: |
+      Every entity's available property reflects real coordinator state
+      (category enabled/present), not a cached local flag.
+  integration-owner:
+    status: done
+    comment: manifest.json codeowners lists @PHeonix25.
+  log-when-unavailable:
+    status: done
+    comment: |
+      DataUpdateCoordinator's built-in behaviour (single WARNING on first
+      UpdateFailed/ConfigEntryAuthFailed, single INFO on recovery) is relied
+      on rather than reimplemented; _async_update_data raises the correct
+      exception types for it to apply.
+  parallel-updates:
+    status: done
+    comment: |
+      PARALLEL_UPDATES = 0 declared in binary_sensor.py, sensor.py, event.py,
+      and button.py. Every entity is coordinator-driven with no per-entity
+      network calls, including button presses, which only touch in-memory
+      state and local storage.
+  reauthentication-flow:
+    status: done
+    comment: |
+      async_step_reauth / async_step_reauth_confirm implemented; also raises
+      a repair issue (ISSUE_ID_AUTH_FAILED) alongside the standard reauth
+      prompt. The version-4 username/password-to-API-key migration
+      (_migrate_v3_to_v4 in __init__.py) reuses the same reauth entry point,
+      with its own repair issue (ISSUE_ID_APIKEY_MIGRATION) so the prompt
+      does not look like an ordinary credential failure.
+  test-coverage:
+    status: done
+    comment: |
+      make test and CI both enforce --cov-fail-under=95.
+
+  # Gold
+  devices:
+    status: done
+    comment: |
+      All entities share one DeviceInfo per config entry (entry_type
+      "service"), registered proactively in async_setup_entry before
+      platform forwarding.
+  diagnostics:
+    status: done
+    comment: |
+      diagnostics.py returns redacted config/options plus live coordinator
+      state, with alert content deliberately excluded (see its inline
+      comment) to avoid leaking client hostnames/MACs/IPs.
+  discovery:
+    status: done
+    comment: |
+      manifest.json declares ssdp matchers for UDM/UDM Pro/UDM SE/UDM Pro
+      Max; async_step_ssdp handles discovery.
+  discovery-update-info:
+    status: todo
+    comment: |
+      async_step_ssdp only aborts on a matching unique_id; it never updates
+      the existing entry's controller_url on rediscovery with a changed IP.
+      Filed as #343.
+  docs-data-update:
+    status: done
+    comment: |
+      docs/ARCHITECTURE.md and docs/HOMEASSISTANT.md document the dual
+      webhook-push/REST-polling data path in detail.
+  docs-examples:
+    status: done
+    comment: docs/EXAMPLES.md (dashboard card, automation).
+  docs-known-limitations:
+    status: done
+    comment: |
+      docs/UNIFI.md documents the 3000-record /list/alarm cap; README
+      documents the security-categories-share-a-trigger caveat, the
+      local-network-only requirement, and the ?token=/Authorization header
+      deprecation window.
+  docs-supported-devices:
+    status: done
+    comment: README "Tested controllers" table.
+  docs-supported-functions:
+    status: done
+    comment: README "Features" and "Alert categories" sections.
+  docs-troubleshooting:
+    status: done
+    comment: docs/TROUBLESHOOTING.md.
+  docs-use-cases:
+    status: todo
+    comment: |
+      Features and setup are documented but there is no section explicitly
+      framed around use cases. Filed as #346.
+  dynamic-devices:
+    status: exempt
+    comment: |
+      One fixed service device per config entry; the integration never adds
+      or removes devices at runtime.
+  entity-category:
+    status: done
+    comment: |
+      Diagnostic sensors (message, webhook-health) use
+      EntityCategory.DIAGNOSTIC; clear buttons use EntityCategory.CONFIG;
+      primary state entities (binary sensor, count sensor, event) are
+      correctly left uncategorised.
+  entity-device-class:
+    status: done
+    comment: |
+      BinarySensorDeviceClass.PROBLEM on binary sensors,
+      SensorDeviceClass.ENUM on the webhook-health sensor. Count sensors
+      have no device class because none fits an alert counter; they use
+      SensorStateClass.MEASUREMENT instead (see sensor.py inline comment).
+  entity-disabled-by-default:
+    status: todo
+    comment: |
+      No entity sets entity_registry_enabled_default = False. Ambiguous
+      whether this is actually a gap, since users already opt into
+      categories at config time. Filed as #345 for a maintainer decision.
+  entity-translations:
+    status: done
+    comment: |
+      Every entity sets _attr_translation_key; names are supplied via
+      strings.json/translations/en.json, kept identical and drift-checked
+      in CI.
+  exception-translations:
+    status: todo
+    comment: |
+      Repair issues use translation_key correctly, but raised exceptions
+      (ConfigEntryAuthFailed, ConfigEntryNotReady, UpdateFailed) carry plain
+      f-string messages rather than translation_domain/translation_key.
+      Filed as #341.
+  icon-translations:
+    status: done
+    comment: |
+      icons.json (added in #338) covers every entity's icon, keyed by
+      translation_key, including state-dependent on/off pairs for binary
+      sensors. The one remaining Python-side icon property (the per-category
+      message sensor) is a justified exception: its icon depends on
+      is_alerting, a different signal from the sensor's own displayed
+      value (the message text), which icons.json's state-keyed mechanism
+      cannot express.
+  reconfiguration-flow:
+    status: todo
+    comment: |
+      No async_step_reconfigure. The options flow already covers changing
+      the controller URL and API key, but not through HA's dedicated
+      reconfigure entry point. Filed as #344.
+  repair-issues:
+    status: done
+    comment: |
+      Six distinct repair issues, each created and cleared at the right
+      lifecycle point: auth failed, API-key migration needed, webhook
+      secret rotated, webhook URLs changed (migration), watermark persist
+      failed, legacy query-string webhook auth deprecation.
+  stale-devices:
+    status: exempt
+    comment: |
+      One fixed service device per config entry; there is no set of
+      sub-devices that can go stale independently.
+
+  # Platinum
+  async-dependency:
+    status: done
+    comment: All I/O uses aiohttp; no synchronous network or disk calls.
+  inject-websession:
+    status: done
+    comment: |
+      async_get_clientsession(hass, verify_ssl=...) is used everywhere; no
+      bare aiohttp.ClientSession is ever created (see
+      docs/HOMEASSISTANT.md "aiohttp session lifecycle").
+  strict-typing:
+    status: done
+    comment: pyproject.toml sets mypy strict = true, enforced in CI.


### PR DESCRIPTION
## Summary

Walks Home Assistant's integration quality scale checklist (Bronze/Silver/Gold) rule by rule against the actual code and records the result in a new `quality_scale.yaml`. Closes #272.

## Changes

- Added `quality_scale.yaml` at the repo root: every rule marked `done`, `exempt` (with a reason), or `todo` (with a linked issue), verified against the current code rather than assumed.
- Added a short "Quality scale" section to `README.md` pointing at the audit file.
- **`manifest.json` is deliberately untouched.** The Bronze-tier `brands` rule is still open (logo not yet submitted to home-assistant/brands, tracked by #143's own acceptance criteria), so declaring any tier in the manifest right now would overclaim. Once that lands, the manifest key can be added and the tier claim CI-verified for real by the existing `hassfest`/`hacs/action` jobs (both already run in this repo's CI, so that's the actual verification path rather than a local reproduction).

## Gaps found, filed as their own issues

- #340 `action-exceptions` — `clear_category`/`clear_all` silently no-op on an unknown/unloaded `entry_id` instead of raising a visible error
- #341 `exception-translations` — setup/auth/connect exceptions use plain f-strings instead of translation keys
- #343 `discovery-update-info` — SSDP rediscovery doesn't update the entry's `controller_url` on an IP change
- #344 `reconfiguration-flow` — no dedicated `async_step_reconfigure` (the options flow covers similar ground but isn't the same entry point)
- #345 `entity-disabled-by-default` — ambiguous, flagged for a maintainer decision rather than treated as a clear-cut gap
- #346 `docs-use-cases` — no explicit "Use cases" section in the README

Two issues (`parallel-updates`, `icon-translations`) were filed first against a stale local branch base, then found to already be resolved by #338 once the branch was rebased onto current `dev` — closed as not-planned with a note.

Also updated #143 with the audit result.

~~### Unrelated bug found during the audit~~

Retracted: I filed #347 believing `except X, Y:` (no parens) in `coordinator.py`/`unifi_auth.py`/`models.py` was a Python 2 syntax leak. It isn't — it's valid Python 3.14 syntax under PEP 758, and exactly what this project's pinned tooling produces, per the hard rule already documented in `CLAUDE.md`. My local `.venv` is Python 3.12, which predates PEP 758 and gave a false-positive `SyntaxError`. CI (Python 3.14) confirms all jobs pass clean on `dev`. Closed #347 with a correction and an apology for the noise.

## How to test

This is a docs/config-only change (no `custom_components/` logic), so the lighter doc-only gate applies:

```bash
python3 scripts/validate_docs.py       # prose linter, HISTORY h2 format
python3 scripts/check_translations.py  # strings.json / translations/en.json parity
python3 scripts/validate_hacs.py       # HACS manifest pre-flight
```

All three pass locally. Full CI (lint, mypy, hassfest, HACS action, both test legs) is green on this PR.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #272`... see Summary)
- [x] `make doc-check` equivalent passes locally (see above)
- [ ] `CHANGELOG.md` — not updated; no user-visible change, manifest untouched
- [x] PR title starts with a Conventional Commit prefix (`feat:`)
- [x] PR has a label recognised by `.github/release.yml` — applied automatically by `pr-labeler.yml` from the `feat:` prefix
- [x] `strings.json` and `translations/en.json` — untouched, still identical
- [x] No blocking I/O introduced
