### PR TITLE
feat: add diagnostic trail for silently-filtered alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - The category message sensor, category and rollup binary sensors, and the `alert_received` event now expose `severity_level` (`last_severity_level` on the binary sensors and the rollup count sensor) alongside the existing raw `severity` attribute: the same normalised `LOW`/`MEDIUM`/`HIGH`/`VERY_HIGH`/`UNKNOWN` value already used internally for the minimum-severity gate, now available for automations to key off directly. ([#356])
+- An alert dropped by a category's minimum-severity gate now leaves a diagnostic trail instead of vanishing silently: a DEBUG log on both the webhook push path and the polling path, and new `filtered_count`/`last_filtered_at` per-category fields in the diagnostics download (webhook-driven, alongside the existing `webhook_health`/`unrecognised_keys` diagnostics). Previously there was no way to tell "alert never arrived" from "alert arrived but was filtered" without reading source code. ([#357])
 
 ### Fixed
 
@@ -417,3 +418,4 @@ Internal critical-review pass. No user-visible changes; the audit findings were 
 [#406]: https://github.com/PHeonix25/unifi_alerts/issues/406
 [#383]: https://github.com/PHeonix25/unifi_alerts/issues/383
 [#356]: https://github.com/PHeonix25/unifi_alerts/issues/356
+[#357]: https://github.com/PHeonix25/unifi_alerts/issues/357

--- a/custom_components/unifi_alerts/coordinator.py
+++ b/custom_components/unifi_alerts/coordinator.py
@@ -170,9 +170,18 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
                 if not state.enabled:
                     continue
                 minimum = get_effective_min_severity(self._config, cat)
-                eligible = [
-                    alert for alert in alerts if meets_minimum(alert.severity_level, minimum)
-                ]
+                eligible: list[UniFiAlert] = []
+                for alert in alerts:
+                    if meets_minimum(alert.severity_level, minimum):
+                        eligible.append(alert)
+                    else:
+                        _LOGGER.debug(
+                            "Filtered polled alert for category %s: severity_level %s "
+                            "below minimum %s",
+                            cat,
+                            alert.severity_level,
+                            minimum,
+                        )
                 self._track_newest_seen(state, eligible)
                 # Count only alarms newer than last_cleared_at so open_count reads as
                 # "since last Clear", not a lifetime total.
@@ -398,6 +407,13 @@ class UniFiAlertsCoordinator(DataUpdateCoordinator[dict[str, CategoryState]]):
             # event - the periodic poll refresh picks it up, which keeps a
             # noisy filtered category from generating unbounded listener
             # notifications.
+            _LOGGER.debug(
+                "Filtered webhook alert for category %s: severity_level %s below minimum %s",
+                category,
+                alert.severity_level,
+                minimum,
+            )
+            state.record_filtered(alert)
             state.last_webhook_at = alert.received_at
             self._schedule_persist()
             return

--- a/custom_components/unifi_alerts/diagnostics.py
+++ b/custom_components/unifi_alerts/diagnostics.py
@@ -46,11 +46,17 @@ async def async_get_config_entry_diagnostics(
                 "is_alerting": state.is_alerting,
                 "open_count": state.open_count,
                 "alert_count": state.alert_count,
+                "filtered_count": state.filtered_count,
                 "last_cleared_at": (
                     state.last_cleared_at.isoformat() if state.last_cleared_at is not None else None
                 ),
                 "last_webhook_at": (
                     state.last_webhook_at.isoformat() if state.last_webhook_at is not None else None
+                ),
+                "last_filtered_at": (
+                    state.last_filtered_at.isoformat()
+                    if state.last_filtered_at is not None
+                    else None
                 ),
                 "webhook_health": state.webhook_health(),
             }

--- a/custom_components/unifi_alerts/models.py
+++ b/custom_components/unifi_alerts/models.py
@@ -287,11 +287,17 @@ class CategoryState:
     last_alert: UniFiAlert | None = None
     alert_count: int = 0  # incremented by webhooks
     open_count: int = 0  # set by polling (unarchived alarms)
+    # Count of webhook pushes dropped by the Minimum_Severity_Setting gate.
+    # Webhook-only, like alert_count/last_webhook_at: the poll path
+    # re-observes the same uncleared alarms on every cycle, so counting
+    # there would inflate this beyond "number of distinct filtered events".
+    filtered_count: int = 0
     last_cleared_at: datetime | None = None
     # Timestamp of the last webhook actually received for this category. Set
     # only on the push path (never by polling) so it reflects webhook
     # connectivity specifically, which powers the onboarding/health signal.
     last_webhook_at: datetime | None = None
+    last_filtered_at: datetime | None = None
     # Newest `received_at` seen for this category, from either the push or
     # polling path. Tracked so Clear can anchor `last_cleared_at` to the
     # controller's own timeline instead of the HA host clock (#268): using
@@ -306,6 +312,11 @@ class CategoryState:
         received_at = ensure_aware(alert.received_at)
         if self.last_alarm_received_at is None or received_at > self.last_alarm_received_at:
             self.last_alarm_received_at = received_at
+
+    def record_filtered(self, alert: UniFiAlert) -> None:
+        """Record a webhook alert dropped by the Minimum_Severity_Setting gate."""
+        self.filtered_count += 1
+        self.last_filtered_at = ensure_aware(alert.received_at)
 
     def clear(self) -> None:
         """Acknowledge everything seen so far for this category.

--- a/tests/unit/coordinator/test_polling.py
+++ b/tests/unit/coordinator/test_polling.py
@@ -7,7 +7,7 @@ test_persistence.py, and test_autoclear.py in this package.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from conftest import run_sync
@@ -527,6 +527,54 @@ class TestPollingSeverityGate:
         state = coord.get_category_state(CATEGORY_NETWORK_DEVICE)
         assert state.open_count == 1
         assert state.is_alerting is True
+
+    def test_severity_filtered_polling_logs_debug_for_filtered_alerts(self):
+        """A filtered alert during polling must leave a DEBUG trail, analogous
+        to the push-path filter log, so a user can tell "alert never arrived"
+        from "alert arrived but was filtered" without enabling raw payload
+        logging (#357)."""
+        category = CATEGORY_NETWORK_WAN
+        alert = UniFiAlert(
+            category=category,
+            message="below-threshold alert",
+            received_at=datetime(2024, 1, 1, tzinfo=UTC),
+            severity=SEVERITY_ORDER[0],
+        )
+
+        hass, client = make_hass_and_client()
+        client.categorise_alarms = AsyncMock(return_value={category: [alert]})
+        coord = make_full_coordinator(hass, client)
+        coord._config[CONF_MIN_SEVERITY] = {category: SEVERITY_ORDER[-1]}
+
+        with patch("custom_components.unifi_alerts.coordinator._LOGGER") as mock_logger:
+            run_sync(coord._async_update_data())
+
+        debug_messages = [call.args[0] for call in mock_logger.debug.call_args_list]
+        assert any("Filtered polled alert" in msg for msg in debug_messages)
+
+    def test_polling_does_not_touch_filtered_diagnostic_trail(self):
+        """The poll path re-observes the same uncleared alarms every cycle, so
+        it must never touch filtered_count/last_filtered_at — those are
+        webhook-only, mirroring alert_count/last_webhook_at (#357)."""
+        category = CATEGORY_NETWORK_WAN
+        alert = UniFiAlert(
+            category=category,
+            message="below-threshold alert",
+            received_at=datetime(2024, 1, 1, tzinfo=UTC),
+            severity=SEVERITY_ORDER[0],
+        )
+
+        hass, client = make_hass_and_client()
+        client.categorise_alarms = AsyncMock(return_value={category: [alert]})
+        coord = make_full_coordinator(hass, client)
+        coord._config[CONF_MIN_SEVERITY] = {category: SEVERITY_ORDER[-1]}
+
+        run_sync(coord._async_update_data())
+        run_sync(coord._async_update_data())
+
+        state = coord.get_category_state(category)
+        assert state.filtered_count == 0
+        assert state.last_filtered_at is None
 
     # A disabled category must be untouched by a poll cycle regardless of
     # severity content

--- a/tests/unit/coordinator/test_push_dedup.py
+++ b/tests/unit/coordinator/test_push_dedup.py
@@ -594,6 +594,9 @@ class TestPushAlertSeverityGate:
         assert state.last_alert is prior_last_alert
         # No immediate broadcast for a filtered event either.
         coord.async_set_updated_data.assert_not_called()
+        # The filtered-alert diagnostic trail must still advance.
+        assert state.filtered_count == 1
+        assert state.last_filtered_at == alert.received_at
 
     # last_webhook_at must still advance on a gated (below-threshold) push.
     @given(
@@ -643,6 +646,8 @@ class TestPushAlertSeverityGate:
         assert state.alert_count == prior_alert_count
         assert state.open_count == prior_open_count
         assert state.last_alert is prior_last_alert
+        assert state.filtered_count == 1
+        assert state.last_filtered_at == alert.received_at
 
     def test_realistic_webhook_payload_with_no_severity_field_is_not_gated_out(
         self,
@@ -746,6 +751,27 @@ class TestPushAlertSeverityGate:
             prior_open_count + 1 if expect_open_count_incremented else prior_open_count
         )
         assert state.open_count == expected_open_count
+        # An accepted push must never touch the filtered-alert diagnostic trail.
+        assert state.filtered_count == 0
+        assert state.last_filtered_at is None
+
+    def test_below_threshold_push_logs_debug(self):
+        """A below-threshold push must leave a DEBUG trail, analogous to the
+        existing dedup-suppression debug log, so a user can tell "alert
+        never arrived" from "alert arrived but was filtered" (#357)."""
+        category = CATEGORY_NETWORK_WAN
+        coord = make_coordinator(enabled=[category])
+        coord.async_set_updated_data = MagicMock()
+        coord._config[CONF_MIN_SEVERITY] = {category: SEVERITY_ORDER[-1]}
+
+        alert = make_alert(category, "below-threshold alert")
+        alert.severity = SEVERITY_ORDER[0]
+
+        with patch("custom_components.unifi_alerts.coordinator._LOGGER") as mock_logger:
+            coord.push_alert(category, alert)
+
+        mock_logger.debug.assert_called_once()
+        assert "Filtered webhook alert" in mock_logger.debug.call_args[0][0]
 
     # A disabled category must never evaluate the severity gate.
     @given(
@@ -809,3 +835,7 @@ class TestPushAlertSeverityGate:
         assert state.last_webhook_at == prior_last_webhook_at
         # No notification either — a disabled-category push is a full no-op.
         coord.async_set_updated_data.assert_not_called()
+        # The severity gate (and its filtered-alert diagnostic trail) is
+        # never reached for a disabled category.
+        assert state.filtered_count == 0
+        assert state.last_filtered_at is None

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -127,6 +127,7 @@ class TestDiagnosticsContent:
     @pytest.mark.asyncio
     async def test_exposes_per_category_state(self) -> None:
         cleared_at = datetime(2026, 4, 30, 12, 0, 0, tzinfo=UTC)
+        filtered_at = datetime(2026, 4, 30, 12, 5, 0, tzinfo=UTC)
         cat = ALL_CATEGORIES[0]
         states = {c: CategoryState(category=c) for c in ALL_CATEGORIES}
         # Use a current timestamp so webhook_health() reads "healthy" (within the
@@ -138,8 +139,10 @@ class TestDiagnosticsContent:
             is_alerting=True,
             alert_count=4,
             open_count=2,
+            filtered_count=6,
             last_cleared_at=cleared_at,
             last_webhook_at=webhook_at,
+            last_filtered_at=filtered_at,
         )
         coordinator = _make_coordinator(category_states=states)
         entry = _make_entry_with_runtime(coordinator)
@@ -154,8 +157,10 @@ class TestDiagnosticsContent:
             "is_alerting": True,
             "open_count": 2,
             "alert_count": 4,
+            "filtered_count": 6,
             "last_cleared_at": cleared_at.isoformat(),
             "last_webhook_at": webhook_at.isoformat(),
+            "last_filtered_at": filtered_at.isoformat(),
             "webhook_health": "healthy",
         }
 
@@ -171,6 +176,8 @@ class TestDiagnosticsContent:
             cat_entry = result["coordinator"]["categories"][cat]
             assert cat_entry["last_cleared_at"] is None
             assert cat_entry["last_webhook_at"] is None
+            assert cat_entry["last_filtered_at"] is None
+            assert cat_entry["filtered_count"] == 0
             assert cat_entry["webhook_health"] == "never_received"
 
     @pytest.mark.asyncio

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -230,6 +230,33 @@ class TestCategoryState:
         state = CategoryState(category=CATEGORY_NETWORK_WAN)
         assert state.last_webhook_at is None
 
+    def test_filtered_count_and_last_filtered_at_default(self):
+        state = CategoryState(category=CATEGORY_NETWORK_WAN)
+        assert state.filtered_count == 0
+        assert state.last_filtered_at is None
+
+    def test_record_filtered_increments_count_and_stamps_last_filtered_at(self):
+        state = CategoryState(category=CATEGORY_NETWORK_WAN)
+        alert = UniFiAlert.from_webhook_payload(CATEGORY_NETWORK_WAN, {"message": "test"})
+        state.record_filtered(alert)
+        assert state.filtered_count == 1
+        assert state.last_filtered_at == alert.received_at
+
+    def test_record_filtered_does_not_affect_alerting_fields(self):
+        state = CategoryState(category=CATEGORY_NETWORK_WAN)
+        alert = UniFiAlert.from_webhook_payload(CATEGORY_NETWORK_WAN, {"message": "test"})
+        state.record_filtered(alert)
+        assert state.is_alerting is False
+        assert state.alert_count == 0
+        assert state.last_alert is None
+
+    def test_record_filtered_increments_across_calls(self):
+        state = CategoryState(category=CATEGORY_NETWORK_WAN)
+        for i in range(3):
+            alert = UniFiAlert.from_webhook_payload(CATEGORY_NETWORK_WAN, {"message": f"alert {i}"})
+            state.record_filtered(alert)
+        assert state.filtered_count == 3
+
 
 class TestWebhookHealth:
     """Tests for CategoryState.webhook_health()."""


### PR DESCRIPTION
## Summary

Neither the push-path nor poll-path `Minimum_Severity_Setting` gate left any diagnostic trail (debug log, counter, or attribute) when an alert was filtered out. A user whose automation stopped firing after enabling a minimum-severity setting had no way to tell "alert never arrived" from "alert arrived but was filtered" without reading source code.

## Changes

- `coordinator.py`: added a `_LOGGER.debug(...)` call on both filter branches — the webhook push path (`push_alert`) and the poll path (`_async_update_data`'s per-alert eligibility check) — analogous to the existing dedup-suppression debug log three lines away from the push-path gate.
- `models.py`: added `CategoryState.filtered_count` / `last_filtered_at` fields and a `record_filtered()` helper, updated **only on the webhook push path** — mirroring `alert_count`/`last_webhook_at`, since the poll path re-observes the same uncleared alarms every cycle and would otherwise inflate the counter well past "number of distinct filtered events".
- `diagnostics.py`: surfaced `filtered_count`/`last_filtered_at` in the per-category diagnostics dict, alongside the existing `webhook_health`/`unrecognised_keys` diagnostics.
- Tests: `test_models.py` (new `CategoryState` fields/method), `test_push_dedup.py` (filtered-count/last-filtered-at assertions added to the existing severity-gate property tests, plus a new DEBUG-log test), `test_polling.py` (new DEBUG-log test and a regression test confirming polling never touches the diagnostic counters), `test_diagnostics.py` (new fields covered in the per-category exact-dict assertions).
- `CHANGELOG.md`: added an `[Unreleased]` → `Added` bullet.

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

Note: as with #414/#356, this sandbox's only available Python 3.14 interpreter is `3.14.0rc2` (one patch below the `homeassistant==2026.7.1` floor's `Python>=3.14.2`), and `mashumaro` 3.22 (latest released) references `typing.ByteString`, which this interpreter build has already removed — neither is caused by this change. `lint`, `typecheck`, `validate`, and `doc-check` all pass locally; `pytest tests/ --cov-fail-under=95` was verified locally with a throwaway interpreter shim working around the `ByteString` gap (788 passed, 99.27% coverage, all new assertions included) — CI's pinned environment is authoritative for the final run.

Closes #357

## Checklist

- [x] Linked the issue this PR resolves (`Closes #357` in the description)
- [x] `make check` passes locally (see note above re: `test` target)
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] PR title starts with a Conventional Commit prefix (`feat:`)
- [x] PR has a label recognised by `.github/release.yml` (applied automatically for CC-prefixed titles via pr-release-label.yml)
- [x] `strings.json` and `translations/en.json` are still identical (no translation-key changes; these are diagnostics/log fields, not user-facing strings)
- [x] No new category added
- [x] No blocking I/O introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Xhu6ypjFwWu2q8rfgzt4C

---
_Generated by [Claude Code](https://claude.ai/code/session_012Xhu6ypjFwWu2q8rfgzt4C)_