### PR TITLE
feat: use translation_key for min_severity selector options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **Breaking:** inbound webhook authentication now checks an `Authorization: Bearer <secret>` header in addition to the legacy `?token=<secret>` query parameter. The header is the preferred form: query strings are routinely captured by reverse-proxy and access logs, browser history, and screenshots of the config flow, so the secret has more exposure surface than a header. The `?token=` form is still accepted during a deprecation window (no earlier than v3.0.0) so existing UniFi Alarm Manager configurations keep working, but a `webhook_legacy_query_auth` repair issue nudges affected entries to migrate. The config and options flow "Webhook URLs" screens no longer embed the secret in the displayed URL; it is shown separately for use as the header value. ([#335])
 - `UniFiClient` is now fully stateless: the v2 system-log-probe cache and backoff (previously `_has_system_log`/`_probe_fail_count`/`_probe_backoff_until` on the client) moved to `UniFiAlertsCoordinator`, which already owns all other cross-poll state. Behaviour is unchanged; this is a refactor. ([#240])
 - The setup and polling errors surfaced to the user (`ConfigEntryAuthFailed`, `ConfigEntryNotReady`, `UpdateFailed`) now carry translation keys instead of hard-coded English messages, so they can be localised the same way repair issues already are. ([#341])
+- The minimum-severity selector's option labels ("No Filter", "Low", "Medium", "High", "Very High") are now defined in `translations/en.json` instead of being hard-coded English strings in the selector config, so translators can provide locale-specific versions. Stored values are unchanged. ([#353])
 
 ### Fixed
 
@@ -362,3 +363,4 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#341]: https://github.com/PHeonix25/unifi_alerts/issues/341
 [#343]: https://github.com/PHeonix25/unifi_alerts/issues/343
 [#344]: https://github.com/PHeonix25/unifi_alerts/issues/344
+[#353]: https://github.com/PHeonix25/unifi_alerts/issues/353

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -66,17 +66,19 @@ _LOGGER = logging.getLogger(__name__)
 
 # Minimum_Severity_Setting selector, shared by the Config_Flow and
 # Options_Flow categories steps.
-# Inline SelectOptionDict labels are used instead of a `selector.*`
-# translation-key section, matching the level of ceremony already used for
-# the password/API-key TextSelector fields above.
+# Bare value options with a `selector.min_severity.options` translation-key
+# section (strings.json / translations/en.json) so the display text is
+# localisable, matching the pattern used elsewhere in this integration.
 _MIN_SEVERITY_OPTIONS: Final[list[SelectOptionDict]] = [
-    SelectOptionDict(value=MIN_SEVERITY_NO_FILTER, label="No Filter"),
-    SelectOptionDict(value=SEVERITY_LOW, label="Low"),
-    SelectOptionDict(value=SEVERITY_MEDIUM, label="Medium"),
-    SelectOptionDict(value=SEVERITY_HIGH, label="High"),
-    SelectOptionDict(value=SEVERITY_VERY_HIGH, label="Very High"),
+    SelectOptionDict(value=MIN_SEVERITY_NO_FILTER),
+    SelectOptionDict(value=SEVERITY_LOW),
+    SelectOptionDict(value=SEVERITY_MEDIUM),
+    SelectOptionDict(value=SEVERITY_HIGH),
+    SelectOptionDict(value=SEVERITY_VERY_HIGH),
 ]
-_min_severity_selector = SelectSelector(SelectSelectorConfig(options=_MIN_SEVERITY_OPTIONS))
+_min_severity_selector = SelectSelector(
+    SelectSelectorConfig(options=_MIN_SEVERITY_OPTIONS, translation_key="min_severity")
+)
 
 
 def _create_auth_failed_issue(hass: Any, entry: Any) -> None:

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -18,7 +18,6 @@ from homeassistant.core import callback
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
-    SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
     TextSelector,
@@ -66,18 +65,28 @@ _LOGGER = logging.getLogger(__name__)
 
 # Minimum_Severity_Setting selector, shared by the Config_Flow and
 # Options_Flow categories steps.
-# Bare value options with a `selector.min_severity.options` translation-key
-# section (strings.json / translations/en.json) so the display text is
-# localisable, matching the pattern used elsewhere in this integration.
-_MIN_SEVERITY_OPTIONS: Final[list[SelectOptionDict]] = [
-    SelectOptionDict(value=MIN_SEVERITY_NO_FILTER),
-    SelectOptionDict(value=SEVERITY_LOW),
-    SelectOptionDict(value=SEVERITY_MEDIUM),
-    SelectOptionDict(value=SEVERITY_HIGH),
-    SelectOptionDict(value=SEVERITY_VERY_HIGH),
-]
+# hassfest requires translation keys to be lowercase slugs, so the widget
+# offers lowercase option values with a `selector.min_severity.options`
+# translation-key section (strings.json / translations/en.json) for the
+# display text, while the stored config value stays the upper-case
+# Severity_Level constant (e.g. "LOW") that the rest of the integration
+# compares against. `_MIN_SEVERITY_TO_WIDGET`/`_WIDGET_TO_MIN_SEVERITY`
+# convert between the two at the Config_Flow/Options_Flow boundary; nothing
+# outside this module ever sees the widget-only lowercase form.
+_MIN_SEVERITY_TO_WIDGET: Final[dict[str, str]] = {
+    MIN_SEVERITY_NO_FILTER: MIN_SEVERITY_NO_FILTER,
+    SEVERITY_LOW: "low",
+    SEVERITY_MEDIUM: "medium",
+    SEVERITY_HIGH: "high",
+    SEVERITY_VERY_HIGH: "very_high",
+}
+_WIDGET_TO_MIN_SEVERITY: Final[dict[str, str]] = {
+    widget: stored for stored, widget in _MIN_SEVERITY_TO_WIDGET.items()
+}
 _min_severity_selector = SelectSelector(
-    SelectSelectorConfig(options=_MIN_SEVERITY_OPTIONS, translation_key="min_severity")
+    SelectSelectorConfig(
+        options=list(_MIN_SEVERITY_TO_WIDGET.values()), translation_key="min_severity"
+    )
 )
 
 
@@ -290,7 +299,10 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             enabled = [cat for cat in ALL_CATEGORIES if user_input.get(f"cat_{cat}", False)]
             min_severity = {
-                cat: user_input.get(f"min_severity_{cat}", MIN_SEVERITY_NO_FILTER)
+                cat: _WIDGET_TO_MIN_SEVERITY.get(
+                    user_input.get(f"min_severity_{cat}", MIN_SEVERITY_NO_FILTER),
+                    MIN_SEVERITY_NO_FILTER,
+                )
                 for cat in ALL_CATEGORIES
             }
             if not enabled:
@@ -804,7 +816,10 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
         if user_input is not None:
             enabled = [cat for cat in ALL_CATEGORIES if user_input.get(f"cat_{cat}", False)]
             min_severity = {
-                cat: user_input.get(f"min_severity_{cat}", MIN_SEVERITY_NO_FILTER)
+                cat: _WIDGET_TO_MIN_SEVERITY.get(
+                    user_input.get(f"min_severity_{cat}", MIN_SEVERITY_NO_FILTER),
+                    MIN_SEVERITY_NO_FILTER,
+                )
                 for cat in ALL_CATEGORIES
             }
             if not enabled:
@@ -868,7 +883,10 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
             fields[
                 vol.Optional(
                     f"min_severity_{cat}",
-                    default=current_min_severity.get(cat, MIN_SEVERITY_NO_FILTER),
+                    default=_MIN_SEVERITY_TO_WIDGET.get(
+                        current_min_severity.get(cat, MIN_SEVERITY_NO_FILTER),
+                        MIN_SEVERITY_NO_FILTER,
+                    ),
                 )
             ] = _min_severity_selector
         fields[vol.Optional(CONF_POLL_INTERVAL, default=current_poll)] = vol.All(

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -285,5 +285,16 @@
         }
       }
     }
+  },
+  "selector": {
+    "min_severity": {
+      "options": {
+        "no_filter": "No Filter",
+        "LOW": "Low",
+        "MEDIUM": "Medium",
+        "HIGH": "High",
+        "VERY_HIGH": "Very High"
+      }
+    }
   }
 }

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -290,10 +290,10 @@
     "min_severity": {
       "options": {
         "no_filter": "No Filter",
-        "LOW": "Low",
-        "MEDIUM": "Medium",
-        "HIGH": "High",
-        "VERY_HIGH": "Very High"
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "very_high": "Very High"
       }
     }
   }

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -285,5 +285,16 @@
         }
       }
     }
+  },
+  "selector": {
+    "min_severity": {
+      "options": {
+        "no_filter": "No Filter",
+        "LOW": "Low",
+        "MEDIUM": "Medium",
+        "HIGH": "High",
+        "VERY_HIGH": "Very High"
+      }
+    }
   }
 }

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -290,10 +290,10 @@
     "min_severity": {
       "options": {
         "no_filter": "No Filter",
-        "LOW": "Low",
-        "MEDIUM": "Medium",
-        "HIGH": "High",
-        "VERY_HIGH": "Very High"
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High",
+        "very_high": "Very High"
       }
     }
   }

--- a/tests/unit/config_flow/test_min_severity.py
+++ b/tests/unit/config_flow/test_min_severity.py
@@ -14,7 +14,10 @@ from conftest import run_sync
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
-from custom_components.unifi_alerts.config_flow import UniFiAlertsOptionsFlow
+from custom_components.unifi_alerts.config_flow import (
+    _MIN_SEVERITY_TO_WIDGET,
+    UniFiAlertsOptionsFlow,
+)
 from custom_components.unifi_alerts.const import (
     ALL_CATEGORIES,
     CONF_ENABLED_CATEGORIES,
@@ -43,7 +46,12 @@ class TestConfigFlowMinSeverity:
     ) -> None:
         """Submitting the categories step with an arbitrary subset-to-setting
         mapping must store the submitted value for every category present in
-        the mapping, and No_Filter for every category omitted from it."""
+        the mapping, and No_Filter for every category omitted from it.
+
+        `cat_input` carries the widget's lowercase option value (what a real
+        submission sends); `submitted`/`expected` stay in terms of the stored
+        Severity_Level constant, since that is what `_entry_data` persists.
+        """
 
         async def _run() -> dict[str, str]:
             flow = make_flow()
@@ -59,7 +67,7 @@ class TestConfigFlowMinSeverity:
             # form with an error instead of proceeding to store _entry_data.
             cat_input: dict[str, object] = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
             for cat, value in submitted.items():
-                cat_input[f"min_severity_{cat}"] = value
+                cat_input[f"min_severity_{cat}"] = _MIN_SEVERITY_TO_WIDGET[value]
 
             await flow.async_step_categories(cat_input)
             return flow._entry_data[CONF_MIN_SEVERITY]
@@ -92,7 +100,13 @@ class TestOptionsFlowMinSeverity:
     ) -> None:
         """Submitting the options-flow categories step must persist exactly the
         submitted per-category mapping (omitted categories defaulting to
-        No_Filter), regardless of what was previously stored/pre-filled."""
+        No_Filter), regardless of what was previously stored/pre-filled.
+
+        `cat_input` carries the widget's lowercase option value (what a real
+        submission sends); `submitted`/`expected` stay in terms of the stored
+        Severity_Level constant, since that is what `_pending_options`
+        persists.
+        """
 
         async def _run() -> dict[str, str]:
             config_entry = MagicMock()
@@ -119,7 +133,7 @@ class TestOptionsFlowMinSeverity:
             # form with an error instead of storing _pending_options.
             cat_input: dict[str, object] = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
             for cat, value in submitted.items():
-                cat_input[f"min_severity_{cat}"] = value
+                cat_input[f"min_severity_{cat}"] = _MIN_SEVERITY_TO_WIDGET[value]
 
             await flow.async_step_categories(cat_input)
             return flow._pending_options[CONF_MIN_SEVERITY]
@@ -148,8 +162,8 @@ class TestOptionsFlowMinSeverity:
 
     def test_categories_step_prefill_resolves_stored_value(self) -> None:
         """An entry with an explicit stored `min_severity` value for a category
-        must pre-fill that category's selector with the stored value, while
-        other categories still default to No_Filter."""
+        must pre-fill that category's selector with the corresponding widget
+        option value, while other categories still default to No_Filter."""
         stored_cat = ALL_CATEGORIES[0]
         stored_value = next(v for v in MIN_SEVERITY_ORDER if v != MIN_SEVERITY_NO_FILTER)
 
@@ -164,7 +178,7 @@ class TestOptionsFlowMinSeverity:
         markers_by_name = {str(k): k for k in schema.schema}
 
         stored_marker = markers_by_name[f"min_severity_{stored_cat}"]
-        assert stored_marker.default() == stored_value
+        assert stored_marker.default() == _MIN_SEVERITY_TO_WIDGET[stored_value]
 
         for cat in ALL_CATEGORIES:
             if cat == stored_cat:

--- a/tests/unit/config_flow/test_setup.py
+++ b/tests/unit/config_flow/test_setup.py
@@ -536,16 +536,12 @@ class TestCategoriesStep:
     async def test_min_severity_selector_rendered_for_all_categories(self) -> None:
         """Each of the 7 categories must expose a min_severity_{cat} selector.
 
-        The selector must offer exactly the 5 expected options (No_Filter plus
-        the four Severity_Levels) and default to No_Filter.
+        The selector offers exactly the 5 expected widget option values
+        (lowercase slugs, since hassfest requires translation keys to be
+        lowercase) and defaults to No_Filter.
         """
-        from custom_components.unifi_alerts.severity import (
-            MIN_SEVERITY_NO_FILTER,
-            SEVERITY_HIGH,
-            SEVERITY_LOW,
-            SEVERITY_MEDIUM,
-            SEVERITY_VERY_HIGH,
-        )
+        from custom_components.unifi_alerts.config_flow import _MIN_SEVERITY_TO_WIDGET
+        from custom_components.unifi_alerts.severity import MIN_SEVERITY_NO_FILTER
 
         flow = make_flow()
         flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
@@ -555,13 +551,7 @@ class TestCategoriesStep:
         call_kwargs = flow.async_show_form.call_args.kwargs
         schema = call_kwargs["data_schema"]
 
-        expected_option_values = {
-            MIN_SEVERITY_NO_FILTER,
-            SEVERITY_LOW,
-            SEVERITY_MEDIUM,
-            SEVERITY_HIGH,
-            SEVERITY_VERY_HIGH,
-        }
+        expected_option_values = set(_MIN_SEVERITY_TO_WIDGET.values())
 
         markers_by_name = {str(k): k for k in schema.schema}
         assert len(ALL_CATEGORIES) == 7
@@ -573,7 +563,7 @@ class TestCategoriesStep:
             assert marker.default() == MIN_SEVERITY_NO_FILTER
 
             selector = schema.schema[marker]
-            option_values = {opt["value"] for opt in selector.config["options"]}
+            option_values = set(selector.config["options"])
             assert option_values == expected_option_values
 
 


### PR DESCRIPTION
## Summary

Stops hardcoding the English `SelectSelector` option labels for the minimum-severity setting, moving the display text into HA's translation system.

## Changes

- `custom_components/unifi_alerts/config_flow.py`: `_min_severity_selector`'s `SelectSelectorConfig` now uses `translation_key="min_severity"` with a plain `list[str]` of lowercase option values (`no_filter`/`low`/`medium`/`high`/`very_high`), since hassfest requires translation keys to be lowercase slugs and this HA version's `SelectSelectorConfig` schema requires `SelectOptionDict.label` at runtime (a bare-value dict form isn't accepted). `_MIN_SEVERITY_TO_WIDGET`/`_WIDGET_TO_MIN_SEVERITY` convert between the widget's lowercase form and the stored upper-case `Severity_Level` constant at the Config_Flow/Options_Flow boundary. **Stored config values (`no_filter`/`LOW`/`MEDIUM`/`HIGH`/`VERY_HIGH`) are unchanged** — nothing outside `config_flow.py` sees the widget-only lowercase form.
- `custom_components/unifi_alerts/strings.json` and `custom_components/unifi_alerts/translations/en.json`: added the matching `selector.min_severity.options` block (lowercase keys), kept byte-identical.
- `CHANGELOG.md`: added an `[Unreleased]` bullet.
- `tests/unit/config_flow/test_min_severity.py` and `test_setup.py`: updated for the widget/stored-value split — submissions now go through the widget's lowercase value and are asserted against the stored constant on the other side.

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

## Checklist

- [x] Linked the issue this PR resolves (`Closes #353` in the description)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] PR title starts with a Conventional Commit prefix (`feat:`)
- [x] `strings.json` and `translations/en.json` are still identical
- [x] `make check` passes — CI is green (lint, mypy, hassfest, HACS pre-flight, tests on latest and minimum HA). Local `make check` couldn't be fully run in the dev sandbox (no Python 3.14 available there), but was validated against a scratch copy with the unrelated pre-existing PEP 758 syntax patched, plus this PR's own CI run.

Closes #353


---
_Generated by [Claude Code](https://claude.ai/code/session_01LMYjcE4miRPwoAhEKx3pev)_