### PR TITLE
fix: disabled entities exemption documented

### DIFF
--- a/quality_scale.yaml
+++ b/quality_scale.yaml
@@ -235,11 +235,12 @@ rules:
       have no device class because none fits an alert counter; they use
       SensorStateClass.MEASUREMENT instead (see sensor.py inline comment).
   entity-disabled-by-default:
-    status: todo
+    status: exempt
     comment: |
-      No entity sets entity_registry_enabled_default = False. Ambiguous
-      whether this is actually a gap, since users already opt into
-      categories at config time. Filed as #345 for a maintainer decision.
+      Every entity is user-scoped and essential. Categories are opted into
+      during the config flow, so nothing is auto-discovered noise, and the
+      per-category diagnostic entities (last-message, webhook-health) are
+      needed for setup and troubleshooting rather than being verbose clutter.
   entity-translations:
     status: done
     comment: |


### PR DESCRIPTION
## Summary

Updates the quality-scale to document the exemption for the "entities should be disabled" rule. As all of our entities are opt-in, the diagnostic sensors are required for confirming appropriate configuration.

## Changes
- Updated the quality-scale to document the exemption for the "entities should be disabled" rule.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #NN` in the description), if one exists
- [x] `make check` passes locally
- [ ] `CHANGELOG.md` `[Unreleased]` updated (user-visible changes only; skip for internal/ci/docs)
- [x] PR title starts with a Conventional Commit prefix (`feat:`, `fix:`, `docs:`, `ci:`, `tests:`, `security:`, `chore:`, `refactor:`)
- [x] PR has a label recognised by `.github/release.yml` (applied automatically for CC-prefixed titles via pr-labeler)
- [ ] `strings.json` and `translations/en.json` are still identical (if either was touched)
- [ ] New category fully registered: `const.py`, `strings.json`, `translations/en.json` (if adding a category)
- [ ] No blocking I/O introduced (all network/disk calls are `async`)

Closes #345 