### PR TITLE
docs: add Use cases section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ Aggregates **UniFi Network controller alerts** into Home Assistant sensors, bina
 
 ---
 
+## Use cases
+
+- **Network-outage dashboards** - put the rollup `binary_sensor.unifi_alerts_any_alert` and the WAN offline/latency category on a Lovelace card so a failover or ISP outage is visible at a glance.
+- **Security automations** - notify the moment UniFi's IPS/IDS, honeypot, or firewall-block alarms fire, instead of noticing a threat only after checking the controller UI.
+- **Unattended-site power monitoring** - alert on PoE disconnects, power cycles, or UPS events at a remote or unstaffed site where nobody is watching the controller in real time.
+- **Client presence and churn tracking** - use the client connect/disconnect category to notice unexpected devices joining, or expected devices dropping off, the network.
+
+See [docs/EXAMPLES.md](docs/EXAMPLES.md) for a working example of each: a Lovelace entities card ("UniFi Network Health") and an automation that notifies on a security threat, built on the entities this integration creates.
+
+---
+
 ## Requirements
 
 - **Home Assistant** 2026.3 or later (requires Python 3.14)

--- a/quality_scale.yaml
+++ b/quality_scale.yaml
@@ -203,10 +203,12 @@ rules:
     status: done
     comment: docs/TROUBLESHOOTING.md.
   docs-use-cases:
-    status: todo
+    status: done
     comment: |
-      Features and setup are documented but there is no section explicitly
-      framed around use cases. Filed as #346.
+      README "Use cases" section names four concrete scenarios (network-
+      outage dashboards, security automations, unattended-site power
+      monitoring, client presence tracking) and cross-links docs/EXAMPLES.md
+      for the working dashboard card and automation. Closed #346.
   dynamic-devices:
     status: exempt
     comment: |


### PR DESCRIPTION
## Summary

Adds a "Use cases" section to `README.md` so the docs-use-cases Gold-tier quality-scale rule is satisfied explicitly rather than implied by the feature list.

## Changes

- `README.md`: new "Use cases" section placed right after "Features"/"Alert categories" and before "Requirements", so a prospective user sees what the integration is for before how to install it. Four bullets: network-outage dashboards, security automations (IPS/IDS, honeypot, firewall block), unattended-site power monitoring (PoE/UPS), and client presence/churn tracking. Cross-links `docs/EXAMPLES.md`, naming its two concrete examples (the "UniFi Network Health" Lovelace card and the "Notify on UniFi security threat" automation).
- `quality_scale.yaml`: flips the `docs-use-cases` rule (Gold section) from `status: todo` to `status: done`, with a comment describing what now satisfies it.

## How to test

Doc-only change, no `custom_components/` edits.

```bash
make doc-check  # docs + translation parity
make validate   # HACS preflight + docs prose checks
```

Both pass locally (ran the underlying stdlib scripts directly: `validate_docs.py`, `check_translations.py`, `check_agentrc_refs.py`, `validate_hacs.py` all succeeded). `python3.14` was not available in this environment to run the full `make check` (lint/typecheck/test) locally; per `docs/DEVELOPING.md`'s "Doc-only changes (lighter path)", the full suite is skipped locally for doc-only PRs and CI is the safety net.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #346` below)
- [x] `make doc-check` / `make validate` pass locally (doc-only path per `docs/DEVELOPING.md`)
- [ ] `CHANGELOG.md` `[Unreleased]` updated - not needed; no `custom_components/` edits, so `changelog-guard` does not fire
- [x] PR title starts with a Conventional Commit prefix (`docs:`)
- [ ] PR has a label recognised by `.github/release.yml` - expected to be applied automatically by `pr-release-label.yml`
- [x] `strings.json` and `translations/en.json` untouched
- [x] No category added
- [x] No blocking I/O introduced (doc-only)

Closes #346

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJK2GkNsfirS7VpUdL5Jha)_