### PR TITLE
fix: render the min_severity selector as a dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The per-category minimum-severity selector on the "Configure Alert Categories" step (config flow) and "Update Alert Categories" step (options flow) now renders as a dropdown with translated labels, instead of an untranslated radio-button list showing raw keys (e.g. `min_severity_network_wan`, `no_filter`). The selector was missing an explicit dropdown render mode. ([#375])
+
 ## [2.0.0] - 2026-07-24
 
 ### Added
@@ -369,3 +373,4 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#344]: https://github.com/PHeonix25/unifi_alerts/issues/344
 [#353]: https://github.com/PHeonix25/unifi_alerts/issues/353
 [#368]: https://github.com/PHeonix25/unifi_alerts/issues/368
+[#375]: https://github.com/PHeonix25/unifi_alerts/issues/375

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
+    SelectSelectorMode,
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
@@ -85,7 +86,9 @@ _WIDGET_TO_MIN_SEVERITY: Final[dict[str, str]] = {
 }
 _min_severity_selector = SelectSelector(
     SelectSelectorConfig(
-        options=list(_MIN_SEVERITY_TO_WIDGET.values()), translation_key="min_severity"
+        options=list(_MIN_SEVERITY_TO_WIDGET.values()),
+        translation_key="min_severity",
+        mode=SelectSelectorMode.DROPDOWN,
     )
 )
 

--- a/tests/unit/config_flow/test_setup.py
+++ b/tests/unit/config_flow/test_setup.py
@@ -540,6 +540,8 @@ class TestCategoriesStep:
         (lowercase slugs, since hassfest requires translation keys to be
         lowercase) and defaults to No_Filter.
         """
+        from homeassistant.helpers.selector import SelectSelectorMode
+
         from custom_components.unifi_alerts.config_flow import _MIN_SEVERITY_TO_WIDGET
         from custom_components.unifi_alerts.severity import MIN_SEVERITY_NO_FILTER
 
@@ -565,6 +567,10 @@ class TestCategoriesStep:
             selector = schema.schema[marker]
             option_values = set(selector.config["options"])
             assert option_values == expected_option_values
+            # Regression test for #375: without an explicit dropdown mode, HA's
+            # frontend defaults a <=6-option SelectSelector to a radio-button
+            # list instead of a dropdown.
+            assert selector.config["mode"] == SelectSelectorMode.DROPDOWN
 
 
 class TestFinishStep:


### PR DESCRIPTION
## Summary

Fixes the per-category minimum-severity selector on the "Configure Alert Categories" / "Update Alert Categories" step so it renders as a translated dropdown instead of an untranslated radio-button list.

## Changes

- `custom_components/unifi_alerts/config_flow.py`: added `mode=SelectSelectorMode.DROPDOWN` to `_min_severity_selector`'s `SelectSelectorConfig`. Without an explicit mode, Home Assistant's frontend (`ha-selector-select`) defaults a `SelectSelector` with ≤6 options to a radio-button list instead of a dropdown; this selector has 5 options (`no_filter`/`LOW`/`MEDIUM`/`HIGH`/`VERY_HIGH`). The list-mode render path was also showing the raw schema key (`min_severity_network_wan`) and raw option slugs instead of the translated text from `strings.json`/`translations/en.json`, even though those translation keys were already correct.
- `tests/unit/config_flow/test_setup.py`: extended `test_min_severity_selector_rendered_for_all_categories` to assert `selector.config["mode"] == SelectSelectorMode.DROPDOWN`, as a regression test.
- `CHANGELOG.md`: added a `[Unreleased]` → `Fixed` entry.

## Context

This is a regression in v2.0.0 (shipped in PR #373), introduced when the severity-filtering feature (#331) switched the selector from hardcoded English labels to a `translation_key`-based selector (#353). The implementation research recorded on #353 explicitly recommended `mode=SelectSelectorMode.DROPDOWN` as part of that change, but it was dropped when the code was written.

Closes #375

## How to test

Local verification of `pytest`/`mypy` was not possible in this sandbox: this repo's runtime code (`models.py`) uses Python 3.14-only PEP 758 `except A, B:` syntax, and this environment only has Python 3.13 available, which cannot even parse the package. `ruff check` / `ruff format --check` (which target 3.14 and don't need to execute the code) pass clean on both changed files. CI is authoritative for `make check`.

1. Install the branch in a Home Assistant dev instance.
2. Start the config flow and reach "Configure Alert Categories" (or open Configure → "Update Alert Categories" on an existing entry).
3. Confirm each `min_severity_*` field renders as a dropdown with a translated label ("Network: WAN offline/latency - Minimum severity") and translated option text ("No Filter", "Low", "Medium", "High", "Very High"), not a raw-key radio list.

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

## Checklist

- [x] Linked the issue this PR resolves (`Closes #375` above)
- [ ] `make check` passes locally (not runnable in this sandbox, see "How to test"; CI is authoritative)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] PR title starts with a Conventional Commit prefix (`fix:`)
- [ ] PR has a label recognised by `.github/release.yml` (expected to be applied automatically by `pr-release-label.yml`)
- [x] `strings.json` and `translations/en.json` untouched (no translation content changed, only selector rendering mode)
- [ ] New category fully registered (not applicable, no new category added)
- [x] No blocking I/O introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_019VmkhgcFS3iF7YecjUJDfN)_