### PR TITLE
docs: Add IDS>10 example

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -76,6 +76,44 @@ automation:
 
 > **Tip:** Replace `event.unifi_alerts_security_threat_ids_detected_event` with any per-category event entity (e.g. `event.unifi_alerts_network_device_offline_online_event`, `event.unifi_alerts_power_poe_power_loss_event`). Swap `persistent_notification.create` for `notify.mobile_app_your_phone` or any other notify action.
 
+Some alerts are transient and may resolve quickly. If you want to be notified only when the open count is above a threshold for a period of time, use a numeric state trigger on the per-category open-count sensor instead.
+
+```yaml
+automation:
+  - alias: "Notify IDS count above 10"
+    description: "Send me a message if the IDS open count is above 10 for 10 minutes"
+    triggers:
+      - trigger: numeric_state
+        entity_id:
+          - sensor.unifi_alerts_security_threat_ids_detected_open_count
+        for:
+          hours: 0
+          minutes: 10
+          seconds: 0
+        above: 10
+    conditions: []
+    actions:
+      - delay:
+          hours: 0
+          minutes: 10
+          seconds: 0
+          milliseconds: 0
+      - if:
+          - condition: numeric_state
+            entity_id: sensor.unifi_alerts_security_threat_ids_detected_open_count
+            above: 10
+        then:
+          - action: notify.mobile_app
+            data:
+              message: >-
+                IDS open count is above 10! 
+
+                Current value: {{
+                states("sensor.unifi_alerts_security_threat_ids_detected_open_count")
+                }}
+              title: We're under attack!
+```
+
 ---
 
 ## Automation caveats


### PR DESCRIPTION
This pull request adds an example to the documentation demonstrating how to notify users when a specific alert count remains above a threshold for a period of time. The example uses a numeric state trigger and a delayed notification to ensure alerts are only sent if the condition persists.

## Changes

**Documentation improvements:**

* Added a YAML example to `docs/EXAMPLES.md` showing how to create an automation that notifies the user if the `sensor.unifi_alerts_security_threat_ids_detected_open_count` remains above 10 for 10 minutes, including a delayed action and a conditional check before sending the notification.## Summary

## How to test

<!-- Steps a reviewer can follow to verify the change works. Include relevant `make` commands. -->

```bash
make check   # lint + typecheck + validate + all tests
```

## Checklist

- [ ] Linked the issue this PR resolves (`Closes #NN` in the description), if one exists
- [x] `make check` passes locally
- [ ] `CHANGELOG.md` `[Unreleased]` updated (user-visible changes only; skip for internal/ci/docs)
- [x] PR title starts with a Conventional Commit prefix (`feat:`, `fix:`, `docs:`, `ci:`, `tests:`, `security:`, `chore:`, `refactor:`)
- [x] PR has a label recognised by `.github/release.yml` (applied automatically for CC-prefixed titles via pr-labeler)
- [ ] `strings.json` and `translations/en.json` are still identical (if either was touched)
- [ ] New category fully registered: `const.py`, `strings.json`, `translations/en.json` (if adding a category)
- [ ] No blocking I/O introduced (all network/disk calls are `async`)
