### PR TITLE
security: regression test for webhook token leaking via request URL

### DIFF
--- a/tests/unit/test_webhook_handler.py
+++ b/tests/unit/test_webhook_handler.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from yarl import URL
 
 from custom_components.unifi_alerts.const import (
     ALL_CATEGORIES,
@@ -799,3 +801,79 @@ class TestWebhookLegacyQueryAuthRepairIssue:
             await handler(manager._hass, "wh-id", req)
 
         mock_create.assert_not_called()
+
+
+# ── request URL / query-string never logged (#379) ───────────────────────────
+
+
+class TestRequestUrlNeverLogged:
+    """The legacy ``?token=`` query param (kept during the #176 deprecation
+    window) means a webhook secret can appear in the request URL. Nothing in
+    the handler logs ``request.url`` today, but nothing structurally prevents
+    a future change from doing so by accident. These tests give a request a
+    real ``request.url`` carrying the token in its query string and assert,
+    via ``caplog``, that the token value never appears in any log record
+    emitted by the malformed-body path or the auth-failure path.
+    """
+
+    TOKEN = "s3cr3t-webhook-token-f8a41c9e"
+
+    def _request_with_url_token(
+        self,
+        url_token: str,
+        query_token: str | None = None,
+        json_body: dict | None = None,
+    ):
+        """Build a mock request whose ``.url`` carries ``?token=<url_token>``.
+
+        ``request.query`` (used by the handler for auth) defaults to the same
+        token so the request is internally consistent, matching how aiohttp
+        derives ``request.query`` from ``request.url`` in production.
+        """
+        req = make_request(
+            token=query_token if query_token is not None else url_token,
+            json_body=json_body,
+        )
+        req.url = URL(f"http://homeassistant.local:8123/api/webhook/abc123?token={url_token}")
+        return req
+
+    @pytest.mark.asyncio
+    async def test_malformed_body_path_never_logs_token(self, caplog):
+        """Malformed body, authenticated via the token-bearing URL."""
+        manager, push_cb = make_manager(secret=self.TOKEN)
+        handler = manager._make_handler(CATEGORY_NETWORK_WAN, self.TOKEN)
+        req = self._request_with_url_token(self.TOKEN)
+        req.content.read = AsyncMock(return_value=b"not valid json {{")
+
+        with caplog.at_level(
+            logging.DEBUG, logger="custom_components.unifi_alerts.webhook_handler"
+        ):
+            response = await handler(manager._hass, "wh-id", req)
+
+        assert response is not None
+        assert response.status == 400
+        push_cb.assert_not_called()
+        assert self.TOKEN not in caplog.text
+        assert str(req.url) not in caplog.text
+        for record in caplog.records:
+            assert self.TOKEN not in record.getMessage()
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_path_never_logs_token(self, caplog):
+        """Auth failure: the URL carries a wrong/attacker-supplied token."""
+        manager, push_cb = make_manager(secret="the-real-secret")
+        handler = manager._make_handler(CATEGORY_NETWORK_WAN, "the-real-secret")
+        req = self._request_with_url_token(self.TOKEN)
+
+        with caplog.at_level(
+            logging.DEBUG, logger="custom_components.unifi_alerts.webhook_handler"
+        ):
+            response = await handler(manager._hass, "wh-id", req)
+
+        assert response is not None
+        assert response.status == 401
+        push_cb.assert_not_called()
+        assert self.TOKEN not in caplog.text
+        assert str(req.url) not in caplog.text
+        for record in caplog.records:
+            assert self.TOKEN not in record.getMessage()

--- a/tests/unit/test_webhook_handler.py
+++ b/tests/unit/test_webhook_handler.py
@@ -803,9 +803,6 @@ class TestWebhookLegacyQueryAuthRepairIssue:
         mock_create.assert_not_called()
 
 
-# ── request URL / query-string never logged (#379) ───────────────────────────
-
-
 class TestRequestUrlNeverLogged:
     """The legacy ``?token=`` query param (kept during the #176 deprecation
     window) means a webhook secret can appear in the request URL. Nothing in


### PR DESCRIPTION
## Summary

Adds a regression test that locks in the property that the webhook handler never logs the legacy `?token=` query string (or the request URL that carries it), so a future change can't accidentally leak a webhook secret into the logs via something like `request.url`.

## Changes

- `tests/unit/test_webhook_handler.py`: new `TestRequestUrlNeverLogged` class. Builds a mock request with a real `request.url` (`yarl.URL`) carrying `?token=<secret>`, then exercises the malformed-body path and the auth-failure path with `caplog` capturing DEBUG+ output from `custom_components.unifi_alerts.webhook_handler`, asserting the token value never appears in any emitted log record.

No production code change: as noted in the issue, no `_LOGGER` call in `webhook_handler.py` currently logs a request URL at all — the malformed-body handler only logs `category`, the exception class name, and an 80-byte body preview. This PR only adds the regression test that verifies that property and catches a future regression.

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

Note: this session's environment could only provision Python 3.14.0rc2 via `uv` (the network policy blocks fetching a newer standalone build), and `homeassistant>=2026.3.1` requires Python 3.14.2+, so the full `make test` HA-backed suite could not be run locally. `ruff check`, `ruff format --check`, `make doc-check`, and `make validate` all pass locally against the changed file and the repo. CI (which has a proper Python 3.14.2+ interpreter) is authoritative for the pytest run.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #379` below)
- [ ] `make check` passes locally (blocked on Python 3.14.2+ availability in this session; lint/format/doc-check/validate all pass — see note above; CI will run the full suite)
- [x] `CHANGELOG.md` `[Unreleased]` updated (user-visible changes only; skip for internal/ci/docs) — N/A, test-only change, `skip-changelog` label applied
- [x] PR title starts with a Conventional Commit prefix (`security:`)
- [x] PR has a label recognised by `.github/release.yml` (applied automatically via `pr-release-label.yml`)
- [x] `strings.json` and `translations/en.json` are still identical (untouched)
- [x] No new category added
- [x] No blocking I/O introduced

Closes #379

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWHQ2ETPW5fbBR7ptgV9Cb)_