### PR TITLE
release: bump version to 2.1.0-pre1

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -28,5 +28,5 @@
       "modelDescription": "UniFi Dream Machine Pro Max"
     }
   ],
-  "version": "2.0.1"
+  "version": "2.1.0-pre1"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -2,6 +2,29 @@
 
 Dated record of completed work. Newest first. Format per entry: category, short description, PR or commit reference, short why.
 
+## 2026-08-21
+
+- **release**: v2.1.0-pre1 tagged. First checkpoint of the v2.1.0 "severity follow-through and test coverage" cycle: closes most of the #331 review follow-ups (config/options flow accessibility fixes, `severity.py` cleanup, a latent `from_dict` truncation bug), the deferred `_device_info()` duplication (issue #383), a regression test locking down webhook secret-leak safety (issue #379), and the remaining v2.1.0 test-coverage gaps for entity actions, webhook edge cases, and coordinator/service error handling. The "Test Webhook" button (issue #384) was descoped: its literal spec (a live button embedded in the options flow finish step) doesn't fit how HA config flows work, and the auto-clear timing needs more design thought. Issues #355, #356, #357, #385 remain open for the next checkpoint.
+- **feat**: restructured the config/options flow finish-step description into headed sections (Authentication, Legacy Method, Retrieve Later) and replaced per-category webhook URL form fields, which looked editable but silently discarded any edits, with plain-text placeholders; added help text for all 7 `min_severity_*` selectors on the categories step ([#405]). Closes #395, #354.
+- **security**: added a regression test asserting webhook error-log output never leaks the legacy `?token=` query string, across the malformed-body and auth-failure paths ([#407]). Closes #379.
+- **fix**: `UniFiAlert.from_dict()` now truncates `severity` to 32 characters, matching `from_webhook_payload()`/`from_api_alarm()`/`from_system_log_event()`; extracted the four duplicated `_device_info()` helpers into `entity_helpers.device_info_for_entry()` and centralised `UNIFI_OS_NETWORK_PREFIX` into `const.py` ([#409]). Closes #359, #383.
+- **chore**: cleaned up `severity.py`: removed the unused legacy-severity synonym table, added `Literal` type aliases for severity/minimum-severity strings, inlined `filter_by_min_severity()` to remove the `severity.py`/`models.py` import cycle, and trimmed over-dense comments ([#408]). Closes #351, #352, #358, #360.
+- **tests**: closed the remaining v2.1.0 test-coverage gaps: entity action coverage for `alert_received` events and button presses ([#401]), webhook body-size and malformed-JSON rejection ([#400]), and a webhook landing in the window between coordinator shutdown and webhook unregistration ([#402]). Closes #380, #381, #382.
+- **docs**: added v2.1.0/v2.2.0/v2.3.0 sections to `docs/ROADMAP.md` ([#398]); resolved a documentation conflict that described the `_device_info()` duplication as an intentional trade-off instead of scheduled work ([#399]); consolidated the day's `CHANGELOG.md` `[Unreleased]` entries ([#403]).
+- **ci**: hardened Python 3.14 provisioning to use `uv` when the CI base image doesn't already have it available ([#404]).
+
+[#398]: https://github.com/PHeonix25/unifi_alerts/pull/398
+[#399]: https://github.com/PHeonix25/unifi_alerts/pull/399
+[#400]: https://github.com/PHeonix25/unifi_alerts/pull/400
+[#401]: https://github.com/PHeonix25/unifi_alerts/pull/401
+[#402]: https://github.com/PHeonix25/unifi_alerts/pull/402
+[#403]: https://github.com/PHeonix25/unifi_alerts/pull/403
+[#404]: https://github.com/PHeonix25/unifi_alerts/pull/404
+[#405]: https://github.com/PHeonix25/unifi_alerts/pull/405
+[#407]: https://github.com/PHeonix25/unifi_alerts/pull/407
+[#408]: https://github.com/PHeonix25/unifi_alerts/pull/408
+[#409]: https://github.com/PHeonix25/unifi_alerts/pull/409
+
 ## 2026-07-24
 
 - **release**: v2.0.1 stable. Critical hotfix promoted straight to `main` as a patch release, shipping the single fix below.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-07-24):** v2.0.0 (HACS default catalogue) shipped stable on 2026-07-24; the umbrella submission issue (#143) is closed and a PR is open against `hacs/default`. A same-day v2.0.1 patch release followed, fixing the min_severity selector rendering as an untranslated radio-button list instead of a dropdown (#375). The next cycle (v2.1.0) is already seeded with review follow-ups from the severity-filtering feature (#331): UI copy, a diagnostic trail for filtered alerts, and several `severity.py` cleanups. Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
+> **Status (2026-08-21):** v2.1.0-pre1 tagged, the first checkpoint of the v2.1.0 cycle. Closed: most of the #331 review follow-ups (UI copy, `severity.py` cleanups, config/options flow accessibility fixes), the `_device_info()` extraction (#383), a webhook secret-leak regression test (#379), and the remaining entity/webhook/coordinator test-coverage gaps (#380, #381, #382). Descoped: the "Test Webhook" button (#384), whose literal spec doesn't fit HA's config-flow architecture. Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
 
 > **Branching model:** see `CLAUDE.md § Branching and releasing`.
 
@@ -10,9 +10,9 @@ What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `
 
 ## v2.1.0 - Severity follow-through and test coverage
 
-Finish the severity-filtering feature started in #331 and close the test gaps on the paths users depend on most. Adds the first way to verify a webhook setup without waiting for a real alert.
+First checkpoint (v2.1.0-pre1) closed most of the #331 review follow-ups (`severity.py` cleanups, the min_severity UI copy, config/options flow accessibility fixes), the extracted `_device_info()` helper (#383), a latent `from_dict` severity-truncation fix (#359), a webhook secret-leak regression test (#379), and the remaining entity/webhook/coordinator test-coverage gaps (#380, #381, #382). The "Test Webhook" button (#384) was descoped: a live button embedded in the options flow finish step doesn't fit how HA config flows work, and the 30-second auto-clear timing needs more design thought than a first pass gave it.
 
-Main threads: the #331 review follow-ups (UI copy, filtered-alert diagnostics, `severity.py` cleanups), coverage for entity actions, webhook edge cases and coordinator/service error handling, a send-test-alert button, and the config flow accessibility blockers.
+Remaining threads: surfacing `severity_level` as an entity attribute (#356), a diagnostic trail for silently-filtered alerts (#357), a non-No_Filter default `min_severity` for chatty categories (#355, wants a product decision before implementation), and entity state/attribute test coverage (#385).
 
 ## v2.2.0 - Structural simplification
 


### PR DESCRIPTION
## Summary

First pre-release checkpoint of the v2.1.0 cycle. Bumps `manifest.json` from `2.0.1` to `2.1.0-pre1` (`scripts/bump_version.py --next-cycle`, since `dev` never got a `2.1.0-pre1` bump when v2.0.1 shipped — this catches it up in one step) and records the work already merged to `dev` since v2.0.1.

## Changes

- `custom_components/unifi_alerts/manifest.json`: version `2.0.1` -> `2.1.0-pre1`.
- `docs/HISTORY.md`: added the `## 2026-08-21` block covering the 11 PRs merged to `dev` since v2.0.1 (#398-#405, #407-#409): the `#331` review follow-ups (config/options flow accessibility, `severity.py` cleanup, a latent `from_dict` truncation fix), the `_device_info()` extraction (#383), a webhook secret-leak regression test (#379), the remaining v2.1.0 test-coverage gaps, and CI/docs housekeeping.
- `docs/ROADMAP.md`: updated the status line and trimmed the v2.1.0 section down to what's actually still open (#355, #356, #357, #385) now that most of the cycle's threads have landed. Noted that the "Test Webhook" button (#384) was descoped rather than implemented — its literal spec (a live button inside the options flow finish step) doesn't fit how HA config/options flows work, and the issue was closed `not_planned`.

Note: `git describe --tags` on `dev` resolves to `v2.0.0-pre2`, not `v2.0.1` — `v2.0.1` was tagged on a `main`-side merge commit that isn't in `dev`'s own ancestry, a quirk of the merge-commit release flow rather than a real gap. The HISTORY.md merge list above was built directly from `git log <v2.0.1-content-commit>..origin/dev`, not from the script's own (misleading, in this one case) tag lookup.

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

This sandbox's `python3.14` (uv-provisioned, per #404) is `3.14.0rc2`; `homeassistant==2026.7.1` requires `>=3.14.2`, which isn't yet available from uv's `python-build-standalone` index here, so the `test`/`typecheck` legs of `make check` could not be run locally (same limitation noted in #405). What I did run locally, all passing:
- `make doc-check` (docs prose linter, translation parity, agentrc ref check)
- `scripts/validate_hacs.py` (HACS manifest preflight, since `manifest.json` changed)
- `ruff check .` / `ruff format --check .` — no new findings; the pre-existing findings are all in `scripts/` files this PR does not touch

CI is authoritative for `mypy`/`pytest` on this PR.

## Checklist

- [x] Linked the issue this PR resolves (n/a — a version-bump PR, not tied to a single issue)
- [ ] `make check` passes locally (`test`/`typecheck` legs blocked by sandbox Python 3.14.0rc2 vs `homeassistant`'s `>=3.14.2` floor; CI authoritative)
- [x] `CHANGELOG.md` `[Unreleased]` updated (n/a for pre-release bumps — `CHANGELOG.md` is only touched on stable promotion, per `docs/RELEASING.md`)
- [x] PR title starts with a Conventional Commit prefix (`release:`)
- [ ] PR has a label recognised by `.github/release.yml` (`release:` isn't auto-mapped by `pr-release-label.yml`; will apply `chore` by hand after opening)
- [x] `strings.json` and `translations/en.json` are still identical (neither touched)
- [x] New category fully registered (n/a, no category added)
- [x] No blocking I/O introduced (docs/manifest only)

## After merge

```bash
git checkout dev && git pull origin dev
git tag v2.1.0-pre1 && git push origin v2.1.0-pre1
```
GitHub Actions creates the pre-release automatically once the tag is pushed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BmxHToQCGixHkfZVUog3bd)_