### PR TITLE
tests: add integration coverage for webhook body-size and malformed-JSON rejection

### DIFF
--- a/tests/integration/test_webhook.py
+++ b/tests/integration/test_webhook.py
@@ -23,6 +23,7 @@ from custom_components.unifi_alerts.const import (
     CATEGORY_NETWORK_WAN,
     CONF_MIN_SEVERITY,
     CONF_WEBHOOK_SECRET,
+    WEBHOOK_MAX_BODY_BYTES,
     webhook_id_for_category,
 )
 from custom_components.unifi_alerts.severity import SEVERITY_HIGH, SEVERITY_LOW
@@ -169,6 +170,55 @@ async def test_get_request_does_not_dispatch_alert(hass, entry, hass_client):
     # Regardless of HTTP status, the coordinator must not have dispatched an alert
     coordinator = get_coordinator(hass, entry)
     assert not coordinator.get_category_state(TEST_CATEGORY).is_alerting
+    assert hass.states.get(eid).state == "off"
+
+
+@pytest.mark.integration
+async def test_oversized_body_returns_413_and_sensor_stays_off(hass, entry, hass_client):
+    """A body larger than WEBHOOK_MAX_BODY_BYTES must be rejected with HTTP 413.
+
+    Unit coverage in test_webhook_handler.py exercises this against a mocked
+    request; this integration test proves the same contract holds over the
+    real HA HTTP server (Issue #381).
+    """
+    uid = f"{ENTRY_ID}_{TEST_CATEGORY}_binary"
+    eid = entity_id_for(hass, "binary_sensor", uid)
+    assert hass.states.get(eid).state == "off"
+
+    client = await hass_client()
+    oversized_body = b"x" * (WEBHOOK_MAX_BODY_BYTES + 1)
+    resp = await client.post(
+        f"/api/webhook/{TEST_WEBHOOK_ID}?token={WEBHOOK_SECRET}",
+        data=oversized_body,
+    )
+    assert resp.status == 413
+    await resp.read()
+    await hass.async_block_till_done()
+
+    assert hass.states.get(eid).state == "off"
+
+
+@pytest.mark.integration
+async def test_malformed_json_returns_400_and_sensor_stays_off(hass, entry, hass_client):
+    """A body that fails JSON parsing must be rejected with HTTP 400.
+
+    Unit coverage in test_webhook_handler.py exercises this against a mocked
+    request; this integration test proves the same contract holds over the
+    real HA HTTP server (Issue #381).
+    """
+    uid = f"{ENTRY_ID}_{TEST_CATEGORY}_binary"
+    eid = entity_id_for(hass, "binary_sensor", uid)
+    assert hass.states.get(eid).state == "off"
+
+    client = await hass_client()
+    resp = await client.post(
+        f"/api/webhook/{TEST_WEBHOOK_ID}?token={WEBHOOK_SECRET}",
+        data=b"not valid json {{",
+    )
+    assert resp.status == 400
+    await resp.read()
+    await hass.async_block_till_done()
+
     assert hass.states.get(eid).state == "off"
 
 


### PR DESCRIPTION
## Summary

Adds real-HTTP-server integration test coverage for two webhook rejection paths that were previously only exercised at the unit level (mocked request).

## Changes

- `tests/integration/test_webhook.py`: two new tests exercising the live HA webhook route.
  - `test_oversized_body_returns_413_and_sensor_stays_off`: POSTs a body of `WEBHOOK_MAX_BODY_BYTES + 1` and asserts HTTP 413, sensor stays off.
  - `test_malformed_json_returns_400_and_sensor_stays_off`: POSTs an invalid-JSON body and asserts HTTP 400, sensor stays off.

Both rejection behaviours already exist in `webhook_handler.py` (`WEBHOOK_MAX_BODY_BYTES` enforcement, `json.JSONDecodeError` handling) and were already covered by unit tests in `tests/unit/test_webhook_handler.py`; this PR closes the integration-level gap called out in #381's acceptance criteria ("Both integration and unit test levels covered").

Note: #381's third acceptance-criteria bullet ("error logged with redacted URL") pointed at a broken cross-reference (`Issue #1`) and, per the audit already left as a comment on #381, does not correspond to real behaviour in `webhook_handler.py` (no request URL is logged on this path — see the discussion on #379). That bullet is intentionally not addressed here; the two genuinely-untested scenarios (body size limit, malformed JSON) are.

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

No Python 3.14 interpreter was available in this environment to run `make check`/`pytest` locally (only 3.11-3.13 present, and `homeassistant>=2026.7.1` requires >=3.14.2). `ruff check`/`ruff format --check` on the changed file pass under 3.13, and `make doc-check` (pure stdlib, no venv) passes. CI is authoritative for the full `make check` run.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #381`)
- [ ] `make check` passes locally (not runnable in this environment — no Python 3.14; CI is authoritative)
- [x] `CHANGELOG.md` `[Unreleased]` updated (user-visible changes only; skip for internal/ci/docs) — N/A, test-only change, no `custom_components/` edits
- [x] PR title starts with a Conventional Commit prefix (`tests:`)
- [ ] PR has a label recognised by `.github/release.yml` (applied automatically for CC-prefixed titles via pr-release-label.yml)
- [x] `strings.json` and `translations/en.json` are still identical (neither touched)
- [x] No new category added
- [x] No blocking I/O introduced

Closes #381

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqZngVvK7PBgSvjpGHmM7M)_