### PR TITLE
fix: update config entry controller URL on SSDP rediscovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Unselected alert categories no longer create entities that sit at Unknown; entities are created only for chosen categories, and orphaned entities from deselected categories are removed on reload.
 - Clearing a category now anchors the acknowledgement watermark to the newest alarm timestamp already known for that category (falling back to the HA clock only when none has ever been seen), instead of the HA host clock. This keeps `open_count` correct when the UniFi controller's clock and the HA host clock drift apart. ([#268])
 - The `clear_category` and `clear_all` services now raise a translatable error when called with an `entry_id` that is unknown or not currently loaded, instead of silently doing nothing. Calling without an `entry_id` to act on every loaded entry is unaffected. ([#340])
+- SSDP rediscovery of a UniFi OS console at a new IP address (DHCP lease change, console swap) now updates the existing config entry's controller URL in place instead of leaving it pinned to the stale address until a human edited it manually. The console is matched by its UPnP serial number, which stays stable across IP changes. ([#343])
 
 ## [1.9.0] - 2026-07-06
 
@@ -358,3 +359,4 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#240]: https://github.com/PHeonix25/unifi_alerts/issues/240
 [#340]: https://github.com/PHeonix25/unifi_alerts/issues/340
 [#341]: https://github.com/PHeonix25/unifi_alerts/issues/341
+[#343]: https://github.com/PHeonix25/unifi_alerts/issues/343

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -32,6 +32,7 @@ from .const import (
     CONF_API_KEY,
     CONF_CLEAR_TIMEOUT,
     CONF_CONTROLLER_URL,
+    CONF_DEVICE_SERIAL,
     CONF_ENABLED_CATEGORIES,
     CONF_MIN_SEVERITY,
     CONF_POLL_INTERVAL,
@@ -121,6 +122,21 @@ def _entry_needs_apikey_migration(entry: Any) -> bool:
     return not entry.data.get(CONF_API_KEY)
 
 
+def _find_entry_by_serial(hass: Any, serial: str) -> ConfigEntry | None:
+    """Return the config entry whose stored device serial matches `serial`, or None.
+
+    `unique_id` is keyed on the controller URL (see `async_step_user`), which
+    changes if the controller's IP address changes. The UPnP serial number
+    carried in SSDP discovery payloads does not, so it is how
+    `async_step_ssdp` finds a previously configured entry to refresh when a
+    known console reappears at a new address (#343).
+    """
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.data.get(CONF_DEVICE_SERIAL) == serial:
+            return cast(ConfigEntry, entry)
+    return None
+
+
 class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle the initial setup flow shown in Settings → Integrations."""
 
@@ -130,6 +146,10 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
         self._controller_url: str = ""
         self._credentials: dict[str, Any] = {}
         self._entry_data: dict[str, Any] = {}
+        # Set by async_step_ssdp when the discovery payload carries a UPnP
+        # serial number; persisted onto the new entry so a future rediscovery
+        # at a different address can find and refresh it (#343).
+        self._device_serial: str = ""
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Step 1: controller URL + API key."""
@@ -173,6 +193,11 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_WEBHOOK_SECRET: secrets.token_urlsafe(32),
                         CONF_WEBHOOK_ID_SUFFIX: secrets.token_hex(4),
                     }
+                    if self._device_serial:
+                        # Carried over from async_step_ssdp so a future
+                        # rediscovery at a different address can find this
+                        # entry again (#343).
+                        self._credentials[CONF_DEVICE_SERIAL] = self._device_serial
                     return await self.async_step_categories()
 
         _api_key_selector = TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD))
@@ -213,6 +238,8 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
         """
         from urllib.parse import urlparse
 
+        from homeassistant.helpers.service_info import ssdp as ssdp_info
+
         parsed = urlparse(discovery_info.ssdp_location or "")
         host = parsed.hostname or ""
         if not host:
@@ -221,6 +248,34 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
         self._controller_url = f"https://{host}"
         await self.async_set_unique_id(self._controller_url)
         self._abort_if_unique_id_configured()
+
+        # The unique_id check above only catches rediscovery at an unchanged
+        # address, since unique_id is keyed on the controller URL (see
+        # async_step_user). If the controller's IP changed (DHCP lease
+        # change, console swap), the discovered UPnP serial number - stable
+        # across IP changes, unlike the URL - is used to find the previously
+        # configured entry and refresh its controller URL and unique_id in
+        # place, instead of leaving it pinned to the stale address until a
+        # human edits it manually (#343).
+        serial = discovery_info.upnp.get(ssdp_info.ATTR_UPNP_SERIAL)
+        if serial:
+            self._device_serial = serial
+            existing = _find_entry_by_serial(self.hass, serial)
+            if (
+                existing is not None
+                and existing.data.get(CONF_CONTROLLER_URL) != self._controller_url
+            ):
+                self.hass.config_entries.async_update_entry(
+                    existing,
+                    data={
+                        **existing.data,
+                        CONF_CONTROLLER_URL: self._controller_url,
+                        CONF_DEVICE_SERIAL: serial,
+                    },
+                    unique_id=self._controller_url,
+                )
+                return self.async_abort(reason="already_configured")
+
         self.context["title_placeholders"] = {"name": host}
         return await self.async_step_user()
 

--- a/custom_components/unifi_alerts/const.py
+++ b/custom_components/unifi_alerts/const.py
@@ -23,6 +23,13 @@ CONF_WEBHOOK_SECRET: Final = "webhook_secret"
 CONF_WEBHOOK_ID_SUFFIX: Final = "webhook_id_suffix"
 CONF_REGENERATE_WEBHOOK_SECRET: Final = "regenerate_webhook_secret"
 CONF_SITE: Final = "site"
+# Stable UPnP serial number (MAC address) captured from SSDP discovery.
+# Unlike CONF_CONTROLLER_URL (what unique_id is keyed on), this survives an
+# IP address change, so it is how async_step_ssdp finds and refreshes a
+# previously configured entry when a known console reappears at a new
+# address instead of leaving it pinned to the stale URL (#343). Only set on
+# entries created via SSDP discovery; absent on entries added manually.
+CONF_DEVICE_SERIAL: Final = "device_serial"
 
 DEFAULT_POLL_INTERVAL = 60  # seconds
 DEFAULT_CLEAR_TIMEOUT = 30  # minutes

--- a/quality_scale.yaml
+++ b/quality_scale.yaml
@@ -176,11 +176,14 @@ rules:
       manifest.json declares ssdp matchers for UDM/UDM Pro/UDM SE/UDM Pro
       Max; async_step_ssdp handles discovery.
   discovery-update-info:
-    status: todo
+    status: done
     comment: |
-      async_step_ssdp only aborts on a matching unique_id; it never updates
-      the existing entry's controller_url on rediscovery with a changed IP.
-      Filed as #343.
+      async_step_ssdp matches unchanged addresses via unique_id as before.
+      On a changed IP, the discovered UPnP serial number (stable across IP
+      changes, unlike unique_id which is keyed on the controller URL) is
+      used to find the previously configured entry and refresh its
+      controller_url and unique_id in place instead of leaving it pinned to
+      the stale address. Fixed in #343.
   docs-data-update:
     status: done
     comment: |

--- a/tests/unit/config_flow/conftest.py
+++ b/tests/unit/config_flow/conftest.py
@@ -24,6 +24,11 @@ def make_flow() -> UniFiAlertsConfigFlow:
     """Create a config flow instance with a minimal hass mock."""
     flow = UniFiAlertsConfigFlow()
     flow.hass = MagicMock()
+    # No pre-existing entries by default — async_step_ssdp's serial-based
+    # rediscovery lookup (_find_entry_by_serial) iterates this list. Tests
+    # that need a match override it with a MagicMock(return_value=[...]).
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[])
+    flow.hass.config_entries.async_update_entry = MagicMock()
     flow.context = {}
     # Patch unique ID helpers — real implementations need a running hass
     flow.async_set_unique_id = AsyncMock(return_value=None)

--- a/tests/unit/config_flow/test_discovery.py
+++ b/tests/unit/config_flow/test_discovery.py
@@ -14,17 +14,26 @@ from custom_components.unifi_alerts.const import CONF_CONTROLLER_URL, CONF_DEVIC
 from .conftest import _VALID_INPUT, make_flow, make_session_mock
 
 
-def make_ssdp_info(host: str = "192.168.1.1") -> ssdp.SsdpServiceInfo:
-    """Build a minimal SsdpServiceInfo for a UDM Pro at the given host."""
+def make_ssdp_info(
+    host: str = "192.168.1.1", serial: str | None = "aa:bb:cc:dd:ee:ff"
+) -> ssdp.SsdpServiceInfo:
+    """Build a minimal SsdpServiceInfo for a UDM Pro at the given host.
+
+    `serial` defaults to a stand-in UPnP serial; pass `None` to simulate a
+    discovery payload that lacks one, as seen on some firmware/device
+    combinations.
+    """
+    upnp = {
+        ssdp.ATTR_UPNP_MANUFACTURER: "Ubiquiti Networks",
+        ssdp.ATTR_UPNP_MODEL_DESCRIPTION: "UniFi Dream Machine Pro",
+    }
+    if serial is not None:
+        upnp[ssdp.ATTR_UPNP_SERIAL] = serial
     return ssdp.SsdpServiceInfo(
         ssdp_usn="uuid:abcd-1234-efgh-5678",
         ssdp_st="urn:schemas-upnp-org:device:InternetGatewayDevice:1",
         ssdp_location=f"http://{host}:1900/description.xml",
-        upnp={
-            ssdp.ATTR_UPNP_MANUFACTURER: "Ubiquiti Networks",
-            ssdp.ATTR_UPNP_MODEL_DESCRIPTION: "UniFi Dream Machine Pro",
-            ssdp.ATTR_UPNP_SERIAL: "aa:bb:cc:dd:ee:ff",
-        },
+        upnp=upnp,
     )
 
 
@@ -161,6 +170,25 @@ async def test_ssdp_no_matching_serial_continues_to_user_step() -> None:
     flow.hass.config_entries.async_update_entry.assert_not_called()
     flow.async_step_user.assert_called_once()
     assert flow._device_serial == "aa:bb:cc:dd:ee:ff"
+    assert result == {"type": "form", "step_id": "user"}
+
+
+@pytest.mark.asyncio
+async def test_ssdp_discovery_without_serial_continues_to_user_step() -> None:
+    """A discovery payload with no UPnP serial skips the rediscovery lookup.
+
+    Matches pre-#343 behaviour for devices/firmware whose SSDP response
+    never carries a serial.
+    """
+    flow = make_flow()
+    flow.async_step_user = AsyncMock(return_value={"type": "form", "step_id": "user"})
+
+    result = await flow.async_step_ssdp(make_ssdp_info("10.0.0.7", serial=None))
+
+    flow.hass.config_entries.async_entries.assert_not_called()
+    flow.hass.config_entries.async_update_entry.assert_not_called()
+    flow.async_step_user.assert_called_once()
+    assert flow._device_serial == ""
     assert result == {"type": "form", "step_id": "user"}
 
 

--- a/tests/unit/config_flow/test_discovery.py
+++ b/tests/unit/config_flow/test_discovery.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import contextlib
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers.service_info import ssdp
 
-from .conftest import make_flow
+from custom_components.unifi_alerts.const import CONF_CONTROLLER_URL, CONF_DEVICE_SERIAL
+
+from .conftest import _VALID_INPUT, make_flow, make_session_mock
 
 
 def make_ssdp_info(host: str = "192.168.1.1") -> ssdp.SsdpServiceInfo:
@@ -91,6 +93,78 @@ async def test_ssdp_sets_title_placeholder() -> None:
 
 
 @pytest.mark.asyncio
+async def test_ssdp_rediscovery_with_changed_ip_updates_existing_entry() -> None:
+    """A known console rediscovered at a new IP updates the stale entry in place.
+
+    The unique_id (URL-keyed) check does not match here — that is the whole
+    bug (#343) — so the entry is found via its stored UPnP serial instead,
+    which does not change when the controller's IP does.
+    """
+    existing_entry = MagicMock()
+    existing_entry.data = {
+        CONF_CONTROLLER_URL: "https://192.168.1.1",
+        CONF_DEVICE_SERIAL: "aa:bb:cc:dd:ee:ff",
+    }
+
+    flow = make_flow()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[existing_entry])
+    flow.async_abort = MagicMock(return_value={"type": "abort", "reason": "already_configured"})
+    flow.async_step_user = AsyncMock(return_value={"type": "form", "step_id": "user"})
+
+    result = await flow.async_step_ssdp(make_ssdp_info("10.0.0.99"))
+
+    flow.hass.config_entries.async_update_entry.assert_called_once()
+    call = flow.hass.config_entries.async_update_entry.call_args
+    assert call.args[0] is existing_entry
+    assert call.kwargs["data"][CONF_CONTROLLER_URL] == "https://10.0.0.99"
+    assert call.kwargs["data"][CONF_DEVICE_SERIAL] == "aa:bb:cc:dd:ee:ff"
+    assert call.kwargs["unique_id"] == "https://10.0.0.99"
+    flow.async_abort.assert_called_once_with(reason="already_configured")
+    assert result["reason"] == "already_configured"
+    flow.async_step_user.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ssdp_rediscovery_same_url_does_not_update_entry() -> None:
+    """Rediscovery of an entry already at the current URL is a no-op update-wise."""
+    existing_entry = MagicMock()
+    existing_entry.data = {
+        CONF_CONTROLLER_URL: "https://192.168.1.1",
+        CONF_DEVICE_SERIAL: "aa:bb:cc:dd:ee:ff",
+    }
+
+    flow = make_flow()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[existing_entry])
+    flow.async_step_user = AsyncMock(return_value={"type": "form", "step_id": "user"})
+
+    await flow.async_step_ssdp(make_ssdp_info("192.168.1.1"))
+
+    flow.hass.config_entries.async_update_entry.assert_not_called()
+    flow.async_step_user.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ssdp_no_matching_serial_continues_to_user_step() -> None:
+    """A genuinely new device (no serial match) proceeds to the user step as before."""
+    other_entry = MagicMock()
+    other_entry.data = {
+        CONF_CONTROLLER_URL: "https://192.168.1.50",
+        CONF_DEVICE_SERIAL: "11:22:33:44:55:66",
+    }
+
+    flow = make_flow()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[other_entry])
+    flow.async_step_user = AsyncMock(return_value={"type": "form", "step_id": "user"})
+
+    result = await flow.async_step_ssdp(make_ssdp_info("10.0.0.5"))
+
+    flow.hass.config_entries.async_update_entry.assert_not_called()
+    flow.async_step_user.assert_called_once()
+    assert flow._device_serial == "aa:bb:cc:dd:ee:ff"
+    assert result == {"type": "form", "step_id": "user"}
+
+
+@pytest.mark.asyncio
 async def test_user_step_uses_ssdp_url_as_default() -> None:
     """When _controller_url is pre-filled by SSDP, async_step_user uses it as the form default."""
     import voluptuous as vol
@@ -112,3 +186,30 @@ async def test_user_step_uses_ssdp_url_as_default() -> None:
                 schema_defaults[key.schema] = key.default()
 
     assert schema_defaults.get(CONF_CONTROLLER_URL) == "https://10.10.10.1"
+
+
+@pytest.mark.asyncio
+async def test_user_step_carries_ssdp_serial_into_credentials() -> None:
+    """A serial captured by async_step_ssdp is threaded into _credentials on setup.
+
+    So a future rediscovery at a different address can find this entry via
+    _find_entry_by_serial (#343).
+    """
+    flow = make_flow()
+    flow._device_serial = "aa:bb:cc:dd:ee:ff"
+    flow.async_step_categories = AsyncMock(return_value={"type": "form", "step_id": "categories"})
+
+    with (
+        patch(
+            "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+            return_value=make_session_mock(),
+        ),
+        patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+    ):
+        instance = mock_cls.return_value
+        instance.authenticate = AsyncMock(return_value=None)
+        instance.fetch_alarms = AsyncMock(return_value=[])
+
+        await flow.async_step_user(_VALID_INPUT)
+
+    assert flow._credentials[CONF_DEVICE_SERIAL] == "aa:bb:cc:dd:ee:ff"


### PR DESCRIPTION
## Summary

`async_step_ssdp` only aborted on a matching `unique_id`, which is keyed on the controller URL (see `async_step_user`). If a UniFi OS console's IP address changed (DHCP lease change, console swap), rediscovery could never match the stale `unique_id`, so the existing config entry kept polling/webhooking the old address until a human edited it manually. This implements the Gold-tier `discovery-update-info` quality-scale rule (#343).

## Changes

- `custom_components/unifi_alerts/config_flow.py`: `async_step_ssdp` now also matches on the UPnP serial number carried in the SSDP discovery payload (`ATTR_UPNP_SERIAL`), which stays stable across IP changes unlike the URL-keyed `unique_id`. When a match is found at a different address, the entry's `controller_url` and `unique_id` are refreshed in place via `async_update_entry` (mirroring the options flow's existing URL-change handling) instead of leaving it stale. New entries created via SSDP now persist their serial (`CONF_DEVICE_SERIAL`) so future rediscoveries can find them.
- `custom_components/unifi_alerts/const.py`: added `CONF_DEVICE_SERIAL`.
- `tests/unit/config_flow/test_discovery.py`: added coverage for the changed-IP update path, the same-URL no-op path, the no-match pass-through path, and serial threading into `_credentials` on setup.
- `tests/unit/config_flow/conftest.py`: `make_flow()` now mocks `hass.config_entries.async_entries`/`async_update_entry` (mirroring the existing options-flow fixture) since the new lookup helper calls them.
- `quality_scale.yaml`: `discovery-update-info` flipped from `todo` to `done`.
- `CHANGELOG.md`: added a `[Unreleased]` / `Fixed` entry.

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

**Note on local verification:** this sandbox only has Python 3.13 available (apt's `python3.14` package and `uv python install 3.14` both resolve through hosts blocked by this session's egress policy — `launchpadcontent.net` and `github.com` release assets). `homeassistant>=2026.7.1` itself now requires Python >=3.14.2, so `pytest` could not be run at all here. Per this repo's documented policy for this exact situation, I ran everything that doesn't require 3.14:
- `ruff check` / `ruff format --check` on the whole repo: pass.
- `scripts/validate_docs.py`, `scripts/check_translations.py`, `scripts/check_agentrc_refs.py`, `scripts/validate_hacs.py`: all pass.
- `mypy` fails to even start, but on pre-existing, unrelated files (`coordinator.py`/`models.py`, PEP 758 `except A, B:` syntax that only Python 3.14's parser understands) — not something this PR touches. CI (which runs on real 3.14) is authoritative for `mypy`/`pytest`.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #343` below)
- [ ] `make check` passes locally (blocked by lack of a Python 3.14 interpreter in this sandbox — see note above; `ruff`, doc/translation, and HACS checks all pass; CI should be treated as authoritative for `mypy`/`pytest`)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] PR title starts with a Conventional Commit prefix (`fix:`)
- [ ] PR has a label recognised by `.github/release.yml` (expected to be applied automatically by `pr-release-label.yml`)
- [x] `strings.json` and `translations/en.json` untouched (not needed for this change)
- [x] No blocking I/O introduced (all network/disk calls are `async`)

Closes #343

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJK2GkNsfirS7VpUdL5Jha)_