### PR TITLE
fix: provision Python 3.14 via uv when the base image lacks it

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -22,11 +22,26 @@ AI coding agents start from a cold container each session. Before any test can r
 
 | Surface | Entry point | Behaviour |
 |---|---|---|
-| Claude Code (web / remote) | `SessionStart` hook in `.claude/settings.json` calling `scripts/bootstrap_venv.sh` | Runs `make setup` only when `.venv` is absent; a no-op otherwise. Registered as an async hook, so the session starts immediately while the install runs in the background. Gated on `$CLAUDE_CODE_REMOTE`, so local sessions are untouched. Tolerant: a failed install logs and exits 0 rather than breaking the session. |
+| Claude Code (web / remote) | `SessionStart` hook in `.claude/settings.json` calling `scripts/bootstrap_venv.sh` | Runs `make setup` only when `.venv` is absent; a no-op otherwise. Registered as an async hook, so the session starts immediately while the install runs in the background. Gated on `$CLAUDE_CODE_REMOTE`, so local sessions are untouched. Tolerant: a failed install logs and exits 0 rather than breaking the session. If `python3.14` is not already on `PATH`, it self-provisions one via `uv` first (see below) before calling `make setup`. |
 | GitHub Copilot coding agent | `.github/workflows/copilot-setup-steps.yml` | GitHub runs this workflow before the agent starts, creating `.venv` and installing `requirements-dev.txt`. |
 | Local developer | `make setup` (run manually, see [Local setup](#local-setup)) | Explicit and one-off. The Claude hook deliberately skips local sessions so it never installs behind your back. |
 
 Why not a slimmer `requirements-test.txt`? The install is dominated by Home Assistant, which `pytest-homeassistant-custom-component` pulls in transitively regardless of what else is trimmed. A pytest-only requirements file would still drag in the same heavy tree, so it would not meaningfully shorten setup. The full `requirements-dev.txt` install is required; the hook plus the container's pip cache is the mitigation, not a reduced dependency set.
+
+### Python 3.14 on a remote container without it
+
+Claude Code web/remote containers are built from a base image pinned to whatever Python the OS ships (3.11-3.13 as of writing), not necessarily 3.14. The obvious fix, `apt-get install python3.14` from the deadsnakes PPA, fails on these sessions: the network egress policy allowlists specific hosts (`pypi.org`, `files.pythonhosted.org`, GitHub, etc.) and `ppa.launchpadcontent.net` is not one of them, so the proxy returns `403 Forbidden` on the package download (the `apt-cache policy` candidate resolves fine because the index is mirrored locally; only the `.deb` fetch is blocked).
+
+`scripts/bootstrap_venv.sh` works around this with [`uv`](https://docs.astral.sh/uv/)'s standalone Python builds, which are fetched from `python-build-standalone` via GitHub release assets - a host the same policy does allow:
+
+```bash
+python3 -m pip install --user --upgrade uv   # skip if uv is already present and current
+uv python install 3.14                        # fetches a real CPython 3.14 build, no apt/root needed
+```
+
+This produces a genuine CPython interpreter (verified: `venv`, `pip`/`ensurepip`, and `ssl` all work normally), not a container image swap or a policy exception. The hook prepends the resulting interpreter's directory to `PATH` for the rest of its run so `make setup`'s `python3.14 -m venv .venv` picks it up unmodified. A locally installed `python3.14` (or a future base image that already has one) is always preferred and this step is skipped entirely.
+
+If you hit the same wall outside of `bootstrap_venv.sh` (e.g. a manual session), run the two commands above yourself before `make setup`.
 
 ## Running checks
 

--- a/scripts/bootstrap_venv.sh
+++ b/scripts/bootstrap_venv.sh
@@ -16,6 +16,9 @@
 #   * Remote-only: gated on $CLAUDE_CODE_REMOTE so local sessions keep their
 #     existing behaviour (a local dev runs `make setup` deliberately).
 #   * POSIX sh, cross-platform-safe (checks both bin/ and Scripts/ layouts).
+#   * Self-provisions python3.14 via `uv` when the base image doesn't already
+#     have it on PATH, since this session's network policy blocks the
+#     deadsnakes PPA that `apt-get install python3.14` needs.
 set -u
 
 # Emit the async directive first so Claude Code starts the session immediately
@@ -40,6 +43,39 @@ if [ -x ".venv/bin/pytest" ] || [ -x ".venv/Scripts/pytest.exe" ]; then
 fi
 
 echo "[bootstrap] .venv missing; running 'make setup' (Home Assistant + test stack)." >&2
+
+# Remote containers ship whatever Python the base image has (3.11-3.13 as of
+# writing), and this session's network policy blocks the deadsnakes PPA that
+# `apt-get install python3.14` would otherwise pull from (403 from the egress
+# proxy - see docs/DEVELOPING.md). `uv python install` fetches a standalone
+# CPython build from python-build-standalone via GitHub release assets, which
+# the policy does allow, and needs no elevated privileges. Skip all of this
+# when python3.14 is already on PATH (local dev images, future base images).
+if ! command -v python3.14 >/dev/null 2>&1; then
+  echo "[bootstrap] python3.14 not found; provisioning via uv." >&2
+
+  if ! command -v uv >/dev/null 2>&1; then
+    python3 -m pip install --user --quiet --upgrade uv >&2 2>&1 || true
+    PATH="$HOME/.local/bin:$PATH"
+  fi
+
+  if command -v uv >/dev/null 2>&1; then
+    if uv python install 3.14 >&2 2>&1; then
+      UV_PY314_BIN="$(uv python find 3.14 2>/dev/null)"
+      if [ -n "$UV_PY314_BIN" ] && [ -x "$UV_PY314_BIN" ]; then
+        PATH="$(dirname "$UV_PY314_BIN"):$PATH"
+        export PATH
+        echo "[bootstrap] using uv-provisioned python3.14 ($UV_PY314_BIN)." >&2
+      else
+        echo "[bootstrap] uv reported success but python3.14 could not be located; falling back to whatever 'make setup' finds on PATH." >&2
+      fi
+    else
+      echo "[bootstrap] 'uv python install 3.14' failed; falling back to whatever 'make setup' finds on PATH." >&2
+    fi
+  else
+    echo "[bootstrap] uv unavailable after install attempt; falling back to whatever 'make setup' finds on PATH." >&2
+  fi
+fi
 
 # Tolerant install: a failure must not abort the session. Log and exit 0 either
 # way so the session stays usable for lint-only or read-only work.


### PR DESCRIPTION
## Summary

`scripts/bootstrap_venv.sh` (the Claude Code remote `SessionStart` hook) now self-provisions a real Python 3.14 interpreter via `uv` when the container's base image doesn't already have `python3.14` on `PATH`, instead of assuming it exists.

## Changes

- `scripts/bootstrap_venv.sh`: before calling `make setup`, check for `python3.14` on `PATH`. If missing, install/upgrade `uv` (from PyPI, which the session network policy already allows) and run `uv python install 3.14`, then prepend the resulting interpreter's directory to `PATH` for the rest of the script's run. Fully tolerant: any failure at any step logs and falls through to whatever `make setup` finds on `PATH`, matching the script's existing non-blocking design.
- `docs/DEVELOPING.md`: documents why this is needed (remote containers currently ship 3.11-3.13, and `apt-get install python3.14` from the deadsnakes PPA fails on these sessions with a `403` from the egress proxy, since `ppa.launchpadcontent.net` isn't on the allowlist) and how the `uv`-based workaround works, including the manual commands for anyone hitting the same wall outside the hook.

## How to test

Verified directly in a Claude Code remote session with `python3.14` stripped from `PATH` and no `.venv`:

```bash
env -i CLAUDE_CODE_REMOTE=true CLAUDE_PROJECT_DIR="$(pwd)" HOME="$HOME" PATH="<python3.14-free PATH>" sh scripts/bootstrap_venv.sh
```

This provisioned a genuine CPython 3.14.6 build via `uv`, then ran `make setup` end to end (Home Assistant + full test stack, ~200 packages) against it. Confirmed the resulting `.venv` is real 3.14 (`venv`, `pip`/`ensurepip`, `ssl` all work) and re-ran the full suite against it:

```bash
make doc-check  # docs + translation parity
make check      # full validation suite - 747 passed, 99.47% coverage
```

Also re-verified the existing no-op path (`.venv` already present skips setup entirely) still behaves unchanged.

## Checklist

- [x] `make check` passes locally
- [ ] `CHANGELOG.md` `[Unreleased]` updated - skipped: dev/agent-tooling only, no user-visible effect on the integration, and doesn't touch `custom_components/`
- [x] PR title starts with a Conventional Commit prefix (`fix:`)
- [x] PR has a label recognised by `.github/release.yml` (applied automatically via pr-release-label.yml)
- [x] `strings.json`/`translations/en.json` untouched
- [x] No blocking I/O introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjRW23UijpPg9c5sa69pzq)_