### PR TITLE
tests: cover webhook arrival in the shutdown window before unregister

### DIFF
--- a/tests/integration/test_webhook.py
+++ b/tests/integration/test_webhook.py
@@ -223,6 +223,48 @@ async def test_malformed_json_returns_400_and_sensor_stays_off(hass, entry, hass
 
 
 @pytest.mark.integration
+async def test_webhook_arrives_after_coordinator_shutdown_before_unregister(
+    hass, entry, hass_client
+):
+    """A webhook landing in the unload window between coordinator.async_shutdown()
+    and WebhookManager.unregister_all() must be handled gracefully.
+
+    custom_components/unifi_alerts/__init__.py's async_unload_entry calls
+    coordinator.async_shutdown() (cancels pending auto-clear tasks) *before*
+    runtime_data.unregister_webhooks() (tears down the HTTP route) — so this
+    window is real in production, not synthetic (Issue #382). We reproduce it
+    deterministically by driving the two steps directly in that order rather
+    than racing real concurrency, which would be non-deterministic in a test.
+    coordinator.async_shutdown() has no "dead" flag, so push_alert still runs
+    normally; the entry's own teardown (which unloads again) cancels the
+    fresh auto-clear task this webhook schedules, so nothing leaks past this
+    test.
+    """
+    uid = f"{ENTRY_ID}_{TEST_CATEGORY}_binary"
+    eid = entity_id_for(hass, "binary_sensor", uid)
+    coordinator = get_coordinator(hass, entry)
+
+    # Step 1 of the unload sequence: cancel pending auto-clear tasks.
+    await coordinator.async_shutdown()
+
+    # Step 2 (unregister_webhooks) has not run yet - the route is still live.
+    client = await hass_client()
+    resp = await client.post(
+        f"/api/webhook/{TEST_WEBHOOK_ID}?token={WEBHOOK_SECRET}",
+        json=TEST_PAYLOAD,
+    )
+    assert resp.status == 200
+    await resp.read()
+    await hass.async_block_till_done()
+
+    # Coordinator state must still update correctly despite shutdown having run.
+    state = coordinator.get_category_state(TEST_CATEGORY)
+    assert state.is_alerting is True
+    assert state.alert_count == 1
+    assert hass.states.get(eid).state == "on"
+
+
+@pytest.mark.integration
 async def test_post_after_unload_does_not_dispatch_and_entity_is_gone(
     hass, entry, hass_client, caplog
 ):


### PR DESCRIPTION
## Summary

Closes the one remaining gap in #382's scope. The issue lists four error-path areas:

1. **Service validation** (unknown/unloaded `entry_id`) — already fully covered by `tests/unit/test_services.py` (`TestGetCoordinatorsGuard`, `TestHandleClearCategory`/`TestHandleClearAll`).
2. **Coordinator v2/legacy dispatch** — already fully covered by `tests/unit/coordinator/test_polling.py::test_coordinator_dispatches_on_probe_result` (parametrized over probe True/False/exception/404).
3. **Persistence failure recovery** — already fully covered by `tests/unit/coordinator/test_persistence.py::TestWatermarkPersistFailureRepair` (repair issue created on failure, deleted on next success, end-to-end self-heal).
4. **Webhook arriving during shutdown** — genuinely untested. This PR adds that coverage.

## Changes

- `tests/integration/test_webhook.py`: `test_webhook_arrives_after_coordinator_shutdown_before_unregister`.

`custom_components/unifi_alerts/__init__.py`'s `async_unload_entry` calls `coordinator.async_shutdown()` (cancels pending auto-clear tasks) *before* `runtime_data.unregister_webhooks()` (tears down the HTTP route) — so there's a real window in production where a webhook can still land after shutdown has already run. `coordinator.async_shutdown()` has no "dead" flag, so `push_alert` still runs normally in that window.

The test reproduces this deterministically by driving the two steps directly in that order (`await coordinator.async_shutdown()`, then POST to the still-registered webhook) rather than racing real concurrency, which would be non-deterministic. It asserts the POST succeeds (200), the coordinator state updates correctly (`is_alerting`, `alert_count`), and the entity reflects it — i.e. graceful handling, no crash. The fresh auto-clear task this webhook schedules gets cancelled by the `entry` fixture's own teardown (which unloads again), so nothing leaks past the test.

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

No Python 3.14 interpreter was available in this environment to run `make check`/`pytest` locally (only 3.11-3.13 present, and `homeassistant>=2026.7.1` requires >=3.14.2). `ruff check`/`ruff format --check` on the changed file pass under 3.13, and `make doc-check` (pure stdlib, no venv) passes. CI is authoritative for the full `make check` run.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #382`)
- [ ] `make check` passes locally (not runnable in this environment — no Python 3.14; CI is authoritative)
- [x] `CHANGELOG.md` `[Unreleased]` updated (user-visible changes only; skip for internal/ci/docs) — N/A, test-only change, no `custom_components/` edits
- [x] PR title starts with a Conventional Commit prefix (`tests:`)
- [ ] PR has a label recognised by `.github/release.yml` (applied automatically for CC-prefixed titles via pr-release-label.yml)
- [x] `strings.json` and `translations/en.json` are still identical (neither touched)
- [x] No new category added
- [x] No blocking I/O introduced

Closes #382

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqZngVvK7PBgSvjpGHmM7M)_