### PR TITLE
tests: cover multiple rapid alert_received events firing exactly once each

### DIFF
--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -548,6 +548,21 @@ class TestUniFiAlertEventEntity:
         entity._handle_coordinator_update()
         entity._trigger_event.assert_called_once()
 
+    def test_multiple_rapid_alerts_each_fire_exactly_once(self):
+        """Several webhook pushes in quick succession must each fire their
+        own alert_received event - no event may be skipped or double-fired."""
+        alert = make_alert()
+        state = make_state(is_alerting=True, alert_count=0, last_alert=alert)
+        entity = self._make(state)
+        entity._last_seen_count = 0
+
+        for expected_count in (1, 2, 3):
+            state.alert_count = expected_count
+            entity._handle_coordinator_update()
+
+        assert entity._trigger_event.call_count == 3
+        assert entity._last_seen_count == 3
+
     @pytest.mark.asyncio
     async def test_added_to_hass_no_state_leaves_seed_zero(self):
         """Fresh install / unknown category: no restored state → seed stays 0."""


### PR DESCRIPTION
## Summary

Closes the one remaining gap in #380's acceptance criteria: `tests/unit/test_entities.py` already had comprehensive coverage for event firing (payload verification, reload-replay guard) and button press delegation (both `UniFiClearCategoryButton` and `UniFiClearAllButton`, availability by enabled state), but nothing exercised the "multiple rapid events handled correctly" criterion.

## Changes

- `tests/unit/test_entities.py`: `TestUniFiAlertEventEntity.test_multiple_rapid_alerts_each_fire_exactly_once` — bumps `alert_count` across three consecutive coordinator updates (0→1→2→3) and asserts `_trigger_event` fires exactly three times, none skipped or double-fired.

Everything else in #380's scope (event payload verification, button press → coordinator delegation, per-category button availability) was already covered on `dev` prior to this PR — verified by reading `TestUniFiAlertEventEntity`, `TestUniFiClearCategoryButton`, and `TestUniFiClearAllButton` in `tests/unit/test_entities.py`.

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

No Python 3.14 interpreter was available in this environment to run `make check`/`pytest` locally (only 3.11-3.13 present, and `homeassistant>=2026.7.1` requires >=3.14.2). `ruff check`/`ruff format --check` on the changed file pass under 3.13, and `make doc-check` (pure stdlib, no venv) passes. CI is authoritative for the full `make check` run.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #380`)
- [ ] `make check` passes locally (not runnable in this environment — no Python 3.14; CI is authoritative)
- [x] `CHANGELOG.md` `[Unreleased]` updated (user-visible changes only; skip for internal/ci/docs) — N/A, test-only change, no `custom_components/` edits
- [x] PR title starts with a Conventional Commit prefix (`tests:`)
- [ ] PR has a label recognised by `.github/release.yml` (applied automatically for CC-prefixed titles via pr-release-label.yml)
- [x] `strings.json` and `translations/en.json` are still identical (neither touched)
- [x] No new category added
- [x] No blocking I/O introduced

Closes #380

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqZngVvK7PBgSvjpGHmM7M)_