### PR TITLE
feat: add dedicated reconfigure flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added a dedicated reconfigure flow, so the controller URL, API key, and SSL verification can be updated through Home Assistant's "Reconfigure" affordance without deleting and re-adding the entry. The existing "Configure" options flow is unchanged. ([#344])
 - Added a per-category minimum-severity option (Config Flow and Options Flow), with an explicit "No Filter" value, so noisy categories can be enabled without accepting every low-value alert; alerts with no recognisable severity are never filtered out. ([#135])
 
 ### Changed
@@ -360,3 +361,4 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#340]: https://github.com/PHeonix25/unifi_alerts/issues/340
 [#341]: https://github.com/PHeonix25/unifi_alerts/issues/341
 [#343]: https://github.com/PHeonix25/unifi_alerts/issues/343
+[#344]: https://github.com/PHeonix25/unifi_alerts/issues/344

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -446,6 +446,100 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+    # ── Reconfigure flow ─────────────────────────────────────────────────
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Entry point for HA's dedicated "Reconfigure" UI affordance.
+
+        Distinct from the options flow's "Configure" gear icon (which also
+        covers alert categories, polling, and webhook secret rotation), this
+        is what the Gold-tier `reconfiguration-flow` quality-scale rule
+        checks for. Lets the user update the controller URL, API key, and/or
+        verify_ssl for an existing entry without deleting and re-adding it.
+        Reuses the same credential-validation helpers as
+        `UniFiAlertsOptionsFlow`'s credentials step
+        (`_parse_credentials_form_input`, `_build_credentials_test_data`,
+        `_async_validate_controller_credentials`) so the two flows apply
+        identical validation instead of diverging.
+        """
+        entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            parsed = _parse_credentials_form_input(user_input, entry.data)
+
+            if (
+                not parsed.credentials_changed
+                and not parsed.regenerate_secret
+                and not parsed.verify_ssl_changed
+            ):
+                # Nothing changed - nothing to persist or reload.
+                return self.async_abort(reason="reconfigure_successful")
+
+            if not parsed.credentials_changed:
+                # verify_ssl flip only - no controller round-trip needed.
+                new_data = _build_verify_ssl_and_secret_only_pending(entry.data, parsed)
+                return self.async_update_reload_and_abort(
+                    entry, data=new_data, reason="reconfigure_successful"
+                )
+
+            effective_url = (
+                parsed.new_url_raw.rstrip("/")
+                if parsed.new_url_raw
+                else entry.data[CONF_CONTROLLER_URL]
+            )
+
+            if not _is_valid_url_scheme(effective_url):
+                errors[CONF_CONTROLLER_URL] = "invalid_url_scheme"
+            else:
+                test_data = _build_credentials_test_data(entry.data, effective_url, parsed)
+                try:
+                    await _async_validate_controller_credentials(
+                        self.hass, effective_url, parsed.new_verify_ssl, test_data
+                    )
+                except InvalidAuthError:
+                    errors["base"] = "invalid_auth"
+                except SslCertificateError:
+                    errors["base"] = "invalid_ssl_cert"
+                except CannotConnectError as err:
+                    _LOGGER.error("Cannot reach controller during reconfigure: %s", err)
+                    errors["base"] = "cannot_connect"
+                else:
+                    url_changed = effective_url != entry.data[CONF_CONTROLLER_URL]
+                    if url_changed and _find_duplicate_entry(
+                        self.hass, entry.entry_id, effective_url
+                    ):
+                        return self.async_abort(reason="already_configured")
+
+                    new_data = _build_credentials_pending_data(entry.data, effective_url, parsed)
+                    update_kwargs: dict[str, Any] = {
+                        "data": new_data,
+                        "reason": "reconfigure_successful",
+                    }
+                    if url_changed:
+                        update_kwargs["unique_id"] = effective_url
+                    return self.async_update_reload_and_abort(entry, **update_kwargs)
+
+        _api_key_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
+        current_url: str = entry.data.get(CONF_CONTROLLER_URL, "")
+        current_verify_ssl = entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
+
+        schema = vol.Schema(
+            {
+                vol.Optional(CONF_CONTROLLER_URL): str,
+                vol.Optional(CONF_API_KEY): _api_key_selector,
+                vol.Optional(CONF_VERIFY_SSL, default=current_verify_ssl): bool,
+            }
+        )
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={"current_url": current_url},
+        )
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -55,6 +55,18 @@
         "data": {
           "api_key": "API Key"
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure UniFi Alerts",
+        "description": "Update the controller URL, API key, or SSL verification for this entry. Leave the URL and API key fields blank to keep their current values.\n\nCurrent controller: {current_url}\n\nAlert categories, polling, and webhook secret rotation are managed separately via Settings > Devices & Services > UniFi Alerts > Configure.",
+        "data": {
+          "controller_url": "New Controller URL (leave blank to keep current)",
+          "api_key": "New API Key (leave blank to keep current)",
+          "verify_ssl": "Verify SSL certificate"
+        },
+        "data_description": {
+          "verify_ssl": "Disable only if the controller uses a self-signed certificate. Disabling verification exposes the connection to man-in-the-middle attacks on the local network."
+        }
       }
     },
     "error": {
@@ -68,6 +80,7 @@
     "abort": {
       "already_configured": "This UniFi controller is already configured.",
       "reauth_successful": "Re-authentication was successful. The integration has been reloaded.",
+      "reconfigure_successful": "Reconfiguration was successful. The integration has been reloaded.",
       "cannot_connect": "Could not determine the controller address from the discovery information. Set up the controller manually instead."
     }
   },

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -55,6 +55,18 @@
         "data": {
           "api_key": "API Key"
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure UniFi Alerts",
+        "description": "Update the controller URL, API key, or SSL verification for this entry. Leave the URL and API key fields blank to keep their current values.\n\nCurrent controller: {current_url}\n\nAlert categories, polling, and webhook secret rotation are managed separately via Settings > Devices & Services > UniFi Alerts > Configure.",
+        "data": {
+          "controller_url": "New Controller URL (leave blank to keep current)",
+          "api_key": "New API Key (leave blank to keep current)",
+          "verify_ssl": "Verify SSL certificate"
+        },
+        "data_description": {
+          "verify_ssl": "Disable only if the controller uses a self-signed certificate. Disabling verification exposes the connection to man-in-the-middle attacks on the local network."
+        }
       }
     },
     "error": {
@@ -68,6 +80,7 @@
     "abort": {
       "already_configured": "This UniFi controller is already configured.",
       "reauth_successful": "Re-authentication was successful. The integration has been reloaded.",
+      "reconfigure_successful": "Reconfiguration was successful. The integration has been reloaded.",
       "cannot_connect": "Could not determine the controller address from the discovery information. Set up the controller manually instead."
     }
   },

--- a/quality_scale.yaml
+++ b/quality_scale.yaml
@@ -268,11 +268,15 @@ rules:
       value (the message text), which icons.json's state-keyed mechanism
       cannot express.
   reconfiguration-flow:
-    status: todo
+    status: done
     comment: |
-      No async_step_reconfigure. The options flow already covers changing
-      the controller URL and API key, but not through HA's dedicated
-      reconfigure entry point. Filed as #344.
+      async_step_reconfigure implements HA's dedicated reconfigure entry
+      point, letting the user update the controller URL, API key, and
+      verify_ssl for an existing entry without deleting and re-adding it.
+      Reuses the same credential-validation helpers as the options flow's
+      credentials step rather than duplicating that logic. The options flow
+      is kept as-is alongside it, covering alert categories, polling, and
+      webhook secret rotation. Landed in #344.
   repair-issues:
     status: done
     comment: |

--- a/tests/unit/config_flow/conftest.py
+++ b/tests/unit/config_flow/conftest.py
@@ -69,6 +69,39 @@ def make_reauth_flow(entry_id: str = "entry-test") -> UniFiAlertsConfigFlow:
     return flow
 
 
+def make_reconfigure_flow(entry_id: str = "entry-reconfigure") -> UniFiAlertsConfigFlow:
+    """Create a config flow instance wired up for reconfigure tests.
+
+    `_get_reconfigure_entry` is a real `ConfigFlow` base-class method that
+    reads `self._reconfigure_entry_id` (derived from flow context set up by
+    HA's flow manager) and calls `self.hass.config_entries.async_get_known_entry`.
+    Driving that machinery for real needs a running hass, so it is stubbed
+    directly here, matching how `make_reauth_flow` stubs the equivalent
+    reauth lookup.
+    """
+    flow = UniFiAlertsConfigFlow()
+    flow.context = {}
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = entry_id
+    mock_entry.title = "UniFi Alerts (https://192.168.1.1)"
+    mock_entry.data = {
+        CONF_CONTROLLER_URL: "https://192.168.1.1",
+        CONF_API_KEY: "old-api-key",
+        CONF_VERIFY_SSL: True,
+        CONF_WEBHOOK_SECRET: "fixed-secret",
+    }
+
+    hass = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+    hass.config_entries.async_update_entry = MagicMock()
+    hass.config_entries.async_reload = AsyncMock()
+    hass.config_entries.async_schedule_reload = MagicMock()
+    flow.hass = hass
+    flow._get_reconfigure_entry = MagicMock(return_value=mock_entry)  # type: ignore[method-assign]
+    return flow
+
+
 def make_options_flow(
     url: str = "https://192.168.1.1",
     enabled_categories: list[str] | None = None,

--- a/tests/unit/config_flow/test_reconfigure.py
+++ b/tests/unit/config_flow/test_reconfigure.py
@@ -1,0 +1,315 @@
+"""Tests for the dedicated reconfigure flow: async_step_reconfigure (#344).
+
+Covers HA's Gold-tier `reconfiguration-flow` quality-scale entry point,
+distinct from the options flow's "Configure" step tested in
+test_options_credentials.py. async_step_reconfigure reuses the same
+credential-validation helpers as the options flow's credentials step, so
+these tests mirror the structure of TestOptionsFlowCredentials and
+TestReauthConfirmStep in test_reauth.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.unifi_alerts.const import (
+    CONF_API_KEY,
+    CONF_CONTROLLER_URL,
+    CONF_VERIFY_SSL,
+)
+
+from .conftest import make_reconfigure_flow, make_session_mock
+
+
+class TestReconfigureStep:
+    """Tests for async_step_reconfigure."""
+
+    @pytest.mark.asyncio
+    async def test_no_input_shows_form(self) -> None:
+        """With no user_input, reconfigure must show the credentials form."""
+        flow = make_reconfigure_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reconfigure"})
+
+        result = await flow.async_step_reconfigure(user_input=None)
+
+        assert result["step_id"] == "reconfigure"
+        flow.async_show_form.assert_called_once()
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["step_id"] == "reconfigure"
+        assert not call_kwargs["errors"]
+        assert call_kwargs["description_placeholders"]["current_url"] == "https://192.168.1.1"
+
+    @pytest.mark.asyncio
+    async def test_form_offers_credential_fields(self) -> None:
+        """The reconfigure form must present controller URL, API key, and verify_ssl fields."""
+        flow = make_reconfigure_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reconfigure"})
+
+        await flow.async_step_reconfigure(user_input=None)
+
+        schema = flow.async_show_form.call_args.kwargs["data_schema"]
+        field_names = {str(key) for key in schema.schema}
+        assert field_names == {CONF_CONTROLLER_URL, CONF_API_KEY, CONF_VERIFY_SSL}
+
+    @pytest.mark.asyncio
+    async def test_blank_submission_is_a_noop_abort(self) -> None:
+        """All-blank fields with verify_ssl unchanged must abort without updating anything."""
+        flow = make_reconfigure_flow()
+        flow.async_abort = MagicMock(
+            return_value={"type": "abort", "reason": "reconfigure_successful"}
+        )
+
+        blank_input = {
+            CONF_CONTROLLER_URL: "",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: True,  # matches the fixture's stored value
+        }
+
+        result = await flow.async_step_reconfigure(blank_input)
+
+        assert result["reason"] == "reconfigure_successful"
+        flow.async_abort.assert_called_once_with(reason="reconfigure_successful")
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_valid_new_credentials_updates_and_reloads(self) -> None:
+        """Submitting valid new credentials must update the entry and reload it."""
+        flow = make_reconfigure_flow()
+        flow.async_update_reload_and_abort = MagicMock(
+            return_value={"type": "abort", "reason": "reconfigure_successful"}
+        )
+
+        new_creds = {
+            CONF_CONTROLLER_URL: "https://10.0.0.1",
+            CONF_API_KEY: "new-key",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value=None)
+            instance.fetch_alarms = AsyncMock(return_value=[])
+
+            result = await flow.async_step_reconfigure(new_creds)
+
+        assert result["reason"] == "reconfigure_successful"
+        flow.async_update_reload_and_abort.assert_called_once()
+        call = flow.async_update_reload_and_abort.call_args
+        assert call.args[0] is flow._get_reconfigure_entry.return_value
+        assert call.kwargs["data"][CONF_CONTROLLER_URL] == "https://10.0.0.1"
+        assert call.kwargs["data"][CONF_API_KEY] == "new-key"
+        assert call.kwargs["unique_id"] == "https://10.0.0.1"
+        assert call.kwargs["reason"] == "reconfigure_successful"
+
+    @pytest.mark.asyncio
+    async def test_same_url_does_not_pass_unique_id(self) -> None:
+        """Updating only the API key (URL unchanged) must not touch unique_id."""
+        flow = make_reconfigure_flow()
+        flow.async_update_reload_and_abort = MagicMock(
+            return_value={"type": "abort", "reason": "reconfigure_successful"}
+        )
+
+        new_creds = {
+            CONF_CONTROLLER_URL: "",
+            CONF_API_KEY: "new-key",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value=None)
+            instance.fetch_alarms = AsyncMock(return_value=[])
+
+            await flow.async_step_reconfigure(new_creds)
+
+        call_kwargs = flow.async_update_reload_and_abort.call_args.kwargs
+        assert "unique_id" not in call_kwargs
+        assert call_kwargs["data"][CONF_API_KEY] == "new-key"
+        assert call_kwargs["data"][CONF_CONTROLLER_URL] == "https://192.168.1.1"
+
+    @pytest.mark.asyncio
+    async def test_verify_ssl_only_toggle_updates_without_auth_call(self) -> None:
+        """Flipping verify_ssl alone must update the entry without an auth round-trip."""
+        flow = make_reconfigure_flow()
+        flow.async_update_reload_and_abort = MagicMock(
+            return_value={"type": "abort", "reason": "reconfigure_successful"}
+        )
+
+        ssl_only = {
+            CONF_CONTROLLER_URL: "",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: False,  # fixture default is True
+        }
+
+        with patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls:
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock()
+            result = await flow.async_step_reconfigure(ssl_only)
+            instance.authenticate.assert_not_called()
+
+        assert result["reason"] == "reconfigure_successful"
+        call_kwargs = flow.async_update_reload_and_abort.call_args.kwargs
+        assert call_kwargs["data"][CONF_VERIFY_SSL] is False
+        # Other stored fields must be carried over unchanged
+        assert call_kwargs["data"][CONF_API_KEY] == "old-api-key"
+
+    @pytest.mark.asyncio
+    async def test_invalid_credentials_shows_error_and_does_not_update(self) -> None:
+        """Invalid credentials during reconfigure must re-show the form with an error."""
+        from custom_components.unifi_alerts.unifi_client import InvalidAuthError
+
+        flow = make_reconfigure_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reconfigure"})
+
+        new_creds = {
+            CONF_CONTROLLER_URL: "",
+            CONF_API_KEY: "bad-key",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(side_effect=InvalidAuthError("bad creds"))
+
+            result = await flow.async_step_reconfigure(new_creds)
+
+        assert result["step_id"] == "reconfigure"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"] == {"base": "invalid_auth"}
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cannot_connect_shows_error(self) -> None:
+        """A connection error during reconfigure must show cannot_connect error."""
+        from custom_components.unifi_alerts.unifi_client import CannotConnectError
+
+        flow = make_reconfigure_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reconfigure"})
+
+        new_creds = {
+            CONF_CONTROLLER_URL: "https://10.0.0.1",
+            CONF_API_KEY: "new-key",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(side_effect=CannotConnectError("down"))
+
+            result = await flow.async_step_reconfigure(new_creds)
+
+        assert result["step_id"] == "reconfigure"
+        assert flow.async_show_form.call_args.kwargs["errors"] == {"base": "cannot_connect"}
+
+    @pytest.mark.asyncio
+    async def test_ssl_cert_error_shows_invalid_ssl_cert(self) -> None:
+        """SslCertificateError during reconfigure must show invalid_ssl_cert base error."""
+        from custom_components.unifi_alerts.unifi_client import SslCertificateError
+
+        flow = make_reconfigure_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reconfigure"})
+
+        new_creds = {
+            CONF_CONTROLLER_URL: "https://10.0.0.1",
+            CONF_API_KEY: "new-key",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(side_effect=SslCertificateError("cert"))
+
+            result = await flow.async_step_reconfigure(new_creds)
+
+        assert result["step_id"] == "reconfigure"
+        assert flow.async_show_form.call_args.kwargs["errors"] == {"base": "invalid_ssl_cert"}
+
+    @pytest.mark.asyncio
+    async def test_invalid_url_scheme_shows_error(self) -> None:
+        """A non-http/https URL scheme must show a field-level error without hitting the network."""
+        flow = make_reconfigure_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "reconfigure"})
+
+        bad_url_input = {
+            CONF_CONTROLLER_URL: "ftp://192.168.1.1",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with patch(
+            "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+            return_value=make_session_mock(),
+        ) as mock_session:
+            result = await flow.async_step_reconfigure(bad_url_input)
+
+        assert result["step_id"] == "reconfigure"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"].get(CONF_CONTROLLER_URL) == "invalid_url_scheme"
+        # No network call should have been made
+        mock_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_url_collision_aborts(self) -> None:
+        """Changing to a URL already used by another entry must abort with already_configured."""
+        flow = make_reconfigure_flow()
+
+        other_entry = MagicMock()
+        other_entry.entry_id = "other-entry"
+        other_entry.data = {CONF_CONTROLLER_URL: "https://10.0.0.1"}
+        flow.hass.config_entries.async_entries = MagicMock(return_value=[other_entry])
+
+        flow.async_abort = MagicMock(return_value={"type": "abort", "reason": "already_configured"})
+
+        new_creds = {
+            CONF_CONTROLLER_URL: "https://10.0.0.1",
+            CONF_API_KEY: "",
+            CONF_VERIFY_SSL: True,
+        }
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value=None)
+            instance.fetch_alarms = AsyncMock(return_value=[])
+
+            result = await flow.async_step_reconfigure(new_creds)
+
+        assert result["reason"] == "already_configured"
+        flow.hass.config_entries.async_update_entry.assert_not_called()


### PR DESCRIPTION
## Summary

Adds `async_step_reconfigure` to `UniFiAlertsConfigFlow`, HA's dedicated "Reconfigure" entry point (distinct from the existing options flow's "Configure" gear icon). Users can now update the controller URL, API key, and `verify_ssl` for an existing entry via Settings > Devices & Services > UniFi Alerts > Reconfigure, without deleting and re-adding it. This closes the Gold-tier `reconfiguration-flow` quality-scale gap tracked in #344.

## Changes

- `custom_components/unifi_alerts/config_flow.py`: added `async_step_reconfigure`, which reuses the existing module-level helpers already shared with the options flow's credentials step (`_parse_credentials_form_input`, `_build_credentials_test_data`, `_async_validate_controller_credentials`, plus `_is_valid_url_scheme`, `_find_duplicate_entry`, `_build_credentials_pending_data`, `_build_verify_ssl_and_secret_only_pending`) instead of duplicating validation logic. Persists via `self.async_update_reload_and_abort(...)` with an explicit `reason="reconfigure_successful"`. The existing `UniFiAlertsOptionsFlow` is untouched.
- `custom_components/unifi_alerts/strings.json` / `translations/en.json`: added the `config.step.reconfigure` step strings and the `config.abort.reconfigure_successful` abort reason. Both files remain identical.
- `tests/unit/config_flow/conftest.py`: added `make_reconfigure_flow()`, mirroring the existing `make_reauth_flow()` pattern (stubs `_get_reconfigure_entry` directly, since driving it for real needs a running `hass`).
- `tests/unit/config_flow/test_reconfigure.py` (new): covers the no-input form, successful credential/URL/verify_ssl updates (with and without a unique_id change), a no-op abort when nothing changed, `invalid_auth`/`cannot_connect`/`invalid_ssl_cert`/`invalid_url_scheme` error paths, and a duplicate-URL `already_configured` abort.
- `quality_scale.yaml`: flipped `reconfiguration-flow` from `todo` to `done` with an updated comment.
- `CHANGELOG.md`: added an `[Unreleased]` / `Added` bullet ([#344]).

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

**Environment note:** this sandbox only has Python up to 3.13 available, and this repo's `homeassistant>=2026.7.1` pin (and several existing modules, e.g. `unifi_auth.py`, `coordinator.py`) require Python 3.14 (PEP 758 bare multi-exception syntax, and HA's own `Requires-Python`). I could not install the real dev/test dependencies or execute `pytest`/`mypy` here as a result — this matches the caveat already documented in this repo's `CLAUDE.md`. What I *could* and did verify locally:
- `ruff check` and `ruff format --check` both pass against the pinned `ruff==0.15.16` (its parser is independent of the host interpreter and targets `py314`).
- `make doc-check` (translation parity + docs validation) passes.
- `scripts/validate_hacs.py` passes.
- Manually confirmed against a 3.13-installable HA release (2026.2.3) that `ConfigFlow._get_reconfigure_entry()` and `ConfigFlow.async_update_reload_and_abort()` exist with the signatures this PR relies on, and cross-checked the implementation shape against a real core integration (`homeassistant/components/brother/config_flow.py`) that uses the identical pattern.

Please treat CI (which does have a real 3.14 runner) as authoritative for `make check`/`pytest`/`mypy`.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #344` below)
- [ ] `make check` passes locally (could not run in this sandbox - see note above; CI is authoritative)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] PR title starts with a Conventional Commit prefix (`feat:`)
- [ ] PR has a label recognised by `.github/release.yml` (expected to be applied automatically by `pr-release-label.yml`)
- [x] `strings.json` and `translations/en.json` are still identical
- [ ] New category fully registered (not applicable - no new category)
- [x] No blocking I/O introduced (reuses existing async helpers)

Closes #344


---
_Generated by [Claude Code](https://claude.ai/code/session_01TJK2GkNsfirS7VpUdL5Jha)_