### PR TITLE
release: bump version to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-07-24
+
 ### Added
 
 - Added a dedicated reconfigure flow, so the controller URL, API key, and SSL verification can be updated through Home Assistant's "Reconfigure" affordance without deleting and re-adding the entry. The existing "Configure" options flow is unchanged. ([#344])
@@ -277,7 +279,8 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 - UCG-Ultra OS detection: two-stage fallback probe added.
 - Config-flow API-key field guidance reworded to be firmware-version agnostic.
 
-[Unreleased]: https://github.com/PHeonix25/unifi_alerts/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/PHeonix25/unifi_alerts/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v2.0.0
 [1.9.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.9.0
 [1.8.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.8.0
 [1.7.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.7.0

--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -28,5 +28,5 @@
       "modelDescription": "UniFi Dream Machine Pro Max"
     }
   ],
-  "version": "2.0.0-pre2"
+  "version": "2.0.0"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -2,6 +2,10 @@
 
 Dated record of completed work. Newest first. Format per entry: category, short description, PR or commit reference, short why.
 
+## 2026-07-24
+
+- **release**: v2.0.0 stable. Promotes the "HACS default catalogue" cycle to `main`. No further changes landed on `dev` since `v2.0.0-pre2`, so this is a straight version promotion; every pre1/pre2 item ships as-is. The cycle's umbrella issue (#143) closed the same day: repository topics set, the brand icon self-hosted under `custom_components/unifi_alerts/brand/` (replacing the retired `home-assistant/brands` submission path), and a PR opened against `hacs/default`.
+
 ## 2026-07-23
 
 - **release**: v2.0.0-pre2 tagged. Second v2.0.0 checkpoint: per-category severity filtering for noisy categories lands, the HA quality-scale gaps found in the pre1 audit are closed (reconfigure flow, translated exceptions, service-call validation, SSDP host updates, localised selector labels), and the final config step now spells out the `Authorization` header for the new webhook auth. Everything bar the HACS default-catalogue submission (#143) is on `dev`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,18 +2,9 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-07-06):** v1.9.0 (Localisation and Scale) shipped stable on 2026-07-06. The next cycle (v1.10.0) is the path forward towards v2.0.0 (HACS default catalogue). Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
+> **Status (2026-07-24):** v2.0.0 (HACS default catalogue) shipped stable on 2026-07-24; the umbrella submission issue (#143) is closed and a PR is open against `hacs/default`. The next cycle (v2.1.0) is already seeded with review follow-ups from the severity-filtering feature (#331): UI copy, a diagnostic trail for filtered alerts, and several `severity.py` cleanups. Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
 
 > **Branching model:** see `CLAUDE.md § Branching and releasing`.
-
----
-
-## v2.0.0: HACS default catalogue
-
-Prerequisites for submitting to <https://github.com/hacs/default>.
-
-- [x] All `v2.0-gate` issues closed (raw-payload persistence, retention and data-handling statement, Alarm Manager onboarding docs, and localisation maturity).
-- [ ] Submit PR to `hacs/default`.
 
 ---
 


### PR DESCRIPTION
## Summary

Promotes the v2.0.0 "HACS default catalogue" cycle from `2.0.0-pre2` to stable `2.0.0`. No merges landed on `dev` since `v2.0.0-pre2` (`git log v2.0.0-pre2..HEAD --oneline` is empty), so this is a straight version promotion.

Supersedes #372, which was opened from a branch named `claude/v2-release-history-docs-uavuy2` and failed the `history-guard` check (requires a `claude/bump-*` head branch). Same commit, moved to the correctly-named branch.

## Changes

- `custom_components/unifi_alerts/manifest.json`: `version` `2.0.0-pre2` -> `2.0.0` (via `scripts/bump_version.py --stable`).
- `CHANGELOG.md`: `[Unreleased]` renamed to `[2.0.0] - 2026-07-24`, with a fresh empty `[Unreleased]` inserted above and the `[2.0.0]` link reference added.
- `docs/HISTORY.md`: new `## 2026-07-24` block. Since there were no merges to summarise, it records the promotion itself and notes that the cycle's umbrella HACS submission issue (#143) closed the same day (repo topics set, brand icon self-hosted under `custom_components/unifi_alerts/brand/`, PR opened against `hacs/default`).
- `docs/ROADMAP.md`: drops the completed `v2.0.0` section entirely and updates the status line to the 2026-07-24 ship date. Names `v2.1.0` as the next cycle, since GitHub's `v2.1.0` milestone is already seeded with the 9 open review follow-ups from #331 (severity-filtering UI copy, a diagnostic trail for filtered alerts, and several `severity.py` cleanups).

## How to test

```bash
python3 scripts/validate_hacs.py       # manifest/hacs.json pre-flight - passing
python3 scripts/validate_docs.py       # prose linter + HISTORY h2 format - passing
python3 scripts/check_translations.py  # strings.json <-> translations/en.json - passing
python3 scripts/check_agentrc_refs.py  # agentrc.eval.json references - passing
```

`make typecheck` / `make test` could not be run in this session's sandbox: it only has Python up to 3.13 available, and `coordinator.py`/`models.py`/`unifi_auth.py` use PEP 758's unparenthesized multi-exception `except` syntax (correct for this project's Python 3.14 floor, per `CLAUDE.md`'s explicit warning about this exact false positive). No source files were touched by this PR beyond the manifest version bump, so CI (which runs on Python 3.14) is the authority here.

## Checklist

- [x] `make check` passes locally (see note above: `typecheck`/`test` legs deferred to CI due to sandbox Python version; all other legs pass)
- [x] `CHANGELOG.md` `[Unreleased]` promoted to `[2.0.0]`
- [x] PR title starts with a Conventional Commit prefix (`release:`, matching prior bump PRs, e.g. #306)
- [ ] PR has a label recognised by `.github/release.yml` - `release:` isn't auto-mapped by `pr-release-label.yml`; applying `documentation` by hand (matches the `v2.0.0-pre2` bump PR, #371)
- [x] `strings.json` and `translations/en.json` untouched
- [x] No blocking I/O introduced (docs/version-only change)

## After merge

Tag the stable release:

```bash
git checkout dev && git pull origin dev
git tag v2.0.0 && git push origin v2.0.0
```

Then open the `dev` -> `main` PR to promote the release (merge-commit only, never squash, per `docs/RELEASING.md`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEibaqUEYdW4dfQtiRcqTe)_