### PR TITLE
feat: add translation keys to setup and update exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `fetch_alarms()` now discovers the working alarm endpoint once per site and caches it, instead of walking the `[/list/alarm, /alarm, /stat/alarm]` fallback chain and parsing the HTTP 400 `api.err.InvalidObject` body on every poll. Endpoint discovery (`_discover_alarm_url()`) is now separate from the core fetch/parse flow in `_try_fetch_alarms()`; discovery only re-runs if the cached URL stops resolving. Behaviour is unchanged; this is a refactor. ([#239])
 - **Breaking:** inbound webhook authentication now checks an `Authorization: Bearer <secret>` header in addition to the legacy `?token=<secret>` query parameter. The header is the preferred form: query strings are routinely captured by reverse-proxy and access logs, browser history, and screenshots of the config flow, so the secret has more exposure surface than a header. The `?token=` form is still accepted during a deprecation window (no earlier than v3.0.0) so existing UniFi Alarm Manager configurations keep working, but a `webhook_legacy_query_auth` repair issue nudges affected entries to migrate. The config and options flow "Webhook URLs" screens no longer embed the secret in the displayed URL; it is shown separately for use as the header value. ([#335])
 - `UniFiClient` is now fully stateless: the v2 system-log-probe cache and backoff (previously `_has_system_log`/`_probe_fail_count`/`_probe_backoff_until` on the client) moved to `UniFiAlertsCoordinator`, which already owns all other cross-poll state. Behaviour is unchanged; this is a refactor. ([#240])
+- The setup and polling errors surfaced to the user (`ConfigEntryAuthFailed`, `ConfigEntryNotReady`, `UpdateFailed`) now carry translation keys instead of hard-coded English messages, so they can be localised the same way repair issues already are. ([#341])
 
 ### Fixed
 
@@ -356,3 +357,4 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#335]: https://github.com/PHeonix25/unifi_alerts/pull/335
 [#240]: https://github.com/PHeonix25/unifi_alerts/issues/240
 [#340]: https://github.com/PHeonix25/unifi_alerts/issues/340
+[#341]: https://github.com/PHeonix25/unifi_alerts/issues/341

--- a/custom_components/unifi_alerts/__init__.py
+++ b/custom_components/unifi_alerts/__init__.py
@@ -24,6 +24,8 @@ from .const import (
     CONF_VERIFY_SSL,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
+    EXCEPTION_SETUP_AUTH_FAILED,
+    EXCEPTION_SETUP_CANNOT_CONNECT,
     ISSUE_ID_APIKEY_MIGRATION,
     ISSUE_ID_AUTH_FAILED,
     ISSUE_ID_PERSIST_FAILED,
@@ -181,12 +183,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except InvalidAuthError as err:
         _LOGGER.error("Authentication failed for UniFi controller: %s", type(err).__name__)
         raise ConfigEntryAuthFailed(
-            f"Invalid credentials for UniFi controller: {type(err).__name__}"
+            f"Invalid credentials for UniFi controller: {type(err).__name__}",
+            translation_domain=DOMAIN,
+            translation_key=EXCEPTION_SETUP_AUTH_FAILED,
+            translation_placeholders={"error": type(err).__name__},
         ) from err
     except CannotConnectError as err:
         _LOGGER.error("Failed to authenticate to UniFi controller: %s", type(err).__name__)
         raise ConfigEntryNotReady(
-            f"Could not connect to UniFi controller: {type(err).__name__}"
+            f"Could not connect to UniFi controller: {type(err).__name__}",
+            translation_domain=DOMAIN,
+            translation_key=EXCEPTION_SETUP_CANNOT_CONNECT,
+            translation_placeholders={"error": type(err).__name__},
         ) from err
 
     # Proactively register the hub device so it appears in HA's Services section

--- a/custom_components/unifi_alerts/const.py
+++ b/custom_components/unifi_alerts/const.py
@@ -83,6 +83,21 @@ ISSUE_ID_WEBHOOK_LEGACY_QUERY_AUTH: Final = "webhook_legacy_query_auth"
 # looking like a credential failure.
 ISSUE_ID_APIKEY_MIGRATION: Final = "apikey_migration_required"
 
+# Translation keys for exceptions raised during setup and polling (Gold
+# quality-scale rule exception-translations, #341). These are distinct from
+# the ISSUE_ID_* constants above: those key repair issues in the issue
+# registry, these key the "exceptions" section in strings.json/translations
+# consumed via translation_domain/translation_key/translation_placeholders on
+# the raised exception itself (ConfigEntryAuthFailed, ConfigEntryNotReady,
+# UpdateFailed). Scoped only to exceptions HA actually surfaces to the user;
+# unifi_auth.py's internal CannotConnectError/InvalidAuthError/
+# SslCertificateError are caught and re-raised as these, so they do not need
+# their own translation keys.
+EXCEPTION_SETUP_AUTH_FAILED: Final = "setup_auth_failed"
+EXCEPTION_SETUP_CANNOT_CONNECT: Final = "setup_cannot_connect"
+EXCEPTION_POLL_AUTH_FAILED: Final = "poll_auth_failed"
+EXCEPTION_POLL_CANNOT_CONNECT: Final = "poll_cannot_connect"
+
 # ──────────────────────────────────────────────
 # Category identifiers
 # ──────────────────────────────────────────────

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -27,6 +27,8 @@ from .const import (
     DEFAULT_SITE,
     DEFAULT_SYSTEM_LOG_LOOKBACK_HOURS,
     DOMAIN,
+    EXCEPTION_POLL_AUTH_FAILED,
+    EXCEPTION_POLL_CANNOT_CONNECT,
     ISSUE_ID_PERSIST_FAILED,
     STORAGE_VERSION_WATERMARKS,
     WEBHOOK_DEDUP_WINDOW_SECONDS,
@@ -148,9 +150,19 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
             # a 401 means the key was revoked or is otherwise no longer valid.
             # Surface reauth directly instead of retrying.
             _LOGGER.error("UniFi controller rejected the API key: %s", err)
-            raise ConfigEntryAuthFailed(f"UniFi controller rejected the API key: {err}") from err
+            raise ConfigEntryAuthFailed(
+                f"UniFi controller rejected the API key: {err}",
+                translation_domain=DOMAIN,
+                translation_key=EXCEPTION_POLL_AUTH_FAILED,
+                translation_placeholders={"error": str(err)},
+            ) from err
         except CannotConnectError as err:
-            raise UpdateFailed(f"Cannot reach UniFi controller: {err}") from err
+            raise UpdateFailed(
+                f"Cannot reach UniFi controller: {err}",
+                translation_domain=DOMAIN,
+                translation_key=EXCEPTION_POLL_CANNOT_CONNECT,
+                translation_placeholders={"error": str(err)},
+            ) from err
 
         for cat, alerts in categorised.items():
             if cat in self._category_states:

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -117,6 +117,18 @@
     },
     "entry_not_loaded": {
       "message": "The UniFi Alerts config entry \"{entry_id}\" is not currently loaded."
+    },
+    "setup_auth_failed": {
+      "message": "Invalid credentials for UniFi controller: {error}"
+    },
+    "setup_cannot_connect": {
+      "message": "Could not connect to UniFi controller: {error}"
+    },
+    "poll_auth_failed": {
+      "message": "UniFi controller rejected the API key: {error}"
+    },
+    "poll_cannot_connect": {
+      "message": "Cannot reach UniFi controller: {error}"
     }
   },
   "services": {

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -117,6 +117,18 @@
     },
     "entry_not_loaded": {
       "message": "The UniFi Alerts config entry \"{entry_id}\" is not currently loaded."
+    },
+    "setup_auth_failed": {
+      "message": "Invalid credentials for UniFi controller: {error}"
+    },
+    "setup_cannot_connect": {
+      "message": "Could not connect to UniFi controller: {error}"
+    },
+    "poll_auth_failed": {
+      "message": "UniFi controller rejected the API key: {error}"
+    },
+    "poll_cannot_connect": {
+      "message": "Cannot reach UniFi controller: {error}"
     }
   },
   "services": {

--- a/quality_scale.yaml
+++ b/quality_scale.yaml
@@ -244,12 +244,16 @@ rules:
       strings.json/translations/en.json, kept identical and drift-checked
       in CI.
   exception-translations:
-    status: todo
+    status: done
     comment: |
-      Repair issues use translation_key correctly, but raised exceptions
-      (ConfigEntryAuthFailed, ConfigEntryNotReady, UpdateFailed) carry plain
-      f-string messages rather than translation_domain/translation_key.
-      Filed as #341.
+      Repair issues use translation_key correctly, and the exceptions HA
+      surfaces to the user (ConfigEntryAuthFailed, ConfigEntryNotReady,
+      UpdateFailed in __init__.py and coordinator.py) now carry
+      translation_domain/translation_key/translation_placeholders, backed by
+      an "exceptions" section in strings.json/translations/en.json. The
+      internal CannotConnectError/InvalidAuthError/SslCertificateError in
+      unifi_auth.py are out of scope: they are caught and re-raised as the
+      above before ever reaching the user. Landed in #341.
   icon-translations:
     status: done
     comment: |


### PR DESCRIPTION
## Summary

Threads `translation_domain`/`translation_key`/`translation_placeholders` through the four exceptions Home Assistant actually surfaces to the user during setup and polling (`ConfigEntryAuthFailed`, `ConfigEntryNotReady`, `UpdateFailed`), matching the translation mechanism repair issues already use, and closes the Gold-tier `exception-translations` quality-scale gap.

## Changes

- `custom_components/unifi_alerts/__init__.py`: `async_setup_entry`'s `ConfigEntryAuthFailed` (auth failure) and `ConfigEntryNotReady` (connect failure) raises now carry translation kwargs, keeping the original f-string as the first positional arg so the plain-English message is still available for logs and existing `str(exc)`-based tests.
- `custom_components/unifi_alerts/coordinator.py`: `_async_update_data`'s `ConfigEntryAuthFailed` (rejected API key) and `UpdateFailed` (unreachable controller) raises get the same treatment.
- `custom_components/unifi_alerts/const.py`: adds four new `EXCEPTION_*` translation-key constants, documented as distinct from the existing `ISSUE_ID_*` repair-issue constants.
- `custom_components/unifi_alerts/strings.json` and `translations/en.json`: new top-level `exceptions` section with matching keys/placeholders, kept byte-identical (verified via `scripts/check_translations.py`).
- `quality_scale.yaml`: flips `exception-translations` from `todo` to `done` with an updated comment.
- `CHANGELOG.md`: one bullet under `[Unreleased]` / `### Changed`, plus the `[#341]` reference link.

Deliberately out of scope per the issue: `unifi_auth.py`'s internal `CannotConnectError`/`InvalidAuthError`/`SslCertificateError` are caught and re-raised as the above before ever reaching the user, so they don't need their own translation keys.

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

Note: this sandbox has no Python 3.14 interpreter available (attempting to fetch one via `uv python install` was blocked by the egress proxy's organisation policy, 403), so `make setup`/`make check`/`make test` could not be run end-to-end here, consistent with the project's documented "treat CI as authoritative" fallback. What was verified locally instead:
- `ruff format --check` and `ruff check` (0.15.16, Rust-native PEP 758-aware parser) on all touched files: clean.
- `scripts/validate_docs.py`, `scripts/check_translations.py` (strings.json/translations/en.json byte-identical), `scripts/check_agentrc_refs.py`, `scripts/validate_hacs.py`: all pass under Python 3.13 (pure-stdlib scripts, no HA/3.14 dependency).
- A scratch (non-committed) copy of the package with the codebase's pre-existing bare-except PEP 758 lines temporarily parenthesized was run through `mypy --ignore-missing-imports` for a sanity pass; the only errors present are pre-existing "Class cannot subclass value of type Any" cascades caused by `homeassistant` not being installed in this lint-only venv (it requires Python >=3.14.2, unavailable), none in the lines this PR touches.
- Confirmed no existing test asserts an exact exception message string for the four raise sites (`tests/unit/test_init.py`, `tests/unit/coordinator/test_polling.py`); the tests that do check `str(exc)` content (secret-redaction assertions) still pass by construction since the original f-string is preserved as the exception's positional arg.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #341` in the description)
- [ ] `make check` passes locally (could not run end-to-end: no Python 3.14 interpreter available in this sandbox; CI is authoritative, see notes above)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] PR title starts with a Conventional Commit prefix (`feat:`)
- [ ] PR has a label recognised by `.github/release.yml` (expected to be applied automatically by `pr-release-label.yml`)
- [x] `strings.json` and `translations/en.json` are still identical
- [ ] New category fully registered (not applicable, no category added)
- [x] No blocking I/O introduced

Closes #341


---
_Generated by [Claude Code](https://claude.ai/code/session_01TJK2GkNsfirS7VpUdL5Jha)_