### PR TITLE
release: bump version to 2.1.0-pre2

### DIFF
--- a/custom_components/unifi_alerts/manifest.json
+++ b/custom_components/unifi_alerts/manifest.json
@@ -28,5 +28,5 @@
       "modelDescription": "UniFi Dream Machine Pro Max"
     }
   ],
-  "version": "2.1.0-pre1"
+  "version": "2.1.0-pre2"
 }

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -2,6 +2,13 @@
 
 Dated record of completed work. Newest first. Format per entry: category, short description, PR or commit reference, short why.
 
+## 2026-09-08
+
+- **release**: v2.1.0-pre2 tagged. Second checkpoint of the v2.1.0 cycle, closing the UniFi Network 10.6+ setup failure ([#412]). Closes #406.
+- **fix**: setup, credential rotation, and controller-URL changes no longer fail on UniFi Network 10.6+, which removed every legacy alarm endpoint; the config flow now accepts either the v2 system-log transport or the legacy transport via a new `UniFiClient.validate_connectivity()`. The failure was previously misreported as a missing site (`InvalidSiteError`); it is now reported correctly as a missing alarm endpoint (`AlarmEndpointUnavailableError`), and a genuine missing site is detected directly from the controller's `api.err.NoSiteContext` response rather than inferred by exhausting the probe chain. The coordinator no longer falls back to a legacy path it has confirmed is dead, closing a latent outage that could take every entity unavailable for up to an hour. A rejected API key returned with HTTP 200 is no longer misreported as a successful login, and v2 event keys carrying a numeric variant suffix (e.g. `CLIENT_ROAMED_2`) are now matched correctly instead of falling through to the coarse category fallback ([#412]). Closes #406.
+
+[#412]: https://github.com/PHeonix25/unifi_alerts/pull/412
+
 ## 2026-08-21
 
 - **release**: v2.1.0-pre1 tagged. First checkpoint of the v2.1.0 "severity follow-through and test coverage" cycle: closes most of the #331 review follow-ups (config/options flow accessibility fixes, `severity.py` cleanup, a latent `from_dict` truncation bug), the deferred `_device_info()` duplication (issue #383), a regression test locking down webhook secret-leak safety (issue #379), and the remaining v2.1.0 test-coverage gaps for entity actions, webhook edge cases, and coordinator/service error handling. The "Test Webhook" button (issue #384) was descoped: its literal spec (a live button embedded in the options flow finish step) doesn't fit how HA config flows work, and the auto-clear timing needs more design thought. Issues #355, #356, #357, #385 remain open for the next checkpoint.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,13 +2,15 @@
 
 What's planned next. Items ship from `dev` under `X.Y.Z-preN`, then promote to `main` as `X.Y.Z`. Completed work is removed from this file; the historical record lives in `docs/HISTORY.md`, and the user-visible release summary lives in `CHANGELOG.md`.
 
-> **Status (2026-08-21):** v2.1.0-pre1 tagged, the first checkpoint of the v2.1.0 cycle. Closed: most of the #331 review follow-ups (UI copy, `severity.py` cleanups, config/options flow accessibility fixes), the `_device_info()` extraction (#383), a webhook secret-leak regression test (#379), and the remaining entity/webhook/coordinator test-coverage gaps (#380, #381, #382). Descoped: the "Test Webhook" button (#384), whose literal spec doesn't fit HA's config-flow architecture. Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
+> **Status (2026-09-08):** v2.1.0-pre2 tagged, the second checkpoint of the v2.1.0 cycle. Closed: the UniFi Network 10.6+ setup failure (#406) - the config flow now accepts the v2 system-log transport instead of hard-requiring the legacy alarm paths that firmware removed. First checkpoint (v2.1.0-pre1) closed most of the #331 review follow-ups (UI copy, `severity.py` cleanups, config/options flow accessibility fixes), the `_device_info()` extraction (#383), a webhook secret-leak regression test (#379), and the remaining entity/webhook/coordinator test-coverage gaps (#380, #381, #382). Descoped: the "Test Webhook" button (#384), whose literal spec doesn't fit HA's config-flow architecture. Item-level work is tracked in GitHub Issues, grouped by milestone: <https://github.com/PHeonix25/unifi_alerts/milestones>.
 
 > **Branching model:** see `CLAUDE.md § Branching and releasing`.
 
 ---
 
 ## v2.1.0 - Severity follow-through and test coverage
+
+Second checkpoint (v2.1.0-pre2) closed the UniFi Network 10.6+ setup failure (#406): Network 10.6 removed every legacy alarm endpoint, so the config flow now accepts the v2 system-log transport instead of hard-requiring the legacy alarm paths; also fixed the underlying misdiagnosis (`InvalidSiteError` reported for a missing endpoint, not a missing site), a coordinator outage path that could take every entity unavailable for up to an hour, an API-key rejection that could be reported as a successful login, and a v2 event-key matching gap for numeric-variant keys.
 
 First checkpoint (v2.1.0-pre1) closed most of the #331 review follow-ups (`severity.py` cleanups, the min_severity UI copy, config/options flow accessibility fixes), the extracted `_device_info()` helper (#383), a latent `from_dict` severity-truncation fix (#359), a webhook secret-leak regression test (#379), and the remaining entity/webhook/coordinator test-coverage gaps (#380, #381, #382). The "Test Webhook" button (#384) was descoped: a live button embedded in the options flow finish step doesn't fit how HA config flows work, and the 30-second auto-clear timing needs more design thought than a first pass gave it.
 


### PR DESCRIPTION
## Summary

Second pre-release checkpoint of the v2.1.0 cycle. Bumps `manifest.json` from `2.1.0-pre1` to `2.1.0-pre2` (`scripts/bump_version.py --pre`) so users affected by the UniFi Network 10.6+ setup failure (#406) can test the fix from [#412](https://github.com/PHeonix25/unifi_alerts/pull/412) without waiting for a stable release.

## Changes

- `custom_components/unifi_alerts/manifest.json`: version `2.1.0-pre1` -> `2.1.0-pre2`.
- `docs/HISTORY.md`: added the `## 2026-09-08` block covering the one PR merged to `dev` since `v2.1.0-pre1` (#412): the UniFi Network 10.6+ setup fix.
- `docs/ROADMAP.md`: updated the v2.1.0 status line and section summary to record the second checkpoint. #406 wasn't a planned roadmap item (it was an opportunistic bug fix), so there's nothing to drop from the "Remaining threads" list.

Note: `scripts/bump_version.py --pre` reported "No merges since v2.1.0-pre1" because PR #412 was squash-merged (this repo's dev branch is squash-only), so it produced no merge commit for the script's `git log --merges` detection to find. The HISTORY.md block above was built from `git log v2.1.0-pre1..dev --oneline` instead, which shows the single squashed commit.

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite (778 tests, 99%+ coverage) — passing locally
```

## Checklist

- [x] Linked the issue this PR resolves (n/a — a version-bump PR, not tied to a single issue; the underlying fix already closed #406 via #412)
- [x] `make check` passes locally
- [x] `CHANGELOG.md` `[Unreleased]` updated (n/a for pre-release bumps — `CHANGELOG.md` is only touched on stable promotion, per `docs/RELEASING.md`; will apply `skip-changelog` label per the #410 precedent)
- [x] PR title starts with a Conventional Commit prefix (`release:`)
- [x] PR has a label recognised by `.github/release.yml` (`release:` isn't auto-mapped by `pr-release-label.yml`; applying `documentation` + `skip-changelog` by hand, matching #410)
- [x] `strings.json` and `translations/en.json` are still identical (neither touched)
- [x] No blocking I/O introduced (docs/manifest only)

## After merge

```bash
git checkout dev && git pull origin dev
git tag v2.1.0-pre2 && git push origin v2.1.0-pre2
```
GitHub Actions creates the pre-release automatically once the tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBb2rNamd7qwuV3p1Baeez

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBb2rNamd7qwuV3p1Baeez)_