### PR TITLE
feat: accessible webhook URLs and severity help text in config flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added v2.1.0, v2.2.0, and v2.3.0 sections to `docs/ROADMAP.md`, each summarising the theme and main threads of its milestone's open issues. ([#398])
 - Resolved a documentation conflict around the duplicated `_device_info()` helper: `CLAUDE.md`, `docs/ROADMAP.md`, and `docs/TODO.md` previously described the four-copy duplication as an intentional, un-tracked trade-off, contradicting #383 (which schedules the extraction for v2.1.0). All three now point at #383 and describe the decision as revisited in favour of DRY. ([#399])
 
+### Changed
+
+- Improved config flow and options flow accessibility: the "Webhook URLs" step now lists each category's URL as plain Markdown text under headed sections (Authentication, Legacy Method, Retrieve Later) instead of pre-filled form fields that looked editable but silently discarded any edits, and every per-category minimum-severity selector now has descriptive help text explaining what it filters. ([#395])
+
 ### Internal
 
 - Closed the v2.1.0 test-coverage gaps for the webhook and entity-action paths: real-HTTP-server integration coverage for oversized-body (413) and malformed-JSON (400) webhook rejection, consecutive rapid `alert_received` events each firing exactly once, and a webhook landing in the window between `coordinator.async_shutdown()` and webhook unregistration during entry unload. No behaviour change. ([#381], [#380], [#382])
@@ -389,5 +393,6 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#380]: https://github.com/PHeonix25/unifi_alerts/issues/380
 [#381]: https://github.com/PHeonix25/unifi_alerts/issues/381
 [#382]: https://github.com/PHeonix25/unifi_alerts/issues/382
+[#395]: https://github.com/PHeonix25/unifi_alerts/issues/395
 [#398]: https://github.com/PHeonix25/unifi_alerts/pull/398
 [#399]: https://github.com/PHeonix25/unifi_alerts/pull/399

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -168,7 +168,7 @@ def _webhook_url_placeholders(hass: Any, enabled: list[str], suffix: str) -> dic
                 hass, webhook_id_for_category(cat, suffix)
             )
         else:
-            placeholders[f"url_{cat}"] = "not enabled - go back and enable this category"
+            placeholders[f"url_{cat}"] = "not enabled"
     return placeholders
 
 

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -151,6 +151,27 @@ def _find_entry_by_serial(hass: Any, serial: str) -> ConfigEntry | None:
     return None
 
 
+def _webhook_url_placeholders(hass: Any, enabled: list[str], suffix: str) -> dict[str, str]:
+    """Build a `url_<category>` description placeholder for every category.
+
+    The finish step renders these as plain Markdown text rather than form
+    fields, so the URLs are reachable with ordinary keyboard text selection
+    and screen readers instead of needing focus inside an editable input
+    whose value the flow silently discards on submit (#395). Disabled
+    categories get an explanatory note instead of a URL, since their webhook
+    is never registered and calling it would just 404.
+    """
+    placeholders: dict[str, str] = {}
+    for cat in ALL_CATEGORIES:
+        if cat in enabled:
+            placeholders[f"url_{cat}"] = async_generate_url(
+                hass, webhook_id_for_category(cat, suffix)
+            )
+        else:
+            placeholders[f"url_{cat}"] = "not enabled - go back and enable this category"
+    return placeholders
+
+
 class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle the initial setup flow shown in Settings → Integrations."""
 
@@ -377,15 +398,12 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
         enabled: list[str] = self._entry_data.get(CONF_ENABLED_CATEGORIES, ALL_CATEGORIES)
         secret: str = self._entry_data.get(CONF_WEBHOOK_SECRET, "")
         suffix: str = self._entry_data.get(CONF_WEBHOOK_ID_SUFFIX, "")
-        fields: dict[Any, Any] = {}
-        for cat in ALL_CATEGORIES:
-            if cat in enabled:
-                url = async_generate_url(self.hass, webhook_id_for_category(cat, suffix))
-                fields[vol.Optional(f"webhook_url_{cat}", default=url)] = str
+        placeholders = _webhook_url_placeholders(self.hass, enabled, suffix)
+        placeholders["webhook_secret"] = secret
         return self.async_show_form(
             step_id="finish",
-            data_schema=vol.Schema(fields),
-            description_placeholders={"webhook_secret": secret},
+            data_schema=vol.Schema({}),
+            description_placeholders=placeholders,
         )
 
     # ── Reauth flow ───────────────────────────────────────────────────────
@@ -954,13 +972,10 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
             self._config_entry.data.get(CONF_WEBHOOK_SECRET, ""),
         )
         suffix: str = self._config_entry.data.get(CONF_WEBHOOK_ID_SUFFIX, "")
-        fields: dict[Any, Any] = {}
-        for cat in ALL_CATEGORIES:
-            if cat in enabled:
-                url = async_generate_url(self.hass, webhook_id_for_category(cat, suffix))
-                fields[vol.Optional(f"webhook_url_{cat}", default=url)] = str
+        placeholders = _webhook_url_placeholders(self.hass, enabled, suffix)
+        placeholders["webhook_secret"] = secret
         return self.async_show_form(
             step_id="finish",
-            data_schema=vol.Schema(fields),
-            description_placeholders={"webhook_secret": secret},
+            data_schema=vol.Schema({}),
+            description_placeholders=placeholders,
         )

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -34,20 +34,20 @@
           "poll_interval": "Polling interval (seconds)",
           "clear_timeout": "Auto-clear timeout (minutes)",
           "site": "UniFi site name (leave as \"default\" for single-site setups)"
+        },
+        "data_description": {
+          "min_severity_network_device": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_network_wan": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_network_client": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_security_threat": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_security_honeypot": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_security_firewall": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_power": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts."
         }
       },
       "finish": {
         "title": "Webhook URLs",
-        "description": "**Header key:** `Authorization`\n\n**Header value:** `Bearer {webhook_secret}`\n\nAdd this custom header in each alarm's Advanced Settings in UniFi Alarm Manager first; it is the preferred authentication method. Then copy each webhook URL below into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit. If your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead; this legacy method still works but is deprecated. You can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough.",
-        "data": {
-          "webhook_url_network_device": "Network: Device offline/online webhook URL",
-          "webhook_url_network_wan": "Network: WAN offline/latency webhook URL",
-          "webhook_url_network_client": "Network: Client connect/disconnect webhook URL",
-          "webhook_url_security_threat": "Security: Threat / IDS detected webhook URL",
-          "webhook_url_security_honeypot": "Security: Honeypot triggered webhook URL",
-          "webhook_url_security_firewall": "Security: Firewall block webhook URL",
-          "webhook_url_power": "Power: PoE / power loss webhook URL"
-        }
+        "description": "### Authentication\n\n**Header key:** `Authorization`\n**Header value:** `Bearer {webhook_secret}`\n\nAdd this custom header in each alarm's Advanced Settings in UniFi Alarm Manager first; it is the preferred authentication method. Then copy each webhook URL below into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit.\n\n- **Network: Device offline/online**: `{url_network_device}`\n- **Network: WAN offline/latency**: `{url_network_wan}`\n- **Network: Client connect/disconnect**: `{url_network_client}`\n- **Security: Threat / IDS detected**: `{url_security_threat}`\n- **Security: Honeypot triggered**: `{url_security_honeypot}`\n- **Security: Firewall block**: `{url_security_firewall}`\n- **Power: PoE / power loss**: `{url_power}`\n\n### Legacy Method\n\nIf your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead. This legacy method still works but is deprecated.\n\n### Retrieve Later\n\nYou can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough."
       },
       "reauth_confirm": {
         "title": "Re-authenticate UniFi Alerts",
@@ -269,20 +269,20 @@
           "poll_interval": "Polling interval (seconds)",
           "clear_timeout": "Auto-clear timeout (minutes)",
           "site": "UniFi site name"
+        },
+        "data_description": {
+          "min_severity_network_device": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_network_wan": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_network_client": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_security_threat": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_security_honeypot": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_security_firewall": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_power": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts."
         }
       },
       "finish": {
         "title": "Webhook URLs",
-        "description": "**Header key:** `Authorization`\n\n**Header value:** `Bearer {webhook_secret}`\n\nAdd this custom header in each alarm's Advanced Settings in UniFi Alarm Manager first; it is the preferred authentication method. Then copy each webhook URL below into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit. If your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead; this legacy method still works but is deprecated. You can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough.",
-        "data": {
-          "webhook_url_network_device": "Network: Device offline/online webhook URL",
-          "webhook_url_network_wan": "Network: WAN offline/latency webhook URL",
-          "webhook_url_network_client": "Network: Client connect/disconnect webhook URL",
-          "webhook_url_security_threat": "Security: Threat / IDS detected webhook URL",
-          "webhook_url_security_honeypot": "Security: Honeypot triggered webhook URL",
-          "webhook_url_security_firewall": "Security: Firewall block webhook URL",
-          "webhook_url_power": "Power: PoE / power loss webhook URL"
-        }
+        "description": "### Authentication\n\n**Header key:** `Authorization`\n**Header value:** `Bearer {webhook_secret}`\n\nAdd this custom header in each alarm's Advanced Settings in UniFi Alarm Manager first; it is the preferred authentication method. Then copy each webhook URL below into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit.\n\n- **Network: Device offline/online**: `{url_network_device}`\n- **Network: WAN offline/latency**: `{url_network_wan}`\n- **Network: Client connect/disconnect**: `{url_network_client}`\n- **Security: Threat / IDS detected**: `{url_security_threat}`\n- **Security: Honeypot triggered**: `{url_security_honeypot}`\n- **Security: Firewall block**: `{url_security_firewall}`\n- **Power: PoE / power loss**: `{url_power}`\n\n### Legacy Method\n\nIf your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead. This legacy method still works but is deprecated.\n\n### Retrieve Later\n\nYou can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough."
       }
     }
   },

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -34,20 +34,20 @@
           "poll_interval": "Polling interval (seconds)",
           "clear_timeout": "Auto-clear timeout (minutes)",
           "site": "UniFi site name (leave as \"default\" for single-site setups)"
+        },
+        "data_description": {
+          "min_severity_network_device": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_network_wan": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_network_client": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_security_threat": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_security_honeypot": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_security_firewall": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_power": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts."
         }
       },
       "finish": {
         "title": "Webhook URLs",
-        "description": "**Header key:** `Authorization`\n\n**Header value:** `Bearer {webhook_secret}`\n\nAdd this custom header in each alarm's Advanced Settings in UniFi Alarm Manager first; it is the preferred authentication method. Then copy each webhook URL below into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit. If your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead; this legacy method still works but is deprecated. You can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough.",
-        "data": {
-          "webhook_url_network_device": "Network: Device offline/online webhook URL",
-          "webhook_url_network_wan": "Network: WAN offline/latency webhook URL",
-          "webhook_url_network_client": "Network: Client connect/disconnect webhook URL",
-          "webhook_url_security_threat": "Security: Threat / IDS detected webhook URL",
-          "webhook_url_security_honeypot": "Security: Honeypot triggered webhook URL",
-          "webhook_url_security_firewall": "Security: Firewall block webhook URL",
-          "webhook_url_power": "Power: PoE / power loss webhook URL"
-        }
+        "description": "### Authentication\n\n**Header key:** `Authorization`\n**Header value:** `Bearer {webhook_secret}`\n\nAdd this custom header in each alarm's Advanced Settings in UniFi Alarm Manager first; it is the preferred authentication method. Then copy each webhook URL below into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit.\n\n- **Network: Device offline/online**: `{url_network_device}`\n- **Network: WAN offline/latency**: `{url_network_wan}`\n- **Network: Client connect/disconnect**: `{url_network_client}`\n- **Security: Threat / IDS detected**: `{url_security_threat}`\n- **Security: Honeypot triggered**: `{url_security_honeypot}`\n- **Security: Firewall block**: `{url_security_firewall}`\n- **Power: PoE / power loss**: `{url_power}`\n\n### Legacy Method\n\nIf your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead. This legacy method still works but is deprecated.\n\n### Retrieve Later\n\nYou can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough."
       },
       "reauth_confirm": {
         "title": "Re-authenticate UniFi Alerts",
@@ -269,20 +269,20 @@
           "poll_interval": "Polling interval (seconds)",
           "clear_timeout": "Auto-clear timeout (minutes)",
           "site": "UniFi site name"
+        },
+        "data_description": {
+          "min_severity_network_device": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_network_wan": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_network_client": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_security_threat": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_security_honeypot": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_security_firewall": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts.",
+          "min_severity_power": "Only alerts at this severity level or higher will be tracked. Use 'No Filter' to capture all alerts."
         }
       },
       "finish": {
         "title": "Webhook URLs",
-        "description": "**Header key:** `Authorization`\n\n**Header value:** `Bearer {webhook_secret}`\n\nAdd this custom header in each alarm's Advanced Settings in UniFi Alarm Manager first; it is the preferred authentication method. Then copy each webhook URL below into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit. If your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead; this legacy method still works but is deprecated. You can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough.",
-        "data": {
-          "webhook_url_network_device": "Network: Device offline/online webhook URL",
-          "webhook_url_network_wan": "Network: WAN offline/latency webhook URL",
-          "webhook_url_network_client": "Network: Client connect/disconnect webhook URL",
-          "webhook_url_security_threat": "Security: Threat / IDS detected webhook URL",
-          "webhook_url_security_honeypot": "Security: Honeypot triggered webhook URL",
-          "webhook_url_security_firewall": "Security: Firewall block webhook URL",
-          "webhook_url_power": "Power: PoE / power loss webhook URL"
-        }
+        "description": "### Authentication\n\n**Header key:** `Authorization`\n**Header value:** `Bearer {webhook_secret}`\n\nAdd this custom header in each alarm's Advanced Settings in UniFi Alarm Manager first; it is the preferred authentication method. Then copy each webhook URL below into UniFi Network > Settings > Notifications > Alarm Manager **before** clicking Submit.\n\n- **Network: Device offline/online**: `{url_network_device}`\n- **Network: WAN offline/latency**: `{url_network_wan}`\n- **Network: Client connect/disconnect**: `{url_network_client}`\n- **Security: Threat / IDS detected**: `{url_security_threat}`\n- **Security: Honeypot triggered**: `{url_security_honeypot}`\n- **Security: Firewall block**: `{url_security_firewall}`\n- **Power: PoE / power loss**: `{url_power}`\n\n### Legacy Method\n\nIf your Alarm Manager version has no custom-header option, append `?token={webhook_secret}` to the URL instead. This legacy method still works but is deprecated.\n\n### Retrieve Later\n\nYou can retrieve these URLs and the secret later via Settings > Devices & Services > UniFi Alerts > Configure. See docs/ALARM_MANAGER_SETUP.md for a full walkthrough."
       }
     }
   },

--- a/tests/unit/config_flow/test_options_credentials.py
+++ b/tests/unit/config_flow/test_options_credentials.py
@@ -25,7 +25,11 @@ from .conftest import make_options_flow, make_session_mock
 
 @pytest.mark.asyncio
 async def test_options_finish_includes_webhook_urls() -> None:
-    """Options flow finish step should include webhook URL fields with the stored secret."""
+    """Options flow finish step should surface webhook URLs with the stored secret.
+
+    URLs are rendered as plain Markdown text in the description (#395), not
+    as form fields, so the schema itself carries no data.
+    """
     fake_secret = "options-test-secret"
     config_entry = MagicMock()
     config_entry.data = {CONF_ENABLED_CATEGORIES: ALL_CATEGORIES, CONF_WEBHOOK_SECRET: fake_secret}
@@ -47,13 +51,13 @@ async def test_options_finish_includes_webhook_urls() -> None:
 
     assert result["step_id"] == "finish"
     call_kwargs = flow.async_show_form.call_args.kwargs
-    schema = call_kwargs["data_schema"]
-    str_defaults = [v for v in (k.default() for k in schema.schema) if isinstance(v, str)]
+    assert call_kwargs["data_schema"].schema == {}
+    placeholders = call_kwargs["description_placeholders"]
     # Displayed URLs must no longer embed the secret (#176) — it is surfaced
     # separately via description_placeholders for the Authorization header.
-    assert not any(f"token={fake_secret}" in v for v in str_defaults)
-    assert any(fake_url in v for v in str_defaults)
-    assert call_kwargs["description_placeholders"]["webhook_secret"] == fake_secret
+    assert not any(f"token={fake_secret}" in v for v in placeholders.values())
+    assert all(placeholders[f"url_{cat}"] == fake_url for cat in ALL_CATEGORIES)
+    assert placeholders["webhook_secret"] == fake_secret
 
 
 @pytest.mark.asyncio

--- a/tests/unit/config_flow/test_options_rotation_validation.py
+++ b/tests/unit/config_flow/test_options_rotation_validation.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-import voluptuous as vol
 
 from custom_components.unifi_alerts.const import (
     ALL_CATEGORIES,
@@ -171,24 +170,21 @@ class TestWebhookSecretRotation:
         ):
             await flow.async_step_categories(cat_input)
 
-        # Inspect the form schema's default URLs -- displayed URLs no longer
-        # embed the secret (#176); the NEW secret must instead be surfaced via
-        # description_placeholders for the Authorization header instructions.
+        # Inspect the finish step's description placeholders -- displayed
+        # URLs no longer embed the secret (#176); the NEW secret must instead
+        # be surfaced via its own placeholder for the Authorization header
+        # instructions. URLs are rendered as Markdown text (#395), not form
+        # fields, so the schema itself carries no data.
         finish_call = flow.async_show_form.call_args_list[-1]
-        schema = finish_call.kwargs["data_schema"]
-        url_defaults = [
-            marker.default()
-            for marker in schema.schema
-            if isinstance(marker, vol.Optional)
-            and isinstance(marker.schema, str)
-            and marker.schema.startswith("webhook_url_")
-        ]
-        assert url_defaults, "Expected at least one webhook_url_* field on the finish step"
-        for url in url_defaults:
+        assert finish_call.kwargs["data_schema"].schema == {}
+        placeholders = finish_call.kwargs["description_placeholders"]
+        url_values = [placeholders[f"url_{cat}"] for cat in ALL_CATEGORIES]
+        assert url_values, "Expected a url_* placeholder for every category on the finish step"
+        for url in url_values:
             assert new_secret not in url, (
                 f"Finish step must not embed the secret in the URL. URL: {url}"
             )
-        assert finish_call.kwargs["description_placeholders"]["webhook_secret"] == new_secret
+        assert placeholders["webhook_secret"] == new_secret
 
 
 class TestWebhookSecretRotationRepairIssue:

--- a/tests/unit/config_flow/test_setup.py
+++ b/tests/unit/config_flow/test_setup.py
@@ -578,7 +578,13 @@ class TestFinishStep:
 
     @pytest.mark.asyncio
     async def test_shows_webhook_urls(self) -> None:
-        """async_step_finish with no input should show a form with webhook URL fields in data_schema."""
+        """async_step_finish with no input should surface webhook URLs as description placeholders.
+
+        The URLs are rendered as plain Markdown text in the finish-step
+        description (#395), not as form fields, so they're reachable with
+        ordinary keyboard text selection and screen readers instead of an
+        editable input whose value the flow silently discards.
+        """
         flow = make_flow()
         flow._controller_url = "https://192.168.1.1"
         fake_secret = "test-secret-token"
@@ -597,15 +603,36 @@ class TestFinishStep:
 
         assert result["step_id"] == "finish"
         call_kwargs = flow.async_show_form.call_args.kwargs
-        schema = call_kwargs["data_schema"]
-        # Webhook URLs must be present as field defaults in the schema
-        schema_defaults = {str(k): k.default() for k in schema.schema}
+        # No form fields left; the finish step is informational only.
+        assert call_kwargs["data_schema"].schema == {}
+        placeholders = call_kwargs["description_placeholders"]
         # Displayed URLs must no longer embed the secret (#176) — it is
         # surfaced separately via description_placeholders for the
         # Authorization header.
-        assert not any(f"token={fake_secret}" in v for v in schema_defaults.values())
-        assert any(fake_url in v for v in schema_defaults.values())
-        assert call_kwargs["description_placeholders"]["webhook_secret"] == fake_secret
+        assert not any(f"token={fake_secret}" in v for v in placeholders.values())
+        assert all(placeholders[f"url_{cat}"] == fake_url for cat in ALL_CATEGORIES)
+        assert placeholders["webhook_secret"] == fake_secret
+
+    @pytest.mark.asyncio
+    async def test_shows_not_enabled_note_for_disabled_categories(self) -> None:
+        """Disabled categories get an explanatory placeholder instead of a URL."""
+        flow = make_flow()
+        flow._controller_url = "https://192.168.1.1"
+        flow._entry_data = {
+            CONF_ENABLED_CATEGORIES: [ALL_CATEGORIES[0]],
+            CONF_WEBHOOK_SECRET: "test-secret-token",
+        }
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "finish"})
+
+        with patch(
+            "custom_components.unifi_alerts.config_flow.async_generate_url",
+            return_value="http://homeassistant.local:8123/api/webhook/unifi_alerts_network_device",
+        ):
+            await flow.async_step_finish(user_input=None)
+
+        placeholders = flow.async_show_form.call_args.kwargs["description_placeholders"]
+        for cat in ALL_CATEGORIES[1:]:
+            assert "not enabled" in placeholders[f"url_{cat}"]
 
     @pytest.mark.asyncio
     async def test_submit_creates_entry(self) -> None:


### PR DESCRIPTION
## Summary

Fixes the three accessibility gaps in the config flow / options flow tracked in #395: unreadable webhook URL fields, a dense unstructured Finish-step description, and severity selectors with no explanation of what they do.

## Changes

- `config_flow.py`: added a shared `_webhook_url_placeholders()` helper and switched both `async_step_finish` implementations (initial setup and options flow) from per-category `webhook_url_*` form fields to `description_placeholders` (`url_<category>`). The finish-step schema is now empty (`vol.Schema({})`) since the fields were purely a display mechanism the flow already ignored on submit. Disabled categories get a "not enabled" note instead of a URL, since their webhook is never registered.
- `strings.json` / `translations/en.json` (kept byte-identical):
  - `config.step.finish.description` / `options.step.finish.description`: restructured into headed sections (Authentication, Legacy Method, Retrieve Later) with the webhook URLs listed as a Markdown list of `` `{url_<category>}` `` placeholders, replacing the removed `data` block of per-category fields.
  - `config.step.categories.data_description` / `options.step.categories.data_description`: added help text for all 7 `min_severity_<category>` selectors.
- `CHANGELOG.md`: added an `[Unreleased]` entry under a new `### Changed` section.
- Updated the existing finish-step tests (`test_setup.py`, `test_options_credentials.py`, `test_options_rotation_validation.py`) to assert against the new placeholder-based rendering instead of schema field defaults, and added a test for the disabled-category placeholder text.

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

Note: this sandbox only has Python 3.11-3.13 available, not the pinned 3.14, so `homeassistant` (which now requires >=3.14.2) could not be installed and `make check`'s `test`/`typecheck` legs could not be run locally. I ran what's possible without the venv (`scripts/validate_docs.py`, `scripts/check_translations.py`, `scripts/check_agentrc_refs.py`, all pass) plus `ruff check`/`ruff format --check` under a 3.13 venv (both pass). CI is authoritative for `mypy`/`pytest`.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #395` in the description)
- [ ] `make check` passes locally (could not run `test`/`typecheck` legs — no Python 3.14 available in this sandbox; relying on CI)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] PR title starts with a Conventional Commit prefix (`feat:`)
- [x] PR has a label recognised by `.github/release.yml` (auto-applied for `feat:` titles via pr-release-label.yml)
- [x] `strings.json` and `translations/en.json` are still identical
- [ ] New category fully registered (n/a, no new category added)
- [x] No blocking I/O introduced

Closes #395


---
_Generated by [Claude Code](https://claude.ai/code/session_01SnB72PWicJw2zpDLDhqNHm)_