### PR TITLE
fix: accept v2 system-log transport when UniFi Network 10.6+ removes legacy alarm endpoints

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -61,9 +61,18 @@ body:
   - type: input
     id: controller
     attributes:
-      label: Controller model and firmware
-      description: e.g. "UDM-Pro firmware 4.0.21" or "UCG-Ultra firmware 3.2.7"
-      placeholder: "UDM-Pro firmware 4.0.21"
+      label: Controller model and UniFi OS version
+      description: e.g. "UDM-Pro, UniFi OS 4.0.21" or "UCG-Ultra, UniFi OS 3.2.7". This is the UniFi OS/firmware version shown on the console's login screen or Settings → System, not the Network application version below — the two version numbers are independent and both matter for diagnosing controller-firmware bugs.
+      placeholder: "UDM-Pro, UniFi OS 4.0.21"
+    validations:
+      required: true
+
+  - type: input
+    id: network_app_version
+    attributes:
+      label: UniFi Network application version
+      description: From Settings → System → About, or the version shown next to "UniFi Network" in the app switcher. Distinct from the UniFi OS version above — e.g. a UDM on UniFi OS 5.1.26 can be running Network application 10.6.101. Needed to diagnose bugs specific to a Network application release (see issue #406).
+      placeholder: "10.6.101"
     validations:
       required: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Setup, credential rotation, and controller-URL changes no longer fail on UniFi Network 10.6+, which removed every legacy alarm endpoint. The config flow now accepts either the v2 system-log transport or the legacy alarm transport (`UniFiClient.validate_connectivity()`), instead of hard-requiring the now-removed legacy path. The failure was previously misreported as "Site not found" (`InvalidSiteError`); it is now correctly reported as a missing alarm endpoint (`AlarmEndpointUnavailableError`), and a genuine missing-site error is detected directly from the controller's `api.err.NoSiteContext` response rather than inferred by exhausting the probe chain. The coordinator also no longer falls back to a legacy path it has confirmed is dead, which previously took every entity unavailable for up to an hour on Network 10.6+ if the v2 probe hit a transient failure. ([#406])
+- v2 system-log event keys carrying a numeric variant suffix (e.g. `CLIENT_ROAMED_2`) are now matched to their base key (`CLIENT_ROAMED`) instead of missing the exact-match lookup and falling through to the coarse category fallback on every occurrence. ([#406])
+- A rejected API key is no longer misreported as a successful login: UniFi Network returns HTTP 200 with `meta.rc: "error"` for some rejected-key cases, which `_verify_api_key()` previously did not check. ([#406])
 - `UniFiAlert.from_dict()` now truncates `severity` to 32 characters, matching `from_webhook_payload()`, `from_api_alarm()`, and `from_system_log_event()`. Previously an oversized `severity` value restored from the persisted Store could exceed the length applied everywhere else. ([#359])
 
 ### Documentation
@@ -407,4 +410,5 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#358]: https://github.com/PHeonix25/unifi_alerts/issues/358
 [#360]: https://github.com/PHeonix25/unifi_alerts/issues/360
 [#359]: https://github.com/PHeonix25/unifi_alerts/issues/359
+[#406]: https://github.com/PHeonix25/unifi_alerts/issues/406
 [#383]: https://github.com/PHeonix25/unifi_alerts/issues/383

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ See [docs/EXAMPLES.md](docs/EXAMPLES.md) for a working example of each: a Lovela
 | UDM-SE | 4.0.x | Reported by users |
 | UCG-Max | 4.0.x | Reported by users |
 | Cloud Key Gen2+ | 4.0.x | Reported by users |
-| UDM / UDM-Pro | 4.0.x | Should work; not yet reported |
+| UDM / UDM-Pro | 5.1.x | Reported by users |
+| Any UniFi OS console | Network 10.6+ | Confirmed on a UCG-Ultra (Network 10.6.101), UDM (UniFi OS 5.1.26), and UDM-Pro (UniFi OS 5.1.31 / Network 10.6.101). Network 10.6 removed every legacy alarm endpoint; the integration falls back to the v2 system-log API automatically ([#406](https://github.com/PHeonix25/unifi_alerts/issues/406)) |
 
 If your model is not listed, open an [issue](https://github.com/PHeonix25/unifi_alerts/issues) with controller model and firmware so we can grow this table.
 
@@ -100,8 +101,8 @@ An API key is required; the integration no longer supports username/password aut
 
 | Firmware / UI version | Path |
 |---|---|
-| Network Application 8.x+ | **Settings > Admins & Users > API Keys > Create** |
-| Some UCG / UDM firmware | **Integrations > API > New API Key** |
+| Network Application 9.x+ (including 10.6+) | **Integrations > API > New API Key** |
+| Network Application 8.x | **Settings > Admins & Users > API Keys > Create** |
 | Older Cloud Key Gen2+ | **Settings > Control Plane > API Keys** |
 
 The key is shown only once at creation - copy it immediately.

--- a/custom_components/unifi_alerts/__init__.py
+++ b/custom_components/unifi_alerts/__init__.py
@@ -21,7 +21,9 @@ from .const import (
     ALL_CATEGORIES,
     CONF_API_KEY,
     CONF_CONTROLLER_URL,
+    CONF_SITE,
     CONF_VERIFY_SSL,
+    DEFAULT_SITE,
     DEFAULT_VERIFY_SSL,
     DOMAIN,
     EXCEPTION_SETUP_AUTH_FAILED,
@@ -160,6 +162,21 @@ def _prune_disabled_category_entities(
             registry.async_remove(reg_entry.entity_id)
 
 
+async def _log_controller_version(client: UniFiClient, entry: ConfigEntry) -> None:
+    """Best-effort: log the Network application version at setup.
+
+    Distinct from the UniFi OS version, and easy to omit from a bug report
+    since only the UniFi OS version is visible on the console login screen.
+    Never blocks setup (#406).
+    """
+    site = entry.data.get(CONF_SITE, DEFAULT_SITE)
+    controller_version = await client.fetch_controller_version(site)
+    if controller_version:
+        _LOGGER.info("UniFi Network application version: %s", controller_version)
+    else:
+        _LOGGER.debug("Could not determine the UniFi Network application version at setup")
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up UniFi Alerts from a config entry."""
     verify_ssl: bool = entry.data.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
@@ -196,6 +213,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             translation_key=EXCEPTION_SETUP_CANNOT_CONNECT,
             translation_placeholders={"error": type(err).__name__},
         ) from err
+
+    await _log_controller_version(client, entry)
 
     # Proactively register the hub device so it appears in HA's Services section
     # immediately after setup — before any entity is registered.

--- a/custom_components/unifi_alerts/config_flow.py
+++ b/custom_components/unifi_alerts/config_flow.py
@@ -60,7 +60,7 @@ from .severity import (
     SEVERITY_VERY_HIGH,
 )
 from .unifi_auth import CannotConnectError, InvalidAuthError, SslCertificateError
-from .unifi_client import InvalidSiteError, UniFiClient
+from .unifi_client import AlarmEndpointUnavailableError, InvalidSiteError, UniFiClient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -209,11 +209,14 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                 client = UniFiClient(session, url, cast(UniFiClientConfig, user_input))
                 try:
                     await client.authenticate()
-                    await client.fetch_alarms()  # validate alarm endpoint reachable
+                    await client.validate_connectivity()  # v2 or legacy alarm transport reachable
                 except InvalidAuthError:
                     errors["base"] = "invalid_auth"
                 except SslCertificateError:
                     errors[CONF_CONTROLLER_URL] = "invalid_ssl_cert"
+                except AlarmEndpointUnavailableError as err:
+                    _LOGGER.error("No alarm endpoint reachable: %s", err)
+                    errors["base"] = "alarm_endpoint_unavailable"
                 except CannotConnectError as err:
                     _LOGGER.error("Cannot reach alarm endpoint: %s", err)
                     errors["base"] = "cannot_connect"
@@ -341,9 +344,12 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                     )
                     try:
                         await client.authenticate()
-                        await client.fetch_alarms(site)
+                        await client.validate_connectivity(site)
                     except InvalidSiteError:
                         errors[CONF_SITE] = "invalid_site"
+                    except AlarmEndpointUnavailableError as err:
+                        _LOGGER.error("No alarm endpoint reachable for site %r: %s", site, err)
+                        errors["base"] = "alarm_endpoint_unavailable"
                     except (InvalidAuthError, CannotConnectError) as err:
                         _LOGGER.error("Cannot validate site %r during setup: %s", site, err)
                         errors["base"] = "cannot_connect"
@@ -538,6 +544,9 @@ class UniFiAlertsConfigFlow(ConfigFlow, domain=DOMAIN):
                     errors["base"] = "invalid_auth"
                 except SslCertificateError:
                     errors["base"] = "invalid_ssl_cert"
+                except AlarmEndpointUnavailableError as err:
+                    _LOGGER.error("No alarm endpoint reachable during reconfigure: %s", err)
+                    errors["base"] = "alarm_endpoint_unavailable"
                 except CannotConnectError as err:
                     _LOGGER.error("Cannot reach controller during reconfigure: %s", err)
                     errors["base"] = "cannot_connect"
@@ -709,16 +718,17 @@ async def _async_validate_controller_credentials(
     hass: Any, url: str, verify_ssl: bool, test_data: dict[str, Any]
 ) -> None:
     """Instantiate a UniFiClient and validate it can authenticate and reach
-    the alarm endpoint.
+    a v2 or legacy alarm transport.
 
     `InvalidAuthError`, `SslCertificateError`, and `CannotConnectError`
-    propagate unchanged so the caller classifies them into its `errors` dict —
-    this function does not know about the options-flow error-key mapping.
+    (including its `AlarmEndpointUnavailableError` subclass) propagate
+    unchanged so the caller classifies them into its `errors` dict — this
+    function does not know about the options-flow error-key mapping.
     """
     session = async_get_clientsession(hass, verify_ssl=verify_ssl)
     client = UniFiClient(session, url, cast(UniFiClientConfig, test_data))
     await client.authenticate()
-    await client.fetch_alarms()
+    await client.validate_connectivity()
 
 
 class UniFiAlertsOptionsFlow(OptionsFlow):
@@ -789,6 +799,9 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
                     errors["base"] = "invalid_auth"
                 except SslCertificateError:
                     errors["base"] = "invalid_ssl_cert"
+                except AlarmEndpointUnavailableError as err:
+                    _LOGGER.error("No alarm endpoint reachable during options update: %s", err)
+                    errors["base"] = "alarm_endpoint_unavailable"
                 except CannotConnectError as err:
                     _LOGGER.error("Cannot reach controller during options update: %s", err)
                     errors["base"] = "cannot_connect"
@@ -855,9 +868,12 @@ class UniFiAlertsOptionsFlow(OptionsFlow):
                     client = UniFiClient(session, controller_url, cast(UniFiClientConfig, creds))
                     try:
                         await client.authenticate()
-                        await client.fetch_alarms(site)
+                        await client.validate_connectivity(site)
                     except InvalidSiteError:
                         errors[CONF_SITE] = "invalid_site"
+                    except AlarmEndpointUnavailableError as err:
+                        _LOGGER.error("No alarm endpoint reachable for site %r: %s", site, err)
+                        errors["base"] = "alarm_endpoint_unavailable"
                     except (InvalidAuthError, CannotConnectError) as err:
                         _LOGGER.error(
                             "Cannot validate site %r during options update: %s", site, err

--- a/custom_components/unifi_alerts/const.py
+++ b/custom_components/unifi_alerts/const.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Final
 
 DOMAIN = "unifi_alerts"
@@ -334,17 +335,30 @@ def webhook_id_for_category(category: str, suffix: str = "") -> str:
     return f"{WEBHOOK_ID_PREFIX}{category}"
 
 
+# Real v2 system-log payloads carry numeric-variant keys for the same event
+# (e.g. "key": "CLIENT_ROAMED_2" alongside "event": "CLIENT_ROAMED") — field-
+# confirmed (#406). SYSTEM_LOG_KEY_TO_CATEGORY is exact-match, so the suffixed
+# variant otherwise misses, falls through to the coarse enum fallback, and is
+# logged as an undocumented key on every occurrence.
+_TRAILING_NUMERIC_SUFFIX = re.compile(r"_\d+$")
+
+
 def classify_event_key(key: str, v2_category_enum: str = "") -> str:
     """Map a UniFi event key to an integration category string.
 
     Checks (in order):
     1. Exact match in SYSTEM_LOG_KEY_TO_CATEGORY (v2 system-log flat keys)
-    2. Prefix match in UNIFI_KEY_TO_CATEGORY (legacy EVT_* keys)
-    3. Broad enum fallback via SYSTEM_LOG_CATEGORY_FALLBACK (v2 category field)
+    2. The same lookup with a trailing numeric variant suffix stripped
+       (e.g. "CLIENT_ROAMED_2" -> "CLIENT_ROAMED")
+    3. Prefix match in UNIFI_KEY_TO_CATEGORY (legacy EVT_* keys)
+    4. Broad enum fallback via SYSTEM_LOG_CATEGORY_FALLBACK (v2 category field)
 
     Returns "" when no match is found.
     """
     if result := SYSTEM_LOG_KEY_TO_CATEGORY.get(key):
+        return result
+    stripped = _TRAILING_NUMERIC_SUFFIX.sub("", key)
+    if stripped != key and (result := SYSTEM_LOG_KEY_TO_CATEGORY.get(stripped)):
         return result
     for prefix, category in UNIFI_KEY_TO_CATEGORY.items():
         if key.startswith(prefix):

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -36,7 +36,7 @@ from .const import (
 from .models import CategoryState, UniFiAlert, UniFiClientConfig, ensure_aware
 from .severity import get_effective_min_severity, meets_minimum
 from .unifi_auth import CannotConnectError, InvalidAuthError
-from .unifi_client import UniFiClient
+from .unifi_client import AlarmEndpointUnavailableError, UniFiClient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -232,6 +232,13 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
           - the probe returns False (404, or repeated transient failures past backoff)
           - the probe itself raises a network error (logged at DEBUG)
           - this is an older controller without the v2 endpoint
+
+        Never falls back to the legacy path once the client has confirmed it
+        does not exist on this firmware (UniFi Network 10.6+ removed every
+        legacy alarm path, #406): that would fail every poll for the
+        _PROBE_RETRY_AFTER backoff window even though v2 works fine. Instead,
+        try v2 immediately here too — either because the probe already knows
+        this, or because legacy categorise_alarms() just found out.
         """
         try:
             has_v2 = await self._probe_has_system_log()
@@ -245,11 +252,22 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
             )
             has_v2 = False
 
-        if not has_v2:
-            result = await self._client.categorise_alarms(self._site)
-            for key, count in self._client.unrecognised_keys.items():
-                self._unrecognised_keys[key] = self._unrecognised_keys.get(key, 0) + count
-            return result
+        use_legacy = not has_v2 and not self._client.legacy_alarm_endpoint_confirmed_unavailable(
+            self._site
+        )
+        if use_legacy:
+            try:
+                result = await self._client.categorise_alarms(self._site)
+            except AlarmEndpointUnavailableError:
+                _LOGGER.debug(
+                    "Legacy alarm endpoint confirmed unavailable for site %s; "
+                    "using v2 system-log for this and future polls",
+                    self._site,
+                )
+            else:
+                for key, count in self._client.unrecognised_keys.items():
+                    self._unrecognised_keys[key] = self._unrecognised_keys.get(key, 0) + count
+                return result
 
         # v2 path: compute the oldest watermark across enabled categories so we
         # fetch everything since the oldest unacknowledged window. Clamp to
@@ -455,6 +473,20 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
     @property
     def rollup_open_count(self) -> int:
         return sum(s.open_count for s in self._category_states.values() if s.enabled)
+
+    @property
+    def resolved_transport(self) -> str:
+        """Best-known alarm transport for this site, for diagnostics (#406).
+
+        "v2" once the system-log probe has confirmed it; "legacy" once
+        discovery has cached a working legacy alarm URL; "unknown" before
+        either has happened (e.g. the very first poll has not completed).
+        """
+        if self._has_system_log:
+            return "v2"
+        if self._client.discovered_alarm_url(self._site) is not None:
+            return "legacy"
+        return "unknown"
 
     @property
     def unrecognised_keys(self) -> dict[str, int]:

--- a/custom_components/unifi_alerts/diagnostics.py
+++ b/custom_components/unifi_alerts/diagnostics.py
@@ -10,7 +10,9 @@ from homeassistant.core import HomeAssistant
 
 from .const import (
     CONF_API_KEY,
+    CONF_SITE,
     CONF_WEBHOOK_SECRET,
+    DEFAULT_SITE,
 )
 
 _TO_REDACT: set[str] = {CONF_API_KEY, CONF_WEBHOOK_SECRET}
@@ -27,6 +29,8 @@ async def async_get_config_entry_diagnostics(
     """
     runtime_data = getattr(entry, "runtime_data", None)
     coordinator = runtime_data.coordinator if runtime_data is not None else None
+    client = runtime_data.client if runtime_data is not None else None
+    site = entry.data.get(CONF_SITE, DEFAULT_SITE)
     # register_all() no longer embeds the bearer secret in these URLs (#176),
     # so no redaction is needed before including them in shared diagnostics.
     webhook_urls: dict[str, str] = (
@@ -58,6 +62,9 @@ async def async_get_config_entry_diagnostics(
             "unrecognised_keys": dict(
                 sorted(coordinator.unrecognised_keys.items(), key=lambda kv: kv[1], reverse=True)
             ),
+            # Alarm transport, endpoint, and controller version — the fields the
+            # #406 setup failure was missing from every early bug report (#406).
+            "resolved_transport": coordinator.resolved_transport,
             # Per-category alert content (message, device_name, last_alert.raw) is
             # intentionally excluded. Those fields carry controller-supplied strings
             # that may contain client hostnames, MAC addresses, or IP addresses and
@@ -68,9 +75,15 @@ async def async_get_config_entry_diagnostics(
     else:
         coordinator_info = {}
 
+    controller_info: dict[str, Any] = {
+        "discovered_alarm_url": client.discovered_alarm_url(site) if client is not None else None,
+        "controller_version": client.controller_version if client is not None else None,
+    }
+
     return {
         "config_entry": async_redact_data(dict(entry.data), _TO_REDACT),
         "options": async_redact_data(dict(entry.options), _TO_REDACT),
         "webhook_urls": webhook_urls,
         "coordinator": coordinator_info,
+        "controller": controller_info,
     }

--- a/custom_components/unifi_alerts/strings.json
+++ b/custom_components/unifi_alerts/strings.json
@@ -75,7 +75,8 @@
       "invalid_ssl_cert": "SSL certificate verification failed. If this controller uses a self-signed certificate, untick \"Verify SSL certificate\" and try again.",
       "invalid_url_scheme": "Controller URL must start with http:// or https://.",
       "at_least_one_category": "Please enable at least one alert category.",
-      "invalid_site": "Site not found on the controller. Check the site name (the URL slug, not the display name). The default single-site name is 'default'."
+      "invalid_site": "Site not found on the controller. Check the site name (the URL slug, not the display name). The default single-site name is 'default'.",
+      "alarm_endpoint_unavailable": "This controller's firmware no longer exposes a compatible alarm endpoint (UniFi Network 10.6 and later removed the legacy alarm API). The integration needs the newer system-log API; check that the API key has permission to read it and that the controller has finished upgrading."
     },
     "abort": {
       "already_configured": "This UniFi controller is already configured.",
@@ -232,7 +233,8 @@
       "invalid_ssl_cert": "SSL certificate verification failed. If this controller uses a self-signed certificate, untick \"Verify SSL certificate\" and try again.",
       "invalid_url_scheme": "Controller URL must start with http:// or https://.",
       "at_least_one_category": "Please enable at least one alert category.",
-      "invalid_site": "Site not found on the controller. Check the site name (the URL slug, not the display name). The default single-site name is 'default'."
+      "invalid_site": "Site not found on the controller. Check the site name (the URL slug, not the display name). The default single-site name is 'default'.",
+      "alarm_endpoint_unavailable": "This controller's firmware no longer exposes a compatible alarm endpoint (UniFi Network 10.6 and later removed the legacy alarm API). The integration needs the newer system-log API; check that the API key has permission to read it and that the controller has finished upgrading."
     },
     "step": {
       "credentials": {

--- a/custom_components/unifi_alerts/translations/en.json
+++ b/custom_components/unifi_alerts/translations/en.json
@@ -75,7 +75,8 @@
       "invalid_ssl_cert": "SSL certificate verification failed. If this controller uses a self-signed certificate, untick \"Verify SSL certificate\" and try again.",
       "invalid_url_scheme": "Controller URL must start with http:// or https://.",
       "at_least_one_category": "Please enable at least one alert category.",
-      "invalid_site": "Site not found on the controller. Check the site name (the URL slug, not the display name). The default single-site name is 'default'."
+      "invalid_site": "Site not found on the controller. Check the site name (the URL slug, not the display name). The default single-site name is 'default'.",
+      "alarm_endpoint_unavailable": "This controller's firmware no longer exposes a compatible alarm endpoint (UniFi Network 10.6 and later removed the legacy alarm API). The integration needs the newer system-log API; check that the API key has permission to read it and that the controller has finished upgrading."
     },
     "abort": {
       "already_configured": "This UniFi controller is already configured.",
@@ -232,7 +233,8 @@
       "invalid_ssl_cert": "SSL certificate verification failed. If this controller uses a self-signed certificate, untick \"Verify SSL certificate\" and try again.",
       "invalid_url_scheme": "Controller URL must start with http:// or https://.",
       "at_least_one_category": "Please enable at least one alert category.",
-      "invalid_site": "Site not found on the controller. Check the site name (the URL slug, not the display name). The default single-site name is 'default'."
+      "invalid_site": "Site not found on the controller. Check the site name (the URL slug, not the display name). The default single-site name is 'default'.",
+      "alarm_endpoint_unavailable": "This controller's firmware no longer exposes a compatible alarm endpoint (UniFi Network 10.6 and later removed the legacy alarm API). The integration needs the newer system-log API; check that the API key has permission to read it and that the controller has finished upgrading."
     },
     "step": {
       "credentials": {

--- a/custom_components/unifi_alerts/unifi_auth.py
+++ b/custom_components/unifi_alerts/unifi_auth.py
@@ -15,6 +15,7 @@ no real gain and lose the isolated test surface in ``test_unifi_auth.py``.
 
 from __future__ import annotations
 
+import json
 import logging
 
 import aiohttp
@@ -118,6 +119,19 @@ class UniFiAuth:
                     )
                     raise InvalidAuthError("Invalid API key", login_url=endpoint)
                 resp.raise_for_status()
+                # UniFi returns HTTP 200 even for a rejected key; the envelope's
+                # meta.rc is the only reliable signal (#406). Checking status
+                # alone lets a rejected key be reported as a successful login.
+                try:
+                    body = await resp.json(content_type=None)
+                except json.JSONDecodeError, UnicodeDecodeError:
+                    body = {}
+                if body.get("meta", {}).get("rc") != "ok":
+                    msg = body.get("meta", {}).get("msg", "unknown error")
+                    _LOGGER.warning(
+                        "API key rejected for %s (HTTP 200, meta.rc=error: %s)", endpoint, msg
+                    )
+                    raise InvalidAuthError(f"Invalid API key ({msg})", login_url=endpoint)
         except CannotConnectError, InvalidAuthError:
             raise
         except aiohttp.ClientConnectorCertificateError as err:

--- a/custom_components/unifi_alerts/unifi_client.py
+++ b/custom_components/unifi_alerts/unifi_client.py
@@ -30,7 +30,26 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class InvalidSiteError(CannotConnectError):
-    """Raised when the site name does not exist on the controller."""
+    """Raised when the site name does not exist on the controller.
+
+    Reserved for a genuine site miss: HTTP 401 + ``api.err.NoSiteContext``
+    from the controller, or a site name absent from ``GET /api/self/sites``
+    (see ``validate_connectivity``). A firmware that has simply removed the
+    legacy alarm paths (UniFi Network 10.6+) is not a site error — that is
+    ``AlarmEndpointUnavailableError`` (#406).
+    """
+
+
+class AlarmEndpointUnavailableError(CannotConnectError):
+    """Raised when no alarm endpoint this integration knows about is reachable.
+
+    UniFi Network 10.6 removed every legacy alarm path (``/list/alarm``,
+    ``/alarm``, ``/stat/alarm``); only the v2 ``system-log`` API remains.
+    Distinct from ``InvalidSiteError`` — the site and API key are both
+    valid here, the firmware simply no longer exposes a compatible alarm
+    endpoint. ``validate_connectivity`` is the setup-time check that treats
+    this as recoverable (fall through to v2) rather than fatal.
+    """
 
 
 class UniFiClient:
@@ -70,8 +89,60 @@ class UniFiClient:
         # site. Cleared if the cached URL later stops resolving (e.g. a
         # firmware upgrade removes/moves the path) so discovery runs again.
         self._alarm_url_cache: dict[str, str] = {}
+        # Set per site the first time _discover_alarm_url() exhausts the
+        # legacy probe chain (UniFi Network 10.6+ has removed every legacy
+        # alarm path). In-memory only, no config-entry migration — lets the
+        # coordinator stop retrying a path it already knows is dead instead
+        # of failing every poll until the v2-probe backoff window expires (#406).
+        self._legacy_confirmed_unavailable: dict[str, bool] = {}
+        # Network application version, fetched by fetch_controller_version()
+        # at setup and surfaced in diagnostics.py so the next firmware-specific
+        # bug report carries the Network application version, not just the
+        # UniFi OS version (#406).
+        self._controller_version: str | None = None
 
     # ── Public interface ──────────────────────────────────────────────────
+
+    @property
+    def controller_version(self) -> str | None:
+        """Network application version last fetched by fetch_controller_version(), if any."""
+        return self._controller_version
+
+    def discovered_alarm_url(self, site: str) -> str | None:
+        """Return the cached legacy alarm URL for `site`, if discovery has found one."""
+        return self._alarm_url_cache.get(site)
+
+    async def fetch_controller_version(self, site: str = "default") -> str | None:
+        """Fetch and cache the Network application version from stat/sysinfo.
+
+        Best-effort and diagnostic only (#406): failure here must never block
+        setup, so any error is swallowed and logged at DEBUG, returning None
+        (or the previously cached value, if one exists).
+        """
+        url = f"{self._base}{UNIFI_OS_NETWORK_PREFIX}/api/s/{site}/stat/sysinfo"
+        try:
+            async with self._session.get(
+                url,
+                headers=self._auth.headers(),
+                ssl=self._config.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+                timeout=aiohttp.ClientTimeout(total=10),
+                allow_redirects=False,
+            ) as resp:
+                if resp.status != 200:
+                    _LOGGER.debug(
+                        "Could not fetch controller version from %s (HTTP %d)", url, resp.status
+                    )
+                    return self._controller_version
+                body = await resp.json(content_type=None)
+        except (aiohttp.ClientError, json.JSONDecodeError, UnicodeDecodeError) as err:
+            _LOGGER.debug("Could not fetch controller version from %s: %s", url, err)
+            return self._controller_version
+
+        data = body.get("data") or []
+        version = data[0].get("version") if data else None
+        if version:
+            self._controller_version = str(version)
+        return self._controller_version
 
     async def authenticate(self) -> None:
         """Verify the configured API key against the UniFi OS controller.
@@ -80,6 +151,65 @@ class UniFiClient:
         means for API-key auth.
         """
         await self._auth.authenticate()
+
+    async def validate_connectivity(self, site: str = "default") -> str:
+        """Determine which transport reaches alarms for `site`: "v2" or "legacy".
+
+        Tries the v2 ``system-log/count`` probe first so a modern controller
+        (UniFi Network 10.6+, which has removed every legacy alarm path)
+        succeeds without ever touching the dead legacy chain. Falls back to
+        the legacy alarm-path chain for older controllers. Only raises
+        ``AlarmEndpointUnavailableError`` when neither transport is
+        reachable and the site itself is confirmed valid; raises
+        ``InvalidSiteError`` instead when `site` genuinely does not exist,
+        either signalled directly by the controller (``api.err.NoSiteContext``)
+        or confirmed against ``GET /api/self/sites`` (#406).
+        """
+        if await self.probe_system_log_endpoint(site):
+            return "v2"
+        try:
+            await self.fetch_alarms(site)
+        except AlarmEndpointUnavailableError:
+            if await self._site_exists(site):
+                raise
+            raise InvalidSiteError(f"Site '{site}' not found on the controller.") from None
+        else:
+            return "legacy"
+
+    def legacy_alarm_endpoint_confirmed_unavailable(self, site: str) -> bool:
+        """Return True once discovery has confirmed no legacy alarm endpoint exists for `site`.
+
+        Learned the first time ``_discover_alarm_url`` exhausts the probe
+        chain for this site. The coordinator consults this to avoid
+        re-probing a path it already knows is dead (#406).
+        """
+        return self._legacy_confirmed_unavailable.get(site, False)
+
+    async def _site_exists(self, site: str) -> bool:
+        """Check whether `site` is a real site name on the controller.
+
+        Calls ``GET /api/self/sites`` and matches the `name` field — the
+        same identifier used in the legacy ``/api/s/<site>/`` URL segment.
+        Any failure to reach or parse this endpoint is treated as "cannot
+        confirm the site is missing" so a transient network blip is never
+        misreported as InvalidSiteError.
+        """
+        url = f"{self._base}{UNIFI_OS_NETWORK_PREFIX}/api/self/sites"
+        try:
+            async with self._session.get(
+                url,
+                headers=self._auth.headers(),
+                ssl=self._config.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+                timeout=aiohttp.ClientTimeout(total=10),
+                allow_redirects=False,
+            ) as resp:
+                if resp.status != 200:
+                    return True
+                data = await resp.json()
+        except aiohttp.ClientError, json.JSONDecodeError:
+            return True
+        sites: list[dict[str, Any]] = data.get("data", [])
+        return any(entry.get("name") == site for entry in sites)
 
     async def fetch_alarms(self, site: str = "default") -> list[dict[str, Any]]:
         """Return all unarchived alarms from the controller.
@@ -129,8 +259,11 @@ class UniFiClient:
                 self._alarm_url_cache[site] = path
                 return result
             # None means path not found (404 or api.err.InvalidObject) — try next
-        raise InvalidSiteError(
-            f"Site '{site}' not found on the controller. Tried: {', '.join(alarm_paths)}"
+        self._legacy_confirmed_unavailable[site] = True
+        raise AlarmEndpointUnavailableError(
+            f"No legacy alarm endpoint found for site '{site}'. This firmware has "
+            f"removed all legacy alarm paths (UniFi Network 10.6+); the integration "
+            f"needs the v2 system-log API instead. Tried: {', '.join(alarm_paths)}"
         )
 
     async def _try_fetch_alarms(self, url: str, site: str) -> list[dict[str, Any]] | None:
@@ -156,6 +289,15 @@ class UniFiClient:
                         "request; refusing to follow to protect credentials"
                     )
                 if resp.status == 401:
+                    unifi_msg = await self._parse_unifi_error_msg(resp, url)
+                    if unifi_msg == "api.err.NoSiteContext":
+                        # A genuinely missing site, not an auth failure — confirmed
+                        # across several upstream projects. Distinct from InvalidObject
+                        # below, which just means this particular path doesn't exist (#406).
+                        raise InvalidSiteError(
+                            f"Site '{site}' does not exist on the controller "
+                            "(api.err.NoSiteContext)"
+                        )
                     raise InvalidAuthError("API key rejected (HTTP 401)")
                 if resp.status == 404:
                     _LOGGER.debug("Alarm URL %s returned 404 — trying next URL", url)

--- a/docs/UNIFI.md
+++ b/docs/UNIFI.md
@@ -50,15 +50,17 @@ Prior versions also supported username/password (cookie-session) authentication,
 
 `GET /proxy/network/api/s/{site}/<path>`
 
-> **Path variation by firmware.** UniFi has changed the alarm path multiple times. The integration probes them newest-to-oldest so modern firmware succeeds in one call:
+> **Path variation by firmware, and removal on Network 10.6+.** UniFi has changed the alarm path multiple times, and **Network 10.6 removed all three of these legacy paths outright**: confirmed by direct probing of a UCG-Ultra on 10.6.101 and reproduced independently on a UDM (5.1.26) and a UDM-Pro (5.1.31 / 10.6.101) ([#406](https://github.com/PHeonix25/unifi_alerts/issues/406)). The integration probes them newest-to-oldest so pre-10.6 firmware succeeds in one call, then falls back to the v2 `system-log` API (see below) when none resolve:
 >
 > | Path | Era | Notes |
 > |---|---|---|
-> | `/list/alarm` | newest (UniFi Network 9.x+) | Tried first. Replaced `/stat/alarm` somewhere in the 9.x line. |
-> | `/alarm` | long-standing | Universal historical path; still present on most firmware. Tried second. |
-> | `/stat/alarm` | older intermediate | Some firmware exposes only this. Tried last. |
+> | `/list/alarm` | UniFi Network 9.x-10.5 | Tried first. Replaced `/stat/alarm` somewhere in the 9.x line. Removed in Network 10.6. |
+> | `/alarm` | long-standing | Universal historical path on pre-10.6 firmware. Tried second. Removed in Network 10.6. |
+> | `/stat/alarm` | older intermediate | Some firmware exposes only this. Tried last. Removed in Network 10.6. |
 >
-> A path that doesn't exist may return either 404 or `400 api.err.InvalidObject` depending on firmware; both are treated as "try the next path". A genuine 400 (e.g. wrong site name) is surfaced only after every path is exhausted.
+> A path that doesn't exist may return either 404 or `400 api.err.InvalidObject` depending on firmware; both are treated as "try the next path". On Network 10.6+ every path returns `400 api.err.InvalidObject`, so the chain always exhausts.
+>
+> A genuinely missing site is a distinct, earlier signal: HTTP 401 + `api.err.NoSiteContext` (not `InvalidObject`), surfaced immediately as `InvalidSiteError` rather than waiting for the chain to exhaust. Once the chain does exhaust with no site-miss signal, `unifi_client.py::_discover_alarm_url` raises `AlarmEndpointUnavailableError`: "this firmware exposes no alarm endpoint we know about", not a site or auth problem. `UniFiClient.validate_connectivity()` is the setup-time entry point that tries the v2 probe first and only falls back to this legacy chain (and only treats `AlarmEndpointUnavailableError` as fatal) when v2 is also unreachable, so a Network 10.6+ controller sets up successfully on the v2 path alone.
 >
 > This probe chain only runs on the first `fetch_alarms()` call for a site (or again later if the cached URL stops resolving, e.g. after a firmware upgrade): see `unifi_client.py::_discover_alarm_url`. Once a path resolves it is cached per site and reused directly on every subsequent poll, so the 404/`api.err.InvalidObject` fallback parsing does not run on every poll ([#239](https://github.com/PHeonix25/unifi_alerts/issues/239)).
 >
@@ -122,11 +124,15 @@ The controller returns HTTP 200 even for application-level errors. The `meta.rc`
 
 ## v2 system-log API (Network 9.x+)
 
-> **This is the correct modern polling path for UniFi OS consoles.** The legacy
-> `/list/alarm` endpoint has a hard 3000-record cap sorted oldest-first; on busy
-> controllers it returns no recent alarms at all. The v2 system-log API supports
-> timestamp-range filtering and real pagination. The integration must migrate to
-> this path for `open_count` to be reliable on high-volume installations.
+> **This is the correct modern polling path for UniFi OS consoles, and the
+> only path on Network 10.6+.** The legacy `/list/alarm` endpoint has a hard
+> 3000-record cap sorted oldest-first; on busy controllers it returns no
+> recent alarms at all, and Network 10.6 removed it (and every other legacy
+> alarm path) entirely ([#406](https://github.com/PHeonix25/unifi_alerts/issues/406)).
+> The v2 system-log API supports timestamp-range filtering and real
+> pagination. The integration must use this path for `open_count` to be
+> reliable on high-volume installations, and needs it outright on Network
+> 10.6+ controllers, where no legacy alarm endpoint exists to fall back to.
 
 ### Probe for v2 availability
 

--- a/docs/research/alert-endpoints.md
+++ b/docs/research/alert-endpoints.md
@@ -20,6 +20,7 @@ dead ends.
 | 2 | IPS events live at `/stat/ips/event`, not `/list/alarm` | Disproven | `/stat/ips/event` returns `api.err.NotFound`; `/list/alarm` contains `EVT_IPS_IpsAlert` with full payload. |
 | 3 | Today's alarms appear in `/list/alarm` but are below the watermark | Disproven | Field-confirmed: today's alarms do NOT appear in `/list/alarm` at all (3000-record cap). |
 | 4 | `/list/alarm` has a 3000-record cap sorted oldest-first | Confirmed | Both `/list/alarm` and `/rest/alarm` return the same 3000 records covering only the oldest end of the retention window; today's events are absent. Confirmed present via `/system-log/all`. |
+| 5 | Setup failure on Network 10.6 ("Site 'default' not found") is a genuine site error | Disproven | The site exists and the API key is valid (`GET /api/s/default/self` and `GET /api/self/sites` both succeed). Network 10.6 removed every legacy alarm path outright; every probed path returns `400 api.err.InvalidObject`, which the old code misreported as a missing site. A genuinely missing site returns `401 api.err.NoSiteContext` instead, confirmed across several upstream projects. See #406. |
 
 ## Endpoints probed
 
@@ -55,6 +56,46 @@ returned regardless:
 | `/proxy/network/v2/api/site/{site}/system-log/count` | POST | Returns category and event counts. Confirmed working. |
 | `/proxy/network/v2/api/site/{site}/system-log/all` | POST | Returns paginated events with timestamp filtering. Confirmed working. |
 | `/proxy/network/v2/api/site/{site}/system-log/critical` | POST | Returns `[]`. No events classified as "critical" on this controller. |
+
+## Network 10.6 legacy-endpoint removal (2026-08, issue #406)
+
+Follow-up field research against a UCG-Ultra upgraded from Network 10.5.67 to
+10.6.101 (`stat/sysinfo` reports `previous_version: 10.5.67`, which worked).
+Two independent reporters saw the same setup failure on a UDM (UniFi OS
+5.1.26) and a UDM-Pro (UniFi OS 5.1.31 / Network 10.6.101).
+
+Probe results on 10.6.101 with a valid API key:
+
+| Endpoint | Result |
+|---|---|
+| `GET /proxy/network/api/s/default/self` | 200 `rc: ok` |
+| `GET /proxy/network/api/self/sites` | 200, site `default` present |
+| `GET /proxy/network/api/s/default/list/alarm` | 400 `api.err.InvalidObject` |
+| `GET /proxy/network/api/s/default/alarm` | 400 `api.err.InvalidObject` |
+| `GET /proxy/network/api/s/default/stat/alarm` | 404 `api.err.NotFound` |
+| `GET /proxy/network/api/s/default/rest/alarm` | 400 `api.err.InvalidObject` |
+| `GET /proxy/network/api/s/default/cnt/alarm` | 400 `api.err.InvalidObject` |
+| `POST /proxy/network/v2/api/site/default/system-log/count` | 200 with data |
+| `POST /proxy/network/v2/api/site/default/system-log/all` | 200 with data |
+
+Conclusions:
+
+- The site exists and the API key is valid; the `InvalidSiteError` the
+  integration was raising was a misdiagnosis. A genuinely missing site
+  returns `401 api.err.NoSiteContext`, not `400 api.err.InvalidObject`.
+- No legacy alarm path survives on Network 10.6, on any of the three
+  controllers tested. The v2 `system-log` API is the only route; it works
+  with the same API key that the legacy paths reject.
+- `coordinator.py` already preferred v2 at runtime for existing installs, so
+  polling kept working through the upgrade. Only `config_flow.py` hard-gated
+  on the legacy path, which is why new setups and credential changes failed
+  while polling quietly kept working.
+- The coordinator's own v2-probe backoff (`_PROBE_FAIL_LIMIT` transient
+  failures pin `_has_system_log` to `False` for `_PROBE_RETRY_AFTER`) could
+  fall back to the now-dead legacy path and take every entity unavailable for
+  the full backoff window: a latent outage distinct from the setup failure.
+  Fixed by having the coordinator retry v2 instead of falling back once the
+  client has confirmed no legacy endpoint exists (#406).
 
 ## The 3000-record cap
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -101,6 +101,8 @@ def mock_unifi_client():
         instance.authenticate = AsyncMock(return_value=None)
         instance.categorise_alarms = AsyncMock(return_value={})
         instance.probe_system_log_endpoint = AsyncMock(return_value=False)
+        instance.legacy_alarm_endpoint_confirmed_unavailable = MagicMock(return_value=False)
+        instance.fetch_controller_version = AsyncMock(return_value=None)
         instance.close = AsyncMock()
         mock_cls.return_value = instance
         yield instance

--- a/tests/integration/test_apikey_migration.py
+++ b/tests/integration/test_apikey_migration.py
@@ -57,6 +57,8 @@ def _make_client_mock() -> MagicMock:
     instance.authenticate = AsyncMock(return_value=None)
     instance.categorise_alarms = AsyncMock(return_value={})
     instance.probe_system_log_endpoint = AsyncMock(return_value=False)
+    instance.legacy_alarm_endpoint_confirmed_unavailable = MagicMock(return_value=False)
+    instance.fetch_controller_version = AsyncMock(return_value=None)
     instance.close = AsyncMock()
     return instance
 

--- a/tests/unit/config_flow/test_discovery.py
+++ b/tests/unit/config_flow/test_discovery.py
@@ -236,7 +236,7 @@ async def test_user_step_carries_ssdp_serial_into_credentials() -> None:
     ):
         instance = mock_cls.return_value
         instance.authenticate = AsyncMock(return_value=None)
-        instance.fetch_alarms = AsyncMock(return_value=[])
+        instance.validate_connectivity = AsyncMock(return_value="v2")
 
         await flow.async_step_user(_VALID_INPUT)
 

--- a/tests/unit/config_flow/test_options_credentials.py
+++ b/tests/unit/config_flow/test_options_credentials.py
@@ -272,7 +272,7 @@ async def test_options_flow_saves_submitted_values() -> None:
     ):
         instance = mock_cls.return_value
         instance.authenticate = AsyncMock(return_value=None)
-        instance.fetch_alarms = AsyncMock(return_value=[])
+        instance.validate_connectivity = AsyncMock(return_value="v2")
         await flow.async_step_categories(user_input)
 
     # Submit finish -> creates entry
@@ -376,7 +376,7 @@ class TestOptionsFlowCredentials:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
 
             result = await flow.async_step_credentials(new_creds)
 
@@ -475,7 +475,7 @@ class TestOptionsFlowCredentials:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
             instance._is_unifi_os = False
 
             result = await flow.async_step_credentials(new_creds)
@@ -509,7 +509,7 @@ class TestOptionsFlowCredentials:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
             instance._is_unifi_os = True
 
             await flow.async_step_credentials(new_creds)
@@ -574,7 +574,7 @@ class TestOptionsFlowCredentials:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
             instance._is_unifi_os = False
             await flow.async_step_credentials(new_creds)
 
@@ -742,7 +742,7 @@ class TestOptionsCredentialsErrorsAndStaging:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
             result = await flow.async_step_credentials(user_input)
 
         assert result["step_id"] == "categories"

--- a/tests/unit/config_flow/test_options_helpers.py
+++ b/tests/unit/config_flow/test_options_helpers.py
@@ -411,7 +411,7 @@ class TestAsyncValidateControllerCredentials:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
 
             result = await _async_validate_controller_credentials(
                 MagicMock(), "https://10.0.0.1", True, {CONF_API_KEY: "key"}
@@ -420,7 +420,7 @@ class TestAsyncValidateControllerCredentials:
         assert result is None
         mock_get_session.assert_called_once()
         instance.authenticate.assert_awaited_once()
-        instance.fetch_alarms.assert_awaited_once()
+        instance.validate_connectivity.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_invalid_auth_error_propagates_unchanged(self) -> None:
@@ -482,7 +482,7 @@ class TestAsyncValidateControllerCredentials:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(side_effect=CannotConnectError("down"))
+            instance.validate_connectivity = AsyncMock(side_effect=CannotConnectError("down"))
 
             with pytest.raises(CannotConnectError):
                 await _async_validate_controller_credentials(

--- a/tests/unit/config_flow/test_options_rotation_validation.py
+++ b/tests/unit/config_flow/test_options_rotation_validation.py
@@ -86,7 +86,7 @@ class TestWebhookSecretRotation:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
             await flow.async_step_credentials(new_input)
 
         # No eager persistence; staged for finish.
@@ -324,7 +324,7 @@ class TestOptionsFlowUniqueIdFollowsUrl:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
             instance._is_unifi_os = False
             await flow.async_step_credentials(new_creds)
 
@@ -411,7 +411,7 @@ class TestOptionsFlowUniqueIdFollowsUrl:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
             instance._is_unifi_os = False
             result = await flow.async_step_credentials(new_creds)
 
@@ -458,7 +458,7 @@ class TestOptionsFlowSiteValidation:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(
+            instance.validate_connectivity = AsyncMock(
                 side_effect=InvalidSiteError("Site 'bogus-site' not found")
             )
             result = await flow.async_step_categories(cat_input)
@@ -466,6 +466,36 @@ class TestOptionsFlowSiteValidation:
         assert result["step_id"] == "categories"
         call_kwargs = flow.async_show_form.call_args.kwargs
         assert call_kwargs["errors"].get(CONF_SITE) == "invalid_site"
+
+    @pytest.mark.asyncio
+    async def test_alarm_endpoint_unavailable_shows_dedicated_error(self) -> None:
+        """AlarmEndpointUnavailableError during site validation must not be misreported as invalid_site (#406)."""
+        from custom_components.unifi_alerts.const import CONF_SITE
+        from custom_components.unifi_alerts.unifi_client import AlarmEndpointUnavailableError
+
+        flow = make_options_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
+
+        cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+        cat_input[CONF_SITE] = "bogus-site"
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=MagicMock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value=None)
+            instance.validate_connectivity = AsyncMock(
+                side_effect=AlarmEndpointUnavailableError("No legacy alarm endpoint found")
+            )
+            result = await flow.async_step_categories(cat_input)
+
+        assert result["step_id"] == "categories"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"].get("base") == "alarm_endpoint_unavailable"
 
     @pytest.mark.asyncio
     async def test_default_site_skips_validation(self) -> None:
@@ -504,7 +534,7 @@ class TestOptionsFlowSiteValidation:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
             result = await flow.async_step_categories(cat_input)
 
         assert result["step_id"] == "finish"
@@ -534,7 +564,7 @@ class TestOptionsFlowSiteValidation:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
             result = await flow.async_step_categories(cat_input)
 
         # Client must have been created with the pending (updated) controller URL
@@ -563,7 +593,9 @@ class TestOptionsFlowSiteValidation:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(side_effect=CannotConnectError("Connection refused"))
+            instance.validate_connectivity = AsyncMock(
+                side_effect=CannotConnectError("Connection refused")
+            )
             result = await flow.async_step_categories(cat_input)
 
         assert result["step_id"] == "categories"

--- a/tests/unit/config_flow/test_reconfigure.py
+++ b/tests/unit/config_flow/test_reconfigure.py
@@ -96,7 +96,7 @@ class TestReconfigureStep:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
 
             result = await flow.async_step_reconfigure(new_creds)
 
@@ -132,7 +132,7 @@ class TestReconfigureStep:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
 
             await flow.async_step_reconfigure(new_creds)
 
@@ -307,7 +307,7 @@ class TestReconfigureStep:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
 
             result = await flow.async_step_reconfigure(new_creds)
 

--- a/tests/unit/config_flow/test_setup.py
+++ b/tests/unit/config_flow/test_setup.py
@@ -51,7 +51,7 @@ class TestUserStep:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
 
             await flow.async_step_user(
                 {**_VALID_INPUT, CONF_CONTROLLER_URL: "https://192.168.1.1/"}
@@ -116,13 +116,49 @@ class TestUserStep:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
 
             result = await flow.async_step_user(_VALID_INPUT)
 
         assert result == categories_result
         flow.async_set_unique_id.assert_called_once()
         flow._abort_if_unique_id_configured.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_dead_legacy_path_with_live_v2_completes_setup(self) -> None:
+        """A controller with a dead legacy alarm path but a live v2 transport completes setup (#406).
+
+        This is the regression test that would have caught #406: UniFi
+        Network 10.6+ removed every legacy alarm endpoint, so the old
+        authenticate() + fetch_alarms() check always failed setup even
+        though the v2 system-log transport worked fine with the same API
+        key. validate_connectivity() resolving to "v2" (proven against real
+        HTTP responses in tests/unit/unifi_client/test_legacy.py::
+        TestValidateConnectivity::test_v2_only_returns_v2_without_touching_legacy)
+        must let the flow proceed past the user step exactly as a legacy-only
+        controller would.
+        """
+        flow = make_flow()
+        categories_result = {"type": "form", "step_id": "categories"}
+        flow.async_step_categories = AsyncMock(return_value=categories_result)
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value=None)
+            # Models a Network 10.6+ controller: validate_connectivity() only
+            # succeeds via v2 because every legacy alarm path is gone.
+            instance.validate_connectivity = AsyncMock(return_value="v2")
+
+            result = await flow.async_step_user(_VALID_INPUT)
+
+        assert result == categories_result
+        instance.validate_connectivity.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_error_preserves_submitted_values(self) -> None:
@@ -189,7 +225,7 @@ class TestUserStep:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
 
             await flow.async_step_user({**_VALID_INPUT, CONF_VERIFY_SSL: False})
 
@@ -219,8 +255,8 @@ class TestUserStep:
         assert schema_defaults.get(CONF_VERIFY_SSL) == DEFAULT_VERIFY_SSL
 
     @pytest.mark.asyncio
-    async def test_fetch_alarms_failure_shows_cannot_connect(self) -> None:
-        """If fetch_alarms() raises CannotConnectError after successful auth, show cannot_connect error."""
+    async def test_validate_connectivity_failure_shows_cannot_connect(self) -> None:
+        """If validate_connectivity() raises CannotConnectError after successful auth, show cannot_connect error."""
         from custom_components.unifi_alerts.unifi_client import CannotConnectError
 
         flow = make_flow()
@@ -235,7 +271,7 @@ class TestUserStep:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(
+            instance.validate_connectivity = AsyncMock(
                 side_effect=CannotConnectError("UniFi API error: api.err.InvalidObject")
             )
 
@@ -244,6 +280,38 @@ class TestUserStep:
         assert result["step_id"] == "user"
         call_kwargs = flow.async_show_form.call_args.kwargs
         assert call_kwargs["errors"] == {"base": "cannot_connect"}
+
+    @pytest.mark.asyncio
+    async def test_alarm_endpoint_unavailable_shows_dedicated_error(self) -> None:
+        """AlarmEndpointUnavailableError must map to its own error key, not cannot_connect or invalid_site.
+
+        Reproduces #406: a controller (UniFi Network 10.6+) with no alarm
+        endpoint the integration knows about must be reported distinctly from
+        a generic connectivity failure or a missing site.
+        """
+        from custom_components.unifi_alerts.unifi_client import AlarmEndpointUnavailableError
+
+        flow = make_flow()
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "user"})
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value=None)
+            instance.validate_connectivity = AsyncMock(
+                side_effect=AlarmEndpointUnavailableError("No legacy alarm endpoint found")
+            )
+
+            result = await flow.async_step_user(_VALID_INPUT)
+
+        assert result["step_id"] == "user"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"] == {"base": "alarm_endpoint_unavailable"}
 
     @pytest.mark.asyncio
     async def test_ssl_cert_error_on_authenticate_shows_invalid_ssl_cert(self) -> None:
@@ -270,8 +338,8 @@ class TestUserStep:
         assert call_kwargs["errors"] == {CONF_CONTROLLER_URL: "invalid_ssl_cert"}
 
     @pytest.mark.asyncio
-    async def test_ssl_cert_error_on_fetch_alarms_shows_invalid_ssl_cert(self) -> None:
-        """SslCertificateError from fetch_alarms() must map to the invalid_ssl_cert field error."""
+    async def test_ssl_cert_error_on_validate_connectivity_shows_invalid_ssl_cert(self) -> None:
+        """SslCertificateError from validate_connectivity() must map to the invalid_ssl_cert field error."""
         from custom_components.unifi_alerts.unifi_client import SslCertificateError
 
         flow = make_flow()
@@ -286,7 +354,9 @@ class TestUserStep:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(side_effect=SslCertificateError("cert error"))
+            instance.validate_connectivity = AsyncMock(
+                side_effect=SslCertificateError("cert error")
+            )
 
             result = await flow.async_step_user(_VALID_INPUT)
 
@@ -320,7 +390,7 @@ class TestUserStep:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(return_value=[])
+            instance.validate_connectivity = AsyncMock(return_value="v2")
             instance._is_unifi_os = False
 
             await flow.async_step_user(_VALID_INPUT)
@@ -350,7 +420,7 @@ class TestUserStep:
             ):
                 instance = mock_cls.return_value
                 instance.authenticate = AsyncMock(return_value=None)
-                instance.fetch_alarms = AsyncMock(return_value=[])
+                instance.validate_connectivity = AsyncMock(return_value="v2")
                 instance._is_unifi_os = False
                 await flow.async_step_user(_VALID_INPUT)
             suffixes.append(flow._credentials[CONF_WEBHOOK_ID_SUFFIX])
@@ -469,7 +539,7 @@ class TestCategoriesStep:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value="apikey")
-            instance.fetch_alarms = AsyncMock(
+            instance.validate_connectivity = AsyncMock(
                 side_effect=InvalidSiteError("Site 'nonexistent' not found")
             )
 
@@ -524,13 +594,53 @@ class TestCategoriesStep:
         ):
             instance = mock_cls.return_value
             instance.authenticate = AsyncMock(return_value=None)
-            instance.fetch_alarms = AsyncMock(side_effect=CannotConnectError("Network timeout"))
+            instance.validate_connectivity = AsyncMock(
+                side_effect=CannotConnectError("Network timeout")
+            )
 
             result = await flow.async_step_categories(cat_input)
 
         assert result["step_id"] == "categories"
         call_kwargs = flow.async_show_form.call_args.kwargs
         assert call_kwargs["errors"].get("base") == "cannot_connect"
+
+    @pytest.mark.asyncio
+    async def test_site_validation_alarm_endpoint_unavailable_shows_dedicated_error(self) -> None:
+        """AlarmEndpointUnavailableError during site validation must not be misreported as invalid_site.
+
+        Reproduces #406 at the categories step: a non-default site on a
+        controller with no known alarm endpoint (UniFi Network 10.6+) must
+        show alarm_endpoint_unavailable, not invalid_site or cannot_connect.
+        """
+        from custom_components.unifi_alerts.const import CONF_SITE
+        from custom_components.unifi_alerts.unifi_client import AlarmEndpointUnavailableError
+
+        flow = make_flow()
+        flow._controller_url = "https://192.168.1.1"
+        flow._credentials = {**_VALID_INPUT}
+        flow.async_show_form = MagicMock(return_value={"type": "form", "step_id": "categories"})
+
+        cat_input = {f"cat_{cat}": True for cat in ALL_CATEGORIES}
+        cat_input[CONF_SITE] = "mysite"
+
+        with (
+            patch(
+                "custom_components.unifi_alerts.config_flow.async_get_clientsession",
+                return_value=make_session_mock(),
+            ),
+            patch("custom_components.unifi_alerts.config_flow.UniFiClient") as mock_cls,
+        ):
+            instance = mock_cls.return_value
+            instance.authenticate = AsyncMock(return_value=None)
+            instance.validate_connectivity = AsyncMock(
+                side_effect=AlarmEndpointUnavailableError("No legacy alarm endpoint found")
+            )
+
+            result = await flow.async_step_categories(cat_input)
+
+        assert result["step_id"] == "categories"
+        call_kwargs = flow.async_show_form.call_args.kwargs
+        assert call_kwargs["errors"].get("base") == "alarm_endpoint_unavailable"
 
     @pytest.mark.asyncio
     async def test_min_severity_selector_rendered_for_all_categories(self) -> None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -40,6 +40,8 @@ def mock_unifi_client() -> Generator[MagicMock]:
         instance.authenticate = AsyncMock(return_value=None)
         instance.categorise_alarms = AsyncMock(return_value={})
         instance.probe_system_log_endpoint = AsyncMock(return_value=False)
+        instance.fetch_controller_version = AsyncMock(return_value=None)
+        instance.legacy_alarm_endpoint_confirmed_unavailable = MagicMock(return_value=False)
         instance.close = AsyncMock()
         yield instance
 

--- a/tests/unit/coordinator/conftest.py
+++ b/tests/unit/coordinator/conftest.py
@@ -29,6 +29,7 @@ def make_coordinator(hass: MagicMock | None = None, enabled: list[str] | None = 
     client = MagicMock()
     client.categorise_alarms = AsyncMock(return_value={})
     client.probe_system_log_endpoint = AsyncMock(return_value=False)
+    client.legacy_alarm_endpoint_confirmed_unavailable = MagicMock(return_value=False)
 
     config = {
         CONF_ENABLED_CATEGORIES: enabled if enabled is not None else ALL_CATEGORIES,
@@ -92,6 +93,7 @@ def make_hass_and_client():
     client.probe_system_log_endpoint = AsyncMock(return_value=False)
     client.fetch_system_log_alarms = AsyncMock(return_value=[])
     client.categorise_alarms = AsyncMock(return_value={})
+    client.legacy_alarm_endpoint_confirmed_unavailable = MagicMock(return_value=False)
     return hass, client
 
 

--- a/tests/unit/coordinator/test_system_log_probe.py
+++ b/tests/unit/coordinator/test_system_log_probe.py
@@ -153,3 +153,85 @@ class TestProbeBackoff:
         assert coord._probe_backoff_until is None
         assert coord._probe_fail_count == 0
         client.probe_system_log_endpoint.assert_awaited_once()
+
+
+class TestLegacyEndpointConfirmedDead:
+    """Tests for the #406 outage fix: no fallback to a legacy path the client has confirmed dead.
+
+    Before the fix, a v2 probe backoff (this class's sibling TestProbeBackoff)
+    combined with a legacy path removed by firmware (UniFi Network 10.6+)
+    meant every poll during the backoff window called the dead legacy path,
+    raised, and failed the whole poll (UpdateFailed) — taking every entity
+    unavailable for up to an hour. _fetch_categorised() must instead keep
+    retrying v2 once the client confirms no legacy endpoint exists.
+    """
+
+    @pytest.mark.asyncio
+    async def test_dead_legacy_path_falls_through_to_v2_within_same_poll(self):
+        """categorise_alarms() raising AlarmEndpointUnavailableError must not fail the poll.
+
+        Models the exact failure sequence from #406: the v2 probe is
+        (transiently or definitively) not preferred this poll, so the
+        coordinator tries legacy first; legacy is dead, so it falls through
+        to fetch_system_log_alarms() within the same call instead of raising.
+        """
+        from custom_components.unifi_alerts.unifi_client import AlarmEndpointUnavailableError
+
+        hass, client = make_hass_and_client()
+        client.probe_system_log_endpoint = AsyncMock(return_value=False)
+        client.categorise_alarms = AsyncMock(
+            side_effect=AlarmEndpointUnavailableError("no legacy alarm endpoint")
+        )
+        client.legacy_alarm_endpoint_confirmed_unavailable.return_value = False
+        client.fetch_system_log_alarms = AsyncMock(return_value=[])
+        coord = make_full_coordinator(hass, client)
+
+        result = await coord._fetch_categorised()
+
+        assert result == {}
+        client.categorise_alarms.assert_awaited_once()
+        client.fetch_system_log_alarms.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_confirmed_dead_legacy_skips_categorise_alarms_on_next_poll(self):
+        """Once legacy_alarm_endpoint_confirmed_unavailable() is True, never call categorise_alarms again."""
+        hass, client = make_hass_and_client()
+        client.probe_system_log_endpoint = AsyncMock(return_value=False)
+        client.legacy_alarm_endpoint_confirmed_unavailable.return_value = True
+        client.fetch_system_log_alarms = AsyncMock(return_value=[])
+        coord = make_full_coordinator(hass, client)
+
+        result = await coord._fetch_categorised()
+
+        assert result == {}
+        client.categorise_alarms.assert_not_called()
+        client.fetch_system_log_alarms.assert_awaited_once()
+
+
+class TestResolvedTransport:
+    """Tests for UniFiAlertsCoordinator.resolved_transport (diagnostics.py, #406)."""
+
+    @pytest.mark.asyncio
+    async def test_v2_confirmed(self):
+        hass, client = make_hass_and_client()
+        coord = make_full_coordinator(hass, client)
+        coord._has_system_log = True
+        assert coord.resolved_transport == "v2"
+
+    @pytest.mark.asyncio
+    async def test_legacy_confirmed(self):
+        hass, client = make_hass_and_client()
+        client.discovered_alarm_url = lambda site: (
+            "https://192.168.1.1/proxy/network/api/s/default/list/alarm"
+        )
+        coord = make_full_coordinator(hass, client)
+        coord._has_system_log = None
+        assert coord.resolved_transport == "legacy"
+
+    @pytest.mark.asyncio
+    async def test_unknown_before_first_poll(self):
+        hass, client = make_hass_and_client()
+        client.discovered_alarm_url = lambda site: None
+        coord = make_full_coordinator(hass, client)
+        coord._has_system_log = None
+        assert coord.resolved_transport == "unknown"

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -37,6 +37,7 @@ def _patch_all(authenticate_side_effect=None, first_refresh_side_effect=None):
 
     mock_client = MagicMock()
     mock_client.authenticate = AsyncMock(side_effect=authenticate_side_effect)
+    mock_client.fetch_controller_version = AsyncMock(return_value=None)
     mock_client.close = AsyncMock()
 
     mock_webhook_manager = MagicMock()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -417,6 +417,24 @@ class TestFromSystemLogEvent:
         alert = UniFiAlert.from_system_log_event(event)
         assert alert.category == CATEGORY_NETWORK_CLIENT
 
+    def test_maps_numeric_variant_key_to_category(self):
+        """A trailing numeric variant suffix (e.g. "_2") must not defeat the exact-match lookup.
+
+        Field-confirmed real payload shape (#406): "key": "CLIENT_ROAMED_2"
+        alongside "event": "CLIENT_ROAMED". Before the fix this missed
+        SYSTEM_LOG_KEY_TO_CATEGORY's exact match on "CLIENT_ROAMED", fell
+        through to the coarse enum fallback, and was logged as an
+        undocumented key on every roam.
+        """
+        event = dict(
+            self._BASE_EVENT,
+            key="CLIENT_ROAMED_2",
+            event="CLIENT_ROAMED",
+            category="CLIENT_DEVICES",
+        )
+        alert = UniFiAlert.from_system_log_event(event, seen_keys=set())
+        assert alert.category == CATEGORY_NETWORK_CLIENT
+
     def test_maps_power_key_to_power(self):
         event = dict(self._BASE_EVENT, key="POE_OVERLOAD", category="POWER")
         alert = UniFiAlert.from_system_log_event(event)

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -333,6 +333,7 @@ class TestServicesWiredFromInit:
 
         mock_client = MagicMock()
         mock_client.authenticate = AsyncMock()
+        mock_client.fetch_controller_version = AsyncMock(return_value=None)
         mock_client.close = AsyncMock()
 
         mock_wm = MagicMock()

--- a/tests/unit/test_unifi_auth.py
+++ b/tests/unit/test_unifi_auth.py
@@ -7,8 +7,10 @@ X-API-Key header, with no session state.
 
 from __future__ import annotations
 
+import json
 from contextlib import asynccontextmanager
-from unittest.mock import MagicMock
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -30,12 +32,22 @@ def make_auth(config: dict | None = None) -> UniFiAuth:
     return UniFiAuth(session, "https://192.168.1.1", cfg)
 
 
-def _make_response(status: int, headers: dict | None = None):
-    """Build a minimal mock aiohttp response for use in async context managers."""
+def _make_response(
+    status: int, headers: dict | None = None, json_body: dict[str, Any] | None = None
+):
+    """Build a minimal mock aiohttp response for use in async context managers.
+
+    json_body defaults to a successful envelope (meta.rc: "ok") so every
+    existing 200-status test keeps exercising a real "success" response,
+    matching what _verify_api_key now parses after raise_for_status() (#406).
+    """
     resp = MagicMock()
     resp.status = status
     resp.headers = headers or {}
     resp.raise_for_status = MagicMock()
+    resp.json = AsyncMock(
+        return_value=json_body if json_body is not None else {"meta": {"rc": "ok"}}
+    )
 
     @asynccontextmanager
     async def _ctx(*args, **kwargs):
@@ -83,6 +95,7 @@ class TestVerifyApiKey:
             resp.status = 200
             resp.headers = {}
             resp.raise_for_status = MagicMock()
+            resp.json = AsyncMock(return_value={"meta": {"rc": "ok"}})
             yield resp
 
         auth._session.get = _ctx
@@ -157,6 +170,55 @@ class TestVerifyApiKey:
 
         auth._session.get = _raise
         with pytest.raises(SslCertificateError):
+            await auth._verify_api_key()
+
+    @pytest.mark.asyncio
+    async def test_200_with_meta_rc_error_raises_invalid_auth(self):
+        """HTTP 200 with meta.rc == "error" must be treated as a rejected key, not a success.
+
+        UniFi returns HTTP 200 for some rejected-key cases, with the envelope
+        carrying `meta.rc: "error"`. Checking status alone previously let this
+        be reported as a successful login (#406).
+        """
+        auth = make_auth({"api_key": "bad-key", "verify_ssl": False})
+        auth._session.get = _make_response(
+            200, json_body={"meta": {"rc": "error", "msg": "api.err.Invalid"}}
+        )
+
+        with pytest.raises(InvalidAuthError, match=r"api\.err\.Invalid"):
+            await auth._verify_api_key()
+
+    @pytest.mark.asyncio
+    async def test_200_with_meta_rc_ok_authenticates(self):
+        """HTTP 200 with meta.rc == "ok" must succeed (the normal case)."""
+        auth = make_auth({"api_key": "good-key", "verify_ssl": False})
+        auth._session.get = _make_response(200, json_body={"meta": {"rc": "ok"}})
+
+        assert await auth._verify_api_key() is None
+
+    @pytest.mark.asyncio
+    async def test_200_with_unparseable_body_raises_invalid_auth(self):
+        """A 200 response whose body isn't valid JSON must fail closed, not crash or succeed.
+
+        Mirrors unifi_client.py's _parse_unifi_error_msg: an unparseable body
+        must not propagate a JSONDecodeError, and must not be treated as a
+        successful meta.rc == "ok" response either.
+        """
+        auth = make_auth({"api_key": "some-key", "verify_ssl": False})
+        resp = MagicMock()
+        resp.status = 200
+        resp.headers = {}
+        resp.raise_for_status = MagicMock()
+        resp.json = AsyncMock(
+            side_effect=json.JSONDecodeError("Expecting value", "not valid json", 0)
+        )
+
+        @asynccontextmanager
+        async def _ctx(*args, **kwargs):
+            yield resp
+
+        auth._session.get = _ctx
+        with pytest.raises(InvalidAuthError):
             await auth._verify_api_key()
 
     @pytest.mark.asyncio

--- a/tests/unit/unifi_client/conftest.py
+++ b/tests/unit/unifi_client/conftest.py
@@ -113,6 +113,16 @@ def self_url() -> str:
     return f"{BASE_URL}{UNIFI_OS_NETWORK_PREFIX}/api/s/default/self"
 
 
+def self_sites_url() -> str:
+    """The site-listing endpoint hit by UniFiClient._site_exists()."""
+    return f"{BASE_URL}{UNIFI_OS_NETWORK_PREFIX}/api/self/sites"
+
+
+def sysinfo_url(site: str = "default") -> str:
+    """The sysinfo endpoint hit by UniFiClient.fetch_controller_version()."""
+    return f"{BASE_URL}{UNIFI_OS_NETWORK_PREFIX}/api/s/{site}/stat/sysinfo"
+
+
 def probe_url(site: str = "default") -> str:
     return f"{BASE_URL}{UNIFI_OS_NETWORK_PREFIX}/v2/api/site/{site}/system-log/count"
 

--- a/tests/unit/unifi_client/test_legacy.py
+++ b/tests/unit/unifi_client/test_legacy.py
@@ -29,8 +29,11 @@ from .conftest import (
     find_calls,
     list_alarm_url,
     make_client,
+    probe_url,
     queue_responses,
+    self_sites_url,
     stat_alarm_url,
+    sysinfo_url,
     system_log_url,
     total_calls,
 )
@@ -332,11 +335,17 @@ class TestFetchAlarms:
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_all_paths_404_raises_invalid_site_error(
+    async def test_all_paths_404_raises_alarm_endpoint_unavailable_error(
         self, aioclient_mock: AiohttpClientMocker
     ):
-        """When all alarm paths return 404, raise InvalidSiteError (subclass of CannotConnectError)."""
-        from custom_components.unifi_alerts.unifi_client import InvalidSiteError
+        """When all alarm paths return 404, raise AlarmEndpointUnavailableError (#406).
+
+        This firmware has no legacy alarm endpoint the integration knows
+        about — a missing-endpoint problem, not a missing-site problem
+        (InvalidSiteError is reserved for a genuine site miss; see
+        TestValidateConnectivity and TestInvalidSiteDetection).
+        """
+        from custom_components.unifi_alerts.unifi_client import AlarmEndpointUnavailableError
 
         client = make_client(aioclient_mock)
         client._auth._authenticated = True
@@ -344,8 +353,9 @@ class TestFetchAlarms:
         aioclient_mock.get(list_alarm_url(), status=404)
         aioclient_mock.get(alarm_url(), status=404)
         aioclient_mock.get(stat_alarm_url(), status=404)
-        with pytest.raises(InvalidSiteError, match="not found on the controller"):
+        with pytest.raises(AlarmEndpointUnavailableError, match="No legacy alarm endpoint"):
             await client.fetch_alarms()
+        assert client.legacy_alarm_endpoint_confirmed_unavailable("default") is True
 
     @pytest.mark.asyncio
     async def test_http_400_raises_cannot_connect_with_site_hint(
@@ -787,3 +797,217 @@ class TestSslCertificateError:
         )
         with pytest.raises(SslCertificateError):
             await client.fetch_system_log_alarms()
+
+
+_INVALID_OBJECT_BODY = {"meta": {"rc": "error", "msg": "api.err.InvalidObject"}}
+
+
+def _mock_dead_legacy_chain(aioclient_mock: AiohttpClientMocker, site: str = "default") -> None:
+    """Register every legacy alarm path as removed (400 api.err.InvalidObject), as on Network 10.6+."""
+    aioclient_mock.get(list_alarm_url(site), status=400, json=_INVALID_OBJECT_BODY)
+    aioclient_mock.get(alarm_url(site), status=400, json=_INVALID_OBJECT_BODY)
+    aioclient_mock.get(stat_alarm_url(site), status=400, json=_INVALID_OBJECT_BODY)
+
+
+class TestNoSiteContextDetection:
+    """Tests for the 401 api.err.NoSiteContext → InvalidSiteError distinction (#406).
+
+    A genuinely missing site returns 401 + api.err.NoSiteContext, not the 400
+    api.err.InvalidObject a removed/renamed path returns. Confusing the two
+    was the root cause of #406's misleading "Site not found" error.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_site_context_raises_invalid_site_error(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
+        from custom_components.unifi_alerts.unifi_client import InvalidSiteError
+
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        body = {"meta": {"rc": "error", "msg": "api.err.NoSiteContext"}, "data": []}
+        aioclient_mock.get(list_alarm_url("missing"), status=401, json=body)
+
+        with pytest.raises(InvalidSiteError, match="does not exist"):
+            await client.fetch_alarms("missing")
+
+    @pytest.mark.asyncio
+    async def test_plain_401_still_raises_invalid_auth(self, aioclient_mock: AiohttpClientMocker):
+        """A 401 without api.err.NoSiteContext is still a genuine auth failure."""
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        aioclient_mock.get(list_alarm_url(), status=401)
+
+        with pytest.raises(InvalidAuthError):
+            await client.fetch_alarms()
+
+
+class TestSiteExists:
+    """Tests for UniFiClient._site_exists() — the GET /api/self/sites confirmation check."""
+
+    @pytest.mark.asyncio
+    async def test_true_when_name_matches(self, aioclient_mock: AiohttpClientMocker):
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        aioclient_mock.get(
+            self_sites_url(),
+            status=200,
+            json={"data": [{"name": "default"}, {"name": "branch"}]},
+        )
+        assert await client._site_exists("branch") is True
+
+    @pytest.mark.asyncio
+    async def test_false_when_name_absent(self, aioclient_mock: AiohttpClientMocker):
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        aioclient_mock.get(self_sites_url(), status=200, json={"data": [{"name": "default"}]})
+        assert await client._site_exists("bogus") is False
+
+    @pytest.mark.asyncio
+    async def test_true_on_network_error(self, aioclient_mock: AiohttpClientMocker):
+        """A failure to reach /api/self/sites must never be reported as a missing site."""
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        aioclient_mock.get(self_sites_url(), exc=aiohttp.ClientError())
+        assert await client._site_exists("anything") is True
+
+    @pytest.mark.asyncio
+    async def test_true_on_non_200_status(self, aioclient_mock: AiohttpClientMocker):
+        """A non-200 response from /api/self/sites must never be reported as a missing site."""
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        aioclient_mock.get(self_sites_url(), status=500)
+        assert await client._site_exists("anything") is True
+
+
+class TestValidateConnectivity:
+    """Tests for UniFiClient.validate_connectivity() — the #406 setup-time transport check.
+
+    This is the check config_flow.py now runs instead of authenticate() +
+    fetch_alarms(), so a controller with only a v2 transport (UniFi Network
+    10.6+) completes setup without ever touching the dead legacy chain.
+    """
+
+    @pytest.mark.asyncio
+    async def test_v2_only_returns_v2_without_touching_legacy(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
+        """v2 available, legacy unmocked: must return "v2" and never call a legacy path.
+
+        Reproduces the #406 setup path on Network 10.6+, where every legacy
+        alarm path has been removed and only v2 works.
+        """
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        aioclient_mock.post(probe_url(), status=200, json={"categories": []})
+
+        transport = await client.validate_connectivity()
+
+        assert transport == "v2"
+        assert find_calls("GET", list_alarm_url()) == []
+        assert find_calls("GET", alarm_url()) == []
+        assert find_calls("GET", stat_alarm_url()) == []
+
+    @pytest.mark.asyncio
+    async def test_legacy_only_returns_legacy(self, aioclient_mock: AiohttpClientMocker):
+        """v2 unavailable (404), a legacy path resolves: must return "legacy"."""
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        aioclient_mock.post(probe_url(), status=404)
+        aioclient_mock.get(list_alarm_url(), status=200, json={"meta": {"rc": "ok"}, "data": []})
+
+        transport = await client.validate_connectivity()
+
+        assert transport == "legacy"
+
+    @pytest.mark.asyncio
+    async def test_both_available_prefers_v2(self, aioclient_mock: AiohttpClientMocker):
+        """Both transports work: v2 is tried first and legacy is never touched."""
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        aioclient_mock.post(probe_url(), status=200, json={"categories": []})
+        aioclient_mock.get(list_alarm_url(), status=200, json={"meta": {"rc": "ok"}, "data": []})
+
+        transport = await client.validate_connectivity()
+
+        assert transport == "v2"
+        assert find_calls("GET", list_alarm_url()) == []
+
+    @pytest.mark.asyncio
+    async def test_neither_available_raises_alarm_endpoint_unavailable(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
+        """Neither transport reachable, site confirmed valid: AlarmEndpointUnavailableError.
+
+        This is the regression test for #406: a controller whose legacy
+        alarm paths are all gone (Network 10.6+) and whose v2 probe also
+        fails must be reported as a missing endpoint, never as a missing site.
+        """
+        from custom_components.unifi_alerts.unifi_client import AlarmEndpointUnavailableError
+
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        aioclient_mock.post(probe_url(), status=404)
+        _mock_dead_legacy_chain(aioclient_mock)
+        aioclient_mock.get(self_sites_url(), status=200, json={"data": [{"name": "default"}]})
+
+        with pytest.raises(AlarmEndpointUnavailableError):
+            await client.validate_connectivity()
+
+    @pytest.mark.asyncio
+    async def test_neither_available_and_site_missing_raises_invalid_site_error(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
+        """Neither transport reachable AND the site is confirmed absent: InvalidSiteError."""
+        from custom_components.unifi_alerts.unifi_client import InvalidSiteError
+
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        aioclient_mock.post(probe_url("bogus"), status=404)
+        _mock_dead_legacy_chain(aioclient_mock, site="bogus")
+        aioclient_mock.get(self_sites_url(), status=200, json={"data": [{"name": "default"}]})
+
+        with pytest.raises(InvalidSiteError):
+            await client.validate_connectivity("bogus")
+
+
+class TestFetchControllerVersion:
+    """Tests for UniFiClient.fetch_controller_version() — diagnostic-only, never raises (#406)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_and_caches_version(self, aioclient_mock: AiohttpClientMocker):
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        aioclient_mock.get(sysinfo_url(), status=200, json={"data": [{"version": "10.6.101"}]})
+
+        version = await client.fetch_controller_version()
+
+        assert version == "10.6.101"
+        assert client.controller_version == "10.6.101"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_failure_without_raising(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        aioclient_mock.get(sysinfo_url(), status=404)
+
+        version = await client.fetch_controller_version()
+
+        assert version is None
+        assert client.controller_version is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_network_error_without_raising(
+        self, aioclient_mock: AiohttpClientMocker
+    ):
+        """A network error fetching sysinfo must never raise or block setup."""
+        client = make_client(aioclient_mock)
+        client._auth._authenticated = True
+        aioclient_mock.get(sysinfo_url(), exc=aiohttp.ClientError())
+
+        version = await client.fetch_controller_version()
+
+        assert version is None
+        assert client.controller_version is None


### PR DESCRIPTION
## Summary

UniFi Network 10.6 removed every legacy alarm endpoint (`/list/alarm`, `/alarm`, `/stat/alarm`). Setup, credential rotation, and controller-URL changes hard-required that now-dead legacy path and failed with a misleading "Site not found" error, even though the v2 `system-log` transport worked fine with the same API key. This PR makes the config flow accept either transport, fixes the misdiagnosis, and closes a related latent outage in the coordinator.

## Changes

- **`unifi_client.py`**: added `UniFiClient.validate_connectivity(site) -> "v2" | "legacy"`, which tries the v2 `system-log/count` probe first and only falls back to the legacy alarm-path chain when v2 is unreachable. Added `AlarmEndpointUnavailableError` (a `CannotConnectError` subclass) for "no alarm endpoint we know about" — raised when the legacy probe chain exhausts, instead of the previous (incorrect) `InvalidSiteError`. A genuine missing site is now detected directly from `api.err.NoSiteContext` (HTTP 401) or confirmed against `GET /api/self/sites`. Added `fetch_controller_version()` (best-effort, diagnostic-only) and `discovered_alarm_url()`/`legacy_alarm_endpoint_confirmed_unavailable()` accessors.
- **`config_flow.py`**: replaced `authenticate()` + `fetch_alarms()` with `authenticate()` + `validate_connectivity()` at all four validation sites (initial setup, non-default-site validation, `_async_validate_controller_credentials` used by reconfigure/options-credentials, and the options-flow site validation). Added an `alarm_endpoint_unavailable` error mapping at each site.
- **`coordinator.py`**: `_fetch_categorised()` no longer falls back to a legacy path the client has confirmed is dead — it retries the v2 transport within the same poll instead of failing with `UpdateFailed`. Added a `resolved_transport` property for diagnostics.
- **`unifi_auth.py`**: `_verify_api_key()` now parses the response envelope and checks `meta.rc`, since UniFi can return HTTP 200 for a rejected key.
- **`const.py`**: `classify_event_key()` now matches v2 keys carrying a numeric variant suffix (e.g. `CLIENT_ROAMED_2` alongside `event: CLIENT_ROAMED`) by stripping a trailing `_<digits>` before the exact-match lookup, instead of falling through to the coarse category fallback.
- **`__init__.py` / `diagnostics.py`**: log the Network application version at setup, and surface the resolved transport, discovered alarm URL, and controller version in diagnostics.
- **`strings.json` / `translations/en.json`**: added the `alarm_endpoint_unavailable` error key to both error blocks.
- **Docs**: `README.md` (tested-controllers table, API-key section reordered to lead with the Integrations path), `docs/UNIFI.md` (corrected the "newest" claim, documented the 10.6 removal), `docs/research/alert-endpoints.md` (new confirmed hypothesis + 10.6.101 probe table), `.github/ISSUE_TEMPLATE/bug_report.yml` (added a separate "UniFi Network application version" field), `CHANGELOG.md`.
- **Tests**: new coverage for `validate_connectivity()` (v2-only/legacy-only/both/neither), the `NoSiteContext` vs `InvalidObject` distinction, `_verify_api_key()`'s `meta.rc` check, the coordinator's dead-legacy-falls-through-to-v2 behaviour, and the numeric-variant key regression. Updated the 14 existing `InvalidSiteError`/`invalid_site` references and every mocked `fetch_alarms()` call site across the config-flow, coordinator, and integration test suites.

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite (778 tests, 99%+ coverage)
```

Manually: point the integration at a UniFi Network 10.6+ controller (or mock `validate_connectivity()` to resolve via v2 only) and confirm setup completes without the legacy alarm paths ever being probed.

## Checklist

- [x] Linked the issue this PR resolves (`Closes #406` in the description)
- [x] `make check` passes locally
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] PR title starts with a Conventional Commit prefix (`fix:`)
- [x] PR has a label recognised by `.github/release.yml` (should be applied automatically by `pr-release-label.yml`)
- [x] `strings.json` and `translations/en.json` are still identical
- [x] No blocking I/O introduced (all network/disk calls are `async`)

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBb2rNamd7qwuV3p1Baeez

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBb2rNamd7qwuV3p1Baeez)_