### PR TITLE
docs: schedule the _device_info() extraction instead of deferring it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Core hard rules shared across all agent surfaces are canonical in [`AGENTS.md` >
 
 - Module-level `_LOGGER = logging.getLogger(__name__)` in every file that logs.
 - `_attr_*` class attributes for HA entity properties - only override as `@property` if the value is dynamic.
-- `_device_info()` is a module-level helper function (not a method) duplicated across platform files intentionally - keeps each platform self-contained.
+- `_device_info()` is a module-level helper function (not a method) currently duplicated across platform files. That duplication was originally deliberate (platform isolation), but the decision has been revisited: the DRY win now outweighs it, and the helper is being extracted into a shared module in [#383](https://github.com/PHeonix25/unifi_alerts/issues/383). Keep the copies identical until that lands; do not add a fifth.
 - All `const.py` additions go in the appropriate labelled section with a comment.
 - Tests use `MagicMock` / `AsyncMock` for the UniFi client - never make real HTTP calls in tests.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,7 +12,9 @@ What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `
 
 Finish the severity-filtering feature started in #331 and close the test gaps on the paths users depend on most. Adds the first way to verify a webhook setup without waiting for a real alert.
 
-Main threads: the #331 review follow-ups (UI copy, filtered-alert diagnostics, `severity.py` cleanups), coverage for entity actions, webhook edge cases and coordinator/service error handling, a send-test-alert button, and the config flow accessibility blockers.
+Main threads: the #331 review follow-ups (UI copy, filtered-alert diagnostics, `severity.py` cleanups), coverage for entity actions, webhook edge cases and coordinator/service error handling, a send-test-alert button, the config flow accessibility blockers, and extracting the duplicated `_device_info()` helper (#383).
+
+The `_device_info()` duplication was previously listed here as deferred, on the grounds that keeping each platform self-contained was worth the repetition. That decision has been revisited: with four identical copies the DRY win now outweighs the isolation benefit, so the extraction is scheduled rather than deferred and is tracked in #383.
 
 ## v2.2.0 - Structural simplification
 
@@ -30,5 +32,4 @@ Main threads: code and test simplification, removal of redundant tests, opt-in m
 
 ## Deferred / low priority
 
-- Extract `_device_info()` duplication into a shared `entity_base.py` mixin (only if maintenance burden grows; currently intentional for platform isolation).
 - Configurable site per category (power-user feature).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -23,7 +23,3 @@ Each issue carries a **milestone**, a **category** label, a **size** label, and 
 - File new work with the **Task** issue template (or Bug / Feature where they fit). Apply a category, `size`, and `priority` label and assign a milestone.
 - Close items by landing a PR that references the issue (`Closes #NN`); do not delete lines here.
 - The seed/migration tool is `scripts/seed_issues.py` (idempotent; re-run to add new backlog items in bulk).
-
-## Known issues: intentional, do not action
-
-- **`_device_info()` duplication**: duplicated identically across `binary_sensor.py`, `sensor.py`, `event.py`, `button.py`. Intentional for platform isolation; extract to a shared `entity_base.py` only if it becomes a maintenance burden. Not tracked as an issue on purpose.


### PR DESCRIPTION
## Summary

The four identical `_device_info()` copies were recorded in three separate places as a deliberate trade-off, but #383 now tracks extracting them and is milestoned v2.1.0. The documents contradicted both each other and the backlog. This revisits the decision in favour of DRY and brings all three into line.

## Changes

- **`CLAUDE.md:51`**: the coding convention said the duplication was "intentional - keeps each platform self-contained". Now records that the decision was revisited, points at #383, and tells agents to keep the copies identical until it lands rather than add a fifth. This line was the one actively steering agents to preserve the duplication.
- **`docs/ROADMAP.md`**: removed the `_device_info()` bullet from "Deferred / low priority" and added the extraction to the v2.1.0 main threads, with a short paragraph recording why the call changed.
- **`docs/TODO.md`**: removed the "Known issues: intentional, do not action" section. It contained a single `_device_info()` entry asserting "Not tracked as an issue on purpose", which is now false. The section was the last content in the file and had no other items, so it is gone rather than left empty. Easy to reinstate if you want the heading kept for future entries.

No source files touched. `docs/ARCHITECTURE.md:131` and `docs/HOMEASSISTANT.md:47` also mention `_device_info`, but describe what the dict contains rather than why it is duplicated, so they are unaffected and left alone.

## How to test

```bash
python3 scripts/validate_docs.py   # passes
```

`make doc-check` runs the same validator through `python3.14`, which is not installed in this environment (3.11, 3.12 and 3.13 only). The validator is interpreter-agnostic so it was run directly. `make check` was not run: no source files changed. Treat CI as authoritative.

Verified no em-dashes, en-dashes, unicode arrows or smart quotes were introduced across all three files. The only non-ASCII characters present are pre-existing (`§` in ROADMAP, `🧹` in CLAUDE.md).

## Checklist

- [ ] Linked the issue this PR resolves (`Closes #NN` in the description), if one exists - deliberately not linked; this unblocks #383 by removing the contradiction, but does not implement it, so it must not auto-close
- [ ] `make check` passes locally - not run, docs-only change with no source edits
- [x] `CHANGELOG.md` `[Unreleased]` updated (user-visible changes only; skip for internal/ci/docs) - skipped, docs-only
- [x] PR title starts with a Conventional Commit prefix
- [x] PR has a label recognised by `.github/release.yml` - `documentation`, applied automatically from the `docs:` prefix
- [x] `strings.json` and `translations/en.json` are still identical (if either was touched) - neither touched
- [x] New category fully registered (if adding a category) - n/a
- [x] No blocking I/O introduced - n/a, no source changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtnxF6M2JVuJQhmzUtmsky)_