### PR TITLE
release: bump version to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-07-24
+
 ### Fixed
 
 - The per-category minimum-severity selector on the "Configure Alert Categories" step (config flow) and "Update Alert Categories" step (options flow) now renders as a dropdown with translated labels, instead of an untranslated radio-button list showing raw keys (e.g. `min_severity_network_wan`, `no_filter`). The selector was missing an explicit dropdown render mode. ([#375])
@@ -283,7 +285,8 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 - UCG-Ultra OS detection: two-stage fallback probe added.
 - Config-flow API-key field guidance reworded to be firmware-version agnostic.
 
-[Unreleased]: https://github.com/PHeonix25/unifi_alerts/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/PHeonix25/unifi_alerts/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v2.0.1
 [2.0.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v2.0.0
 [1.9.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.9.0
 [1.8.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.8.0

--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -28,5 +28,5 @@
       "modelDescription": "UniFi Dream Machine Pro Max"
     }
   ],
-  "version": "2.0.0"
+  "version": "2.0.1"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -4,7 +4,11 @@ Dated record of completed work. Newest first. Format per entry: category, short 
 
 ## 2026-07-24
 
+- **release**: v2.0.1 stable. Critical hotfix promoted straight to `main` as a patch release, shipping the single fix below.
+- **fix**: the per-category minimum-severity selector on the categories step now renders as a translated dropdown instead of an untranslated radio-button list; it was missing an explicit dropdown render mode, a regression introduced with the `translation_key` selector added for v2.0.0 ([#376]). Closes #375.
 - **release**: v2.0.0 stable. Promotes the "HACS default catalogue" cycle to `main`. No further changes landed on `dev` since `v2.0.0-pre2`, so this is a straight version promotion; every pre1/pre2 item ships as-is. The cycle's umbrella issue (#143) closed the same day: repository topics set, the brand icon self-hosted under `custom_components/unifi_alerts/brand/` (replacing the retired `home-assistant/brands` submission path), and a PR opened against `hacs/default`.
+
+[#376]: https://github.com/PHeonix25/unifi_alerts/pull/376
 
 ## 2026-07-23
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-07-24):** v2.0.0 (HACS default catalogue) shipped stable on 2026-07-24; the umbrella submission issue (#143) is closed and a PR is open against `hacs/default`. The next cycle (v2.1.0) is already seeded with review follow-ups from the severity-filtering feature (#331): UI copy, a diagnostic trail for filtered alerts, and several `severity.py` cleanups. Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
+> **Status (2026-07-24):** v2.0.0 (HACS default catalogue) shipped stable on 2026-07-24; the umbrella submission issue (#143) is closed and a PR is open against `hacs/default`. A same-day v2.0.1 patch release followed, fixing the min_severity selector rendering as an untranslated radio-button list instead of a dropdown (#375). The next cycle (v2.1.0) is already seeded with review follow-ups from the severity-filtering feature (#331): UI copy, a diagnostic trail for filtered alerts, and several `severity.py` cleanups. Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
 
 > **Branching model:** see `CLAUDE.md § Branching and releasing`.
 


### PR DESCRIPTION
## Summary

Version-bump PR for a critical hotfix patch release, `2.0.0` → `2.0.1`, per the "Patch releases are reserved for critical hotfixes" convention in `docs/RELEASING.md`.

## Changes

- `custom_components/unifi_alerts/manifest.json`: `version` `2.0.0` → `2.0.1`.
- `CHANGELOG.md`: promoted `[Unreleased]` to `[2.0.1] - 2026-07-24` (the dropdown-selector fix from #376), inserted a fresh empty `[Unreleased]`, and updated the compare/release link references.
- `docs/HISTORY.md`: added a `## 2026-07-24` block entry for the `v2.0.1` release and the underlying fix (PR #376, closes #375), above the existing same-day `v2.0.0` entry.
- `docs/ROADMAP.md`: updated the status line to mention the same-day patch release.

## Context

`bump_version.py` only supports `--pre`/`--stable`/`--next-cycle`, all of which require the manifest to already be at (or promoting from) a `-preN` version. The current version was already stable `2.0.0` (no pre-release in flight), so a direct patch bump for this hotfix isn't a mode the script covers. I replicated its `--stable` logic by hand (manifest + `CHANGELOG.md` rewrite) rather than extend the script for a one-off, since this repo treats patch releases as a deliberately manual, infrequent path.

Only one PR (`#376`) has merged to `dev` since the `v2.0.0` tag, so the `docs/HISTORY.md` block covers just that one item.

## How to test

`scripts/validate_hacs.py` passes (run manually, see note below).

Local `make check`/`make doc-check` were not runnable in this sandbox: this repo's runtime code (`models.py`) uses Python 3.14-only PEP 758 `except A, B:` syntax, and only Python 3.13 is available here, which can't parse the package at all. CI is authoritative.

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

## Checklist

- [x] Linked the issue this PR resolves (fix already merged via #376, closes #375)
- [ ] `make check` passes locally (not runnable in this sandbox; CI is authoritative)
- [x] `CHANGELOG.md` `[Unreleased]` updated (promoted to `[2.0.1]`)
- [x] PR title starts with a Conventional Commit prefix (`release:` — not one of the auto-mapped prefixes, so labeling by hand, see below)
- [ ] PR has a label recognised by `.github/release.yml` (applying `chore` by hand, since `release:` isn't auto-mapped by `pr-release-label.yml`)
- [x] `strings.json` and `translations/en.json` untouched
- [x] No blocking I/O introduced

## Next steps

After this merges to `dev`, open a `dev` → `main` PR (merge commit, not squash) to promote the stable version. Once that merges, the tag command is:

```bash
git checkout main && git pull origin main
git tag v2.0.1 && git push origin v2.0.1
```


---
_Generated by [Claude Code](https://claude.ai/code/session_019VmkhgcFS3iF7YecjUJDfN)_