### PR TITLE
docs: add v2.1.0/v2.2.0/v2.3.0 sections to ROADMAP

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,6 +8,26 @@ What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `
 
 ---
 
+## v2.1.0 - Severity follow-through and test coverage
+
+Finish the severity-filtering feature started in #331 and close the test gaps on the paths users depend on most. Adds the first way to verify a webhook setup without waiting for a real alert.
+
+Main threads: the #331 review follow-ups (UI copy, filtered-alert diagnostics, `severity.py` cleanups), coverage for entity actions, webhook edge cases and coordinator/service error handling, a send-test-alert button, and the config flow accessibility blockers.
+
+## v2.2.0 - Structural simplification
+
+Reduce surface area, internal and user-facing. Splits the coordinator's persistence and filtering responsibilities into their own modules, and cuts the entity count and first-run configuration load that overwhelm new users.
+
+Main threads: coordinator extraction, fewer diagnostic entities, a two-tier config flow, webhook and diagnostics hardening, and discovery/failover coverage.
+
+## v2.3.0 - Polish and de-cluttering
+
+Low-risk tidying once the structural work has settled. No new capability.
+
+Main threads: code and test simplification, removal of redundant tests, opt-in message sensors, and UX copy polish.
+
+---
+
 ## Deferred / low priority
 
 - Extract `_device_info()` duplication into a shared `entity_base.py` mixin (only if maintenance burden grows; currently intentional for platform isolation).


### PR DESCRIPTION
## Summary

`docs/ROADMAP.md` carried no sections for v2.1.0, v2.2.0 or v2.3.0 even though all three milestones are in active use on GitHub Issues. The only heading below the status block was "Deferred / low priority". This adds one short section per release, each with the theme that has emerged from the issues milestoned against it.

## Changes

- `docs/ROADMAP.md`: three new sections inserted between the status block and "Deferred / low priority".
  - **v2.1.0 - Severity follow-through and test coverage.** 17 open issues, dominated by the #331 review follow-ups plus the critical-path test gaps.
  - **v2.2.0 - Structural simplification.** 6 open issues, all reducing surface area: coordinator extraction, fewer entities, two-tier config flow, hardening.
  - **v2.3.0 - Polish and de-cluttering.** 4 open issues, low-risk tidying with no new capability.

Item-level work deliberately stays in GitHub Issues, per the file's own note that "Item-level work is tracked in GitHub Issues, grouped by milestone". Each section is therefore a theme plus a one-line summary of the main threads, rather than an issue list that would go stale on every merge.

No source files touched.

## How to test

```bash
python3 scripts/validate_docs.py   # passes
```

`make doc-check` invokes the same validator via `python3.14`, which is not present in this environment (only 3.11/3.12/3.13 are). The validator is interpreter-agnostic, so it was run directly and passes. `make check` was not run: it exercises ruff, mypy and pytest against source code this PR does not touch. Treat CI as authoritative.

Also verified the addition contains no em-dashes, en-dashes, unicode arrows or smart quotes, per the house style rules in `CLAUDE.md`. The only non-ASCII character in the file is the pre-existing `§` on line 7.

## Checklist

- [ ] Linked the issue this PR resolves (`Closes #NN` in the description), if one exists - no issue; this came out of a milestone audit during an issues-cleanup session
- [ ] `make check` passes locally - not run, see above; docs-only change with no source edits
- [x] `CHANGELOG.md` `[Unreleased]` updated (user-visible changes only; skip for internal/ci/docs) - skipped, docs-only
- [x] PR title starts with a Conventional Commit prefix
- [x] PR has a label recognised by `.github/release.yml` - `documentation`, applied automatically from the `docs:` prefix
- [x] `strings.json` and `translations/en.json` are still identical (if either was touched) - neither touched
- [x] New category fully registered (if adding a category) - n/a
- [x] No blocking I/O introduced - n/a, no source changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtnxF6M2JVuJQhmzUtmsky)_