### PR TITLE
docs: consolidated CHANGELOG entry for everything merged today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Documentation
+
+- Added v2.1.0, v2.2.0, and v2.3.0 sections to `docs/ROADMAP.md`, each summarising the theme and main threads of its milestone's open issues. ([#398])
+- Resolved a documentation conflict around the duplicated `_device_info()` helper: `CLAUDE.md`, `docs/ROADMAP.md`, and `docs/TODO.md` previously described the four-copy duplication as an intentional, un-tracked trade-off, contradicting #383 (which schedules the extraction for v2.1.0). All three now point at #383 and describe the decision as revisited in favour of DRY. ([#399])
+
 ### Internal
 
 - Closed the v2.1.0 test-coverage gaps for the webhook and entity-action paths: real-HTTP-server integration coverage for oversized-body (413) and malformed-JSON (400) webhook rejection, consecutive rapid `alert_received` events each firing exactly once, and a webhook landing in the window between `coordinator.async_shutdown()` and webhook unregistration during entry unload. No behaviour change. ([#381], [#380], [#382])
@@ -384,3 +389,5 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#380]: https://github.com/PHeonix25/unifi_alerts/issues/380
 [#381]: https://github.com/PHeonix25/unifi_alerts/issues/381
 [#382]: https://github.com/PHeonix25/unifi_alerts/issues/382
+[#398]: https://github.com/PHeonix25/unifi_alerts/pull/398
+[#399]: https://github.com/PHeonix25/unifi_alerts/pull/399

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Internal
+
+- Closed the v2.1.0 test-coverage gaps for the webhook and entity-action paths: real-HTTP-server integration coverage for oversized-body (413) and malformed-JSON (400) webhook rejection, consecutive rapid `alert_received` events each firing exactly once, and a webhook landing in the window between `coordinator.async_shutdown()` and webhook unregistration during entry unload. No behaviour change. ([#381], [#380], [#382])
+
 ## [2.0.1] - 2026-07-24
 
 ### Fixed
@@ -377,3 +381,6 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#353]: https://github.com/PHeonix25/unifi_alerts/issues/353
 [#368]: https://github.com/PHeonix25/unifi_alerts/issues/368
 [#375]: https://github.com/PHeonix25/unifi_alerts/issues/375
+[#380]: https://github.com/PHeonix25/unifi_alerts/issues/380
+[#381]: https://github.com/PHeonix25/unifi_alerts/issues/381
+[#382]: https://github.com/PHeonix25/unifi_alerts/issues/382


### PR DESCRIPTION
## Summary

I checked every PR merged today (`is:pr is:merged merged:2026-07-30` against this repo) rather than just the three I opened — five total: #398, #399 (docs, merged before this session started), #400, #401, #402 (test coverage, this session). This PR documents all five in `CHANGELOG.md`, at the user's request.

None of the five touched `custom_components/`, so `changelog-guard` never fired on them individually, and #398/#399 are docs-only (their own checklists mark the CHANGELOG line "skipped, docs-only" per the letter of `CLAUDE.md`'s "user-visible changes" rule). This PR retroactively documents all five as a deliberate exception to that default, per explicit request, rather than leaving today's work undocumented.

## Changes

- `CHANGELOG.md`, `[Unreleased]`:
  - `### Documentation`: one bullet for #398 (v2.1.0/v2.2.0/v2.3.0 ROADMAP sections), one bullet for #399 (resolved the `_device_info()` duplication documentation conflict across `CLAUDE.md`/`docs/ROADMAP.md`/`docs/TODO.md`).
  - `### Internal`: one consolidated bullet for #400/#401/#402 (closing issues #381, #380, #382) — the webhook and entity-action test-coverage gaps.
  - Five new reference links at the bottom of the file.

## How to test

```bash
make doc-check  # docs + translation parity
```

`scripts/validate_docs.py` passes locally (pure stdlib, ran under Python 3.13 — no Python 3.14 interpreter available in this environment).

## Checklist

- [x] Linked the issues/PRs this documents (`#380`, `#381`, `#382`, `#398`, `#399` — all already closed/merged)
- [x] `make doc-check` passes locally
- [x] `CHANGELOG.md` updated (this is the CHANGELOG-only PR)
- [x] PR title starts with a Conventional Commit prefix (`docs:`)
- [ ] PR has a label recognised by `.github/release.yml` (applied automatically for CC-prefixed titles via pr-release-label.yml)
- [x] `strings.json` and `translations/en.json` untouched
- [x] No new category added
- [x] No blocking I/O introduced