### PR TITLE
feat: surface the Authorization header as its own block on the Webhook URLs step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `UniFiClient` is now fully stateless: the v2 system-log-probe cache and backoff (previously `_has_system_log`/`_probe_fail_count`/`_probe_backoff_until` on the client) moved to `UniFiAlertsCoordinator`, which already owns all other cross-poll state. Behaviour is unchanged; this is a refactor. ([#240])
 - The setup and polling errors surfaced to the user (`ConfigEntryAuthFailed`, `ConfigEntryNotReady`, `UpdateFailed`) now carry translation keys instead of hard-coded English messages, so they can be localised the same way repair issues already are. ([#341])
 - The minimum-severity selector's option labels ("No Filter", "Low", "Medium", "High", "Very High") are now defined in `translations/en.json` instead of being hard-coded English strings in the selector config, so translators can provide locale-specific versions. Stored values are unchanged. ([#353])
+- The "Webhook URLs" finish step of the config and options flows now shows the `Authorization` header key and `Bearer <secret>` header value as their own labelled block above the webhook URLs, instead of burying the header value inside the step description, so the credentials are easier to copy before pasting the URLs into Alarm Manager. ([#368])
 
 ### Fixed
 
@@ -364,3 +365,4 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#343]: https://github.com/PHeonix25/unifi_alerts/issues/343
 [#344]: https://github.com/PHeonix25/unifi_alerts/issues/344
 [#353]: https://github.com/PHeonix25/unifi_alerts/issues/353
+[#368]: https://github.com/PHeonix25/unifi_alerts/issues/368

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -38,7 +38,7 @@
       },
       "finish": {
         "title": "Webhook URLs",
-        "description": "Copy each webhook URL into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit. In the alarm's Advanced Settings, add a custom header named `Authorization` with the value `Bearer {webhook_secret}` — this is the preferred authentication method. If your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead; this legacy method still works but is deprecated. You can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough.",
+        "description": "**Header key:** `Authorization`\n\n**Header value:** `Bearer {webhook_secret}`\n\nAdd this custom header in each alarm's Advanced Settings in UniFi Alarm Manager first; it is the preferred authentication method. Then copy each webhook URL below into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit. If your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead; this legacy method still works but is deprecated. You can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough.",
         "data": {
           "webhook_url_network_device": "Network: Device offline/online webhook URL",
           "webhook_url_network_wan": "Network: WAN offline/latency webhook URL",
@@ -273,7 +273,7 @@
       },
       "finish": {
         "title": "Webhook URLs",
-        "description": "Copy each webhook URL into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit. In the alarm's Advanced Settings, add a custom header named `Authorization` with the value `Bearer {webhook_secret}` — this is the preferred authentication method. If your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead; this legacy method still works but is deprecated. You can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough.",
+        "description": "**Header key:** `Authorization`\n\n**Header value:** `Bearer {webhook_secret}`\n\nAdd this custom header in each alarm's Advanced Settings in UniFi Alarm Manager first; it is the preferred authentication method. Then copy each webhook URL below into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit. If your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead; this legacy method still works but is deprecated. You can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough.",
         "data": {
           "webhook_url_network_device": "Network: Device offline/online webhook URL",
           "webhook_url_network_wan": "Network: WAN offline/latency webhook URL",

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -38,7 +38,7 @@
       },
       "finish": {
         "title": "Webhook URLs",
-        "description": "Copy each webhook URL into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit. In the alarm's Advanced Settings, add a custom header named `Authorization` with the value `Bearer {webhook_secret}` — this is the preferred authentication method. If your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead; this legacy method still works but is deprecated. You can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough.",
+        "description": "**Header key:** `Authorization`\n\n**Header value:** `Bearer {webhook_secret}`\n\nAdd this custom header in each alarm's Advanced Settings in UniFi Alarm Manager first; it is the preferred authentication method. Then copy each webhook URL below into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit. If your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead; this legacy method still works but is deprecated. You can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough.",
         "data": {
           "webhook_url_network_device": "Network: Device offline/online webhook URL",
           "webhook_url_network_wan": "Network: WAN offline/latency webhook URL",
@@ -273,7 +273,7 @@
       },
       "finish": {
         "title": "Webhook URLs",
-        "description": "Copy each webhook URL into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit. In the alarm's Advanced Settings, add a custom header named `Authorization` with the value `Bearer {webhook_secret}` — this is the preferred authentication method. If your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead; this legacy method still works but is deprecated. You can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough.",
+        "description": "**Header key:** `Authorization`\n\n**Header value:** `Bearer {webhook_secret}`\n\nAdd this custom header in each alarm's Advanced Settings in UniFi Alarm Manager first; it is the preferred authentication method. Then copy each webhook URL below into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit. If your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead; this legacy method still works but is deprecated. You can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough.",
         "data": {
           "webhook_url_network_device": "Network: Device offline/online webhook URL",
           "webhook_url_network_wan": "Network: WAN offline/latency webhook URL",


### PR DESCRIPTION
## Summary

On the config-flow and options-flow "Webhook URLs" finish step, the `Authorization: Bearer <secret>` header value was buried mid-paragraph in the step description, so users who skim missed it. This breaks the header key and value out into their own labelled block above the webhook URL fields, so they are copy-paste obvious.

## Changes

- `custom_components/unifi_alerts/strings.json`: rewrote the `finish` step `description` for both the config flow and options flow to lead with a `**Header key:** \`Authorization\`` / `**Header value:** \`Bearer {webhook_secret}\`` block, before the existing instructions for pasting webhook URLs and the legacy `?token=` fallback. `webhook_secret` was already flowing into `description_placeholders` in `config_flow.py`; no code change was needed.
- `custom_components/unifi_alerts/translations/en.json`: kept byte-identical to `strings.json`.
- `CHANGELOG.md`: added an `[Unreleased]` bullet under "Changed".

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

Python 3.14 was not available in the sandbox this PR was prepared in (only 3.12/3.13), so `make check` could not be run locally. No code files changed, only `strings.json`/`translations/en.json`/`CHANGELOG.md`; ran the pure-stdlib doc-check scripts directly (`validate_docs.py`, `check_translations.py`, `check_agentrc_refs.py`) plus JSON validation, all passing. CI is authoritative for the rest.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #368` in the description)
- [ ] `make check` passes locally (not runnable in this sandbox, see note above; CI authoritative)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] PR title starts with a Conventional Commit prefix (`feat:`)
- [ ] PR has a label recognised by `.github/release.yml` (expected to apply automatically via `pr-release-label.yml`)
- [x] `strings.json` and `translations/en.json` are still identical
- [ ] New category fully registered (n/a, no new category)
- [x] No blocking I/O introduced

Closes #368


---
_Generated by [Claude Code](https://claude.ai/code/session_01FathSVNUKnicPJFZNhaW1b)_