### PR TITLE
feat: surface severity_level as an entity attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- The category message sensor, category and rollup binary sensors, and the `alert_received` event now expose `severity_level` (`last_severity_level` on the binary sensors and the rollup count sensor) alongside the existing raw `severity` attribute: the same normalised `LOW`/`MEDIUM`/`HIGH`/`VERY_HIGH`/`UNKNOWN` value already used internally for the minimum-severity gate, now available for automations to key off directly. ([#356])
+
 ### Fixed
 
 - Setup, credential rotation, and controller-URL changes no longer fail on UniFi Network 10.6+, which removed every legacy alarm endpoint. The config flow now accepts either the v2 system-log transport or the legacy alarm transport (`UniFiClient.validate_connectivity()`), instead of hard-requiring the now-removed legacy path. The failure was previously misreported as "Site not found" (`InvalidSiteError`); it is now correctly reported as a missing alarm endpoint (`AlarmEndpointUnavailableError`), and a genuine missing-site error is detected directly from the controller's `api.err.NoSiteContext` response rather than inferred by exhausting the probe chain. The coordinator also no longer falls back to a legacy path it has confirmed is dead, which previously took every entity unavailable for up to an hour on Network 10.6+ if the v2 probe hit a transient failure. ([#406])
@@ -412,3 +416,4 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#359]: https://github.com/PHeonix25/unifi_alerts/issues/359
 [#406]: https://github.com/PHeonix25/unifi_alerts/issues/406
 [#383]: https://github.com/PHeonix25/unifi_alerts/issues/383
+[#356]: https://github.com/PHeonix25/unifi_alerts/issues/356

--- a/custom_components/unifi_alerts/binary_sensor.py
+++ b/custom_components/unifi_alerts/binary_sensor.py
@@ -89,6 +89,7 @@ class UniFiCategoryBinarySensor(CoordinatorEntity[UniFiAlertsCoordinator], Binar
             attrs["last_device"] = state.last_alert.device_name
             attrs["last_key"] = state.last_alert.key
             attrs["last_severity"] = state.last_alert.severity
+            attrs["last_severity_level"] = state.last_alert.severity_level
         if state.last_cleared_at:
             attrs["last_cleared_at"] = state.last_cleared_at.isoformat()
         return attrs
@@ -127,4 +128,5 @@ class UniFiRollupBinarySensor(CoordinatorEntity[UniFiAlertsCoordinator], BinaryS
             attrs["last_alert_at"] = last.received_at.isoformat()
             attrs["last_category"] = last.category
             attrs["last_severity"] = last.severity
+            attrs["last_severity_level"] = last.severity_level
         return attrs

--- a/custom_components/unifi_alerts/event.py
+++ b/custom_components/unifi_alerts/event.py
@@ -94,6 +94,7 @@ class UniFiAlertEventEntity(CoordinatorEntity[UniFiAlertsCoordinator], EventEnti
                     "device_name": alert.device_name,
                     "alert_key": alert.key,
                     "severity": alert.severity,
+                    "severity_level": alert.severity_level,
                     "site": alert.site,
                     "received_at": alert.received_at.isoformat(),
                 },

--- a/custom_components/unifi_alerts/sensor.py
+++ b/custom_components/unifi_alerts/sensor.py
@@ -92,6 +92,7 @@ class UniFiCategoryMessageSensor(CoordinatorEntity[UniFiAlertsCoordinator], Sens
             "device_name": state.last_alert.device_name,
             "alert_key": state.last_alert.key,
             "severity": state.last_alert.severity,
+            "severity_level": state.last_alert.severity_level,
             "site": state.last_alert.site,
         }
 
@@ -206,4 +207,5 @@ class UniFiRollupCountSensor(CoordinatorEntity[UniFiAlertsCoordinator], SensorEn
             attrs["last_message"] = last.message
             attrs["last_category"] = last.category
             attrs["last_alert_at"] = last.received_at.isoformat()
+            attrs["last_severity_level"] = last.severity_level
         return attrs

--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -19,14 +19,18 @@ from custom_components.unifi_alerts.models import CategoryState, UniFiAlert
 # ── shared helpers ────────────────────────────────────────────────────────────
 
 
-def make_alert(category: str = CATEGORY_NETWORK_WAN, message: str = "WAN offline") -> UniFiAlert:
+def make_alert(
+    category: str = CATEGORY_NETWORK_WAN,
+    message: str = "WAN offline",
+    severity: str = "critical",
+) -> UniFiAlert:
     return UniFiAlert(
         category=category,
         message=message,
         received_at=datetime(2024, 6, 1, 12, 0, 0, tzinfo=UTC),
         key="EVT_GW_WANTransition",
         device_name="UDM-Pro",
-        severity="critical",
+        severity=severity,
         site="default",
     )
 
@@ -130,7 +134,15 @@ class TestUniFiCategoryBinarySensor:
         assert attrs["last_device"] == "UDM-Pro"
         assert attrs["last_key"] == "EVT_GW_WANTransition"
         assert attrs["last_severity"] == "critical"
+        assert attrs["last_severity_level"] == "UNKNOWN"
         assert "last_alert_at" in attrs
+
+    def test_extra_attrs_last_severity_level_normalizes_known_severity(self):
+        alert = make_alert(severity="high")
+        state = make_state(last_alert=alert)
+        entity = self._make(state)
+        attrs = entity.extra_state_attributes
+        assert attrs["last_severity_level"] == "HIGH"
 
     def test_extra_attrs_without_alert(self):
         state = make_state()
@@ -206,12 +218,14 @@ class TestUniFiRollupBinarySensor:
         assert attrs["last_message"] == "WAN offline"
         assert attrs["last_category"] == CATEGORY_NETWORK_WAN
         assert attrs["last_severity"] == "critical"
+        assert attrs["last_severity_level"] == "UNKNOWN"
 
     def test_extra_attrs_without_last_alert(self):
         states = {CATEGORY_NETWORK_WAN: make_state()}
         entity = self._make(states)
         attrs = entity.extra_state_attributes
         assert "last_message" not in attrs
+        assert "last_severity_level" not in attrs
         assert attrs["total_alert_count"] == 0
 
 
@@ -275,8 +289,16 @@ class TestUniFiCategoryMessageSensor:
         assert attrs["device_name"] == "UDM-Pro"
         assert attrs["alert_key"] == "EVT_GW_WANTransition"
         assert attrs["severity"] == "critical"
+        assert attrs["severity_level"] == "UNKNOWN"
         assert attrs["site"] == "default"
         assert "received_at" in attrs
+
+    def test_extra_attrs_severity_level_normalizes_known_severity(self):
+        alert = make_alert(severity="high")
+        state = make_state(last_alert=alert)
+        entity = self._make(state)
+        attrs = entity.extra_state_attributes
+        assert attrs["severity_level"] == "HIGH"
 
     def test_extra_attrs_empty_when_no_alert(self):
         state = make_state()
@@ -407,6 +429,7 @@ class TestUniFiRollupCountSensor:
         assert attrs["total_webhook_count"] == 1
         assert attrs["last_message"] == "WAN offline"
         assert attrs["last_category"] == CATEGORY_NETWORK_WAN
+        assert attrs["last_severity_level"] == "UNKNOWN"
         assert "last_alert_at" in attrs
 
     def test_extra_attrs_without_last_alert(self):
@@ -414,6 +437,7 @@ class TestUniFiRollupCountSensor:
         entity = self._make(states)
         attrs = entity.extra_state_attributes
         assert "last_message" not in attrs
+        assert "last_severity_level" not in attrs
         assert attrs["total_webhook_count"] == 0
 
     def test_state_class_is_measurement(self):
@@ -510,10 +534,21 @@ class TestUniFiAlertEventEntity:
             "device_name",
             "alert_key",
             "severity",
+            "severity_level",
             "site",
             "received_at",
         ):
             assert key in payload
+        assert payload["severity_level"] == "UNKNOWN"
+
+    def test_event_payload_severity_level_normalizes_known_severity(self):
+        alert = make_alert(severity="high")
+        state = make_state(is_alerting=True, alert_count=1, last_alert=alert)
+        entity = self._make(state)
+        entity._last_seen_count = 0
+        entity._handle_coordinator_update()
+        _, payload = entity._trigger_event.call_args[0]
+        assert payload["severity_level"] == "HIGH"
 
     @pytest.mark.asyncio
     async def test_reload_does_not_replay_restored_alert(self):


### PR DESCRIPTION
## Summary

Exposes `UniFiAlert.severity_level` (the normalised `LOW`/`MEDIUM`/`HIGH`/`VERY_HIGH`/`UNKNOWN` value already computed by `severity.py` and used internally for the minimum-severity gate) as an entity attribute, so automation authors have a reliable value to key off even when the raw `severity` string is unreliable or absent.

## Changes

- `sensor.py`: `UniFiCategoryMessageSensor.extra_state_attributes` gains `severity_level`; `UniFiRollupCountSensor.extra_state_attributes` gains `last_severity_level` (only when a last alert exists).
- `binary_sensor.py`: `UniFiCategoryBinarySensor.extra_state_attributes` and `UniFiRollupBinarySensor.extra_state_attributes` both gain `last_severity_level` (only when a last alert exists).
- `event.py`: the `alert_received` event payload gains `severity_level`.
- `tests/unit/test_entities.py`: extended `make_alert()` with an optional `severity` param, and added coverage for the new attribute/payload field across all five entities, including the `UNKNOWN` (unrecognised raw severity) case and a known-severity normalisation case (`"high"` → `"HIGH"`).
- `CHANGELOG.md`: added an `[Unreleased]` → `Added` bullet.

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

Note: `make check`'s `test` target could not be run against a full Home Assistant runtime in this sandbox — the only available Python 3.14 interpreter is `3.14.0rc2`, one patch below the `homeassistant==2026.7.1` floor's `Python>=3.14.2` requirement, and separately `mashumaro` 3.22 (latest released) references `typing.ByteString`, which this interpreter build has already removed. Neither is caused by this change. `lint`, `typecheck`, `validate`, and `doc-check` all pass locally; `pytest tests/ --cov-fail-under=95` was verified locally with a throwaway interpreter shim working around the `ByteString` gap (781 passed, 99.27% coverage, all new assertions included) — CI's pinned environment is authoritative for the final run.

Closes #356

## Checklist

- [x] Linked the issue this PR resolves (`Closes #356` in the description)
- [x] `make check` passes locally (see note above re: `test` target)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] PR title starts with a Conventional Commit prefix (`feat:`)
- [x] PR has a label recognised by `.github/release.yml` (applied automatically for CC-prefixed titles via pr-release-label.yml)
- [x] `strings.json` and `translations/en.json` are still identical (no translation-key changes; these are attribute dict keys, not translated)
- [x] No new category added
- [x] No blocking I/O introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Xhu6ypjFwWu2q8rfgzt4C

---
_Generated by [Claude Code](https://claude.ai/code/session_012Xhu6ypjFwWu2q8rfgzt4C)_