### PR TITLE
release: promote v2.0.1 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-07-24
+
 ### Fixed
 
 - The per-category minimum-severity selector on the "Configure Alert Categories" step (config flow) and "Update Alert Categories" step (options flow) now renders as a dropdown with translated labels, instead of an untranslated radio-button list showing raw keys (e.g. `min_severity_network_wan`, `no_filter`). The selector was missing an explicit dropdown render mode. ([#375])
@@ -283,7 +285,8 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 - UCG-Ultra OS detection: two-stage fallback probe added.
 - Config-flow API-key field guidance reworded to be firmware-version agnostic.
 
-[Unreleased]: https://github.com/PHeonix25/unifi_alerts/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/PHeonix25/unifi_alerts/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v2.0.1
 [2.0.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v2.0.0
 [1.9.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.9.0
 [1.8.0]: https://github.com/PHeonix25/unifi_alerts/releases/tag/v1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- The per-category minimum-severity selector on the "Configure Alert Categories" step (config flow) and "Update Alert Categories" step (options flow) now renders as a dropdown with translated labels, instead of an untranslated radio-button list showing raw keys (e.g. `min_severity_network_wan`, `no_filter`). The selector was missing an explicit dropdown render mode. ([#375])
+
 ## [2.0.0] - 2026-07-24
 
 ### Added
@@ -369,3 +373,4 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#344]: https://github.com/PHeonix25/unifi_alerts/issues/344
 [#353]: https://github.com/PHeonix25/unifi_alerts/issues/353
 [#368]: https://github.com/PHeonix25/unifi_alerts/issues/368
+[#375]: https://github.com/PHeonix25/unifi_alerts/issues/375

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
+    SelectSelectorMode,
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
@@ -85,7 +86,9 @@ _WIDGET_TO_MIN_SEVERITY: Final[dict[str, str]] = {
 }
 _min_severity_selector = SelectSelector(
     SelectSelectorConfig(
-        options=list(_MIN_SEVERITY_TO_WIDGET.values()), translation_key="min_severity"
+        options=list(_MIN_SEVERITY_TO_WIDGET.values()),
+        translation_key="min_severity",
+        mode=SelectSelectorMode.DROPDOWN,
     )
 )
 

--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -28,5 +28,5 @@
       "modelDescription": "UniFi Dream Machine Pro Max"
     }
   ],
-  "version": "2.0.0"
+  "version": "2.0.1"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -4,7 +4,11 @@ Dated record of completed work. Newest first. Format per entry: category, short 
 
 ## 2026-07-24
 
+- **release**: v2.0.1 stable. Critical hotfix promoted straight to `main` as a patch release, shipping the single fix below.
+- **fix**: the per-category minimum-severity selector on the categories step now renders as a translated dropdown instead of an untranslated radio-button list; it was missing an explicit dropdown render mode, a regression introduced with the `translation_key` selector added for v2.0.0 ([#376]). Closes #375.
 - **release**: v2.0.0 stable. Promotes the "HACS default catalogue" cycle to `main`. No further changes landed on `dev` since `v2.0.0-pre2`, so this is a straight version promotion; every pre1/pre2 item ships as-is. The cycle's umbrella issue (#143) closed the same day: repository topics set, the brand icon self-hosted under `custom_components/unifi_alerts/brand/` (replacing the retired `home-assistant/brands` submission path), and a PR opened against `hacs/default`.
+
+[#376]: https://github.com/PHeonix25/unifi_alerts/pull/376
 
 ## 2026-07-23
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-07-24):** v2.0.0 (HACS default catalogue) shipped stable on 2026-07-24; the umbrella submission issue (#143) is closed and a PR is open against `hacs/default`. The next cycle (v2.1.0) is already seeded with review follow-ups from the severity-filtering feature (#331): UI copy, a diagnostic trail for filtered alerts, and several `severity.py` cleanups. Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
+> **Status (2026-07-24):** v2.0.0 (HACS default catalogue) shipped stable on 2026-07-24; the umbrella submission issue (#143) is closed and a PR is open against `hacs/default`. A same-day v2.0.1 patch release followed, fixing the min_severity selector rendering as an untranslated radio-button list instead of a dropdown (#375). The next cycle (v2.1.0) is already seeded with review follow-ups from the severity-filtering feature (#331): UI copy, a diagnostic trail for filtered alerts, and several `severity.py` cleanups. Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
 
 > **Branching model:** see `CLAUDE.md § Branching and releasing`.
 

--- a/tests/unit/config_flow/test_setup.py
+++ b/tests/unit/config_flow/test_setup.py
@@ -540,6 +540,8 @@ class TestCategoriesStep:
         (lowercase slugs, since hassfest requires translation keys to be
         lowercase) and defaults to No_Filter.
         """
+        from homeassistant.helpers.selector import SelectSelectorMode
+
         from custom_components.unifi_alerts.config_flow import _MIN_SEVERITY_TO_WIDGET
         from custom_components.unifi_alerts.severity import MIN_SEVERITY_NO_FILTER
 
@@ -565,6 +567,10 @@ class TestCategoriesStep:
             selector = schema.schema[marker]
             option_values = set(selector.config["options"])
             assert option_values == expected_option_values
+            # Regression test for #375: without an explicit dropdown mode, HA's
+            # frontend defaults a <=6-option SelectSelector to a radio-button
+            # list instead of a dropdown.
+            assert selector.config["mode"] == SelectSelectorMode.DROPDOWN
 
 
 class TestFinishStep:


### PR DESCRIPTION
## Summary

Promotes the `v2.0.1` critical hotfix from `dev` to `main`.

## Changes

Two PRs merged to `dev` since the `v2.0.0` tag:

- #376 — fix: the per-category minimum-severity selector on the categories step now renders as a translated dropdown instead of an untranslated radio-button list. It was missing an explicit dropdown render mode, a regression from the `translation_key` selector added for v2.0.0. Closes #375.
- #377 — release: bump version to 2.0.1 (`manifest.json`, `CHANGELOG.md`, `docs/HISTORY.md`, `docs/ROADMAP.md`).

## How to test

```bash
python3 scripts/validate_hacs.py  # manifest/hacs.json pre-flight
make check                        # full validation suite (CI)
```

## Checklist

- [x] `CHANGELOG.md` promoted to `[2.0.1]`
- [x] `docs/HISTORY.md` has the `2026-07-24` block for this release
- [x] `strings.json` / `translations/en.json` untouched
- [ ] **Merge with "Create a merge commit" — never "Squash and merge"** (per `docs/RELEASING.md`; the `main` ruleset should already enforce this)

## After merge

Tag the stable release:

```bash
git checkout main && git pull origin main
git tag v2.0.1 && git push origin v2.0.1
```

GitHub Actions creates the stable release automatically.


---
_Generated by [Claude Code](https://claude.ai/code/session_019VmkhgcFS3iF7YecjUJDfN)_