### PR TITLE
tests: add entity state and attribute test coverage

### DIFF
--- a/tests/unit/test_entities.py
+++ b/tests/unit/test_entities.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -228,6 +228,28 @@ class TestUniFiRollupBinarySensor:
         assert "last_severity_level" not in attrs
         assert attrs["total_alert_count"] == 0
 
+    def test_extra_attrs_with_multiple_categories_reflects_most_recent_alert(self):
+        """With alerts in more than one enabled category, the rollup's
+        last_* attributes must reflect the most recently received alert
+        across all of them, not an arbitrary one (#385)."""
+        older = make_alert(CATEGORY_NETWORK_WAN, "older alert")
+        newer = UniFiAlert(
+            category=CATEGORY_SECURITY_THREAT,
+            message="newer alert",
+            received_at=older.received_at + timedelta(seconds=1),
+            severity="critical",
+        )
+        states = {
+            CATEGORY_NETWORK_WAN: make_state(category=CATEGORY_NETWORK_WAN, last_alert=older),
+            CATEGORY_SECURITY_THREAT: make_state(
+                category=CATEGORY_SECURITY_THREAT, last_alert=newer
+            ),
+        }
+        entity = self._make(states)
+        attrs = entity.extra_state_attributes
+        assert attrs["last_message"] == "newer alert"
+        assert attrs["last_category"] == CATEGORY_SECURITY_THREAT
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # sensor
@@ -402,6 +424,29 @@ class TestUniFiWebhookHealthSensor:
         entity = self._make(make_state())
         assert entity.unique_id.endswith(f"_{CATEGORY_NETWORK_WAN}_webhook_health")
 
+    def test_state_machine_never_received_healthy_stale_healthy_again(self):
+        """Full webhook_health lifecycle through the entity: never_received
+        (fresh install) -> healthy (webhook pushed) -> stale (8 days pass with
+        no further webhook) -> healthy again (webhook pushed once more) (#385).
+
+        Mirrors the existing house style (test_native_value_stale et al.):
+        drives the transition by setting last_webhook_at to a fixed point in
+        time relative to the real clock, rather than freezing wall time.
+        """
+        state = make_state()
+        entity = self._make(state)
+        assert entity.native_value == "never_received"
+
+        now = datetime.now(UTC)
+        state.last_webhook_at = now
+        assert entity.native_value == "healthy"
+
+        state.last_webhook_at = now - timedelta(days=8)
+        assert entity.native_value == "stale"
+
+        state.last_webhook_at = datetime.now(UTC)
+        assert entity.native_value == "healthy"
+
 
 class TestUniFiRollupCountSensor:
     def _make(self, states: dict[str, CategoryState]):
@@ -439,6 +484,28 @@ class TestUniFiRollupCountSensor:
         assert "last_message" not in attrs
         assert "last_severity_level" not in attrs
         assert attrs["total_webhook_count"] == 0
+
+    def test_extra_attrs_with_multiple_categories_reflects_most_recent_alert(self):
+        """With alerts in more than one enabled category, the rollup's
+        last_* attributes must reflect the most recently received alert
+        across all of them, not an arbitrary one (#385)."""
+        older = make_alert(CATEGORY_NETWORK_WAN, "older alert")
+        newer = UniFiAlert(
+            category=CATEGORY_SECURITY_THREAT,
+            message="newer alert",
+            received_at=older.received_at + timedelta(seconds=1),
+            severity="critical",
+        )
+        states = {
+            CATEGORY_NETWORK_WAN: make_state(category=CATEGORY_NETWORK_WAN, last_alert=older),
+            CATEGORY_SECURITY_THREAT: make_state(
+                category=CATEGORY_SECURITY_THREAT, last_alert=newer
+            ),
+        }
+        entity = self._make(states)
+        attrs = entity.extra_state_attributes
+        assert attrs["last_message"] == "newer alert"
+        assert attrs["last_category"] == CATEGORY_SECURITY_THREAT
 
     def test_state_class_is_measurement(self):
         from homeassistant.components.sensor import SensorStateClass
@@ -1089,3 +1156,87 @@ class TestPlatformSetupHonoursEnabled:
             f"{entry.entry_id}_{CATEGORY_SECURITY_THREAT}_binary",
             f"{entry.entry_id}_{CATEGORY_SECURITY_THREAT}_count",
         }
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Availability vs. coordinator poll health (#385)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestAvailabilityIgnoresPollFailureForCategoryScopedEntities:
+    """Category-scoped entities and the per-category button define `available`
+    entirely from `state.enabled`, fully overriding CoordinatorEntity's
+    default `available` (which checks `coordinator.last_update_success`).
+    This is deliberate: docs/HOMEASSISTANT.md documents "available reflects
+    category-enabled state" for the buttons, and every category-scoped
+    sensor/binary_sensor/event entity follows the same pattern, so a
+    webhook-pushed alert keeps updating an entity's state even while polling
+    is failing (this is a local_push integration)."""
+
+    @pytest.mark.parametrize(
+        "entity_cls_path",
+        [
+            "sensor.UniFiCategoryMessageSensor",
+            "sensor.UniFiCategoryCountSensor",
+            "sensor.UniFiWebhookHealthSensor",
+            "binary_sensor.UniFiCategoryBinarySensor",
+            "event.UniFiAlertEventEntity",
+            "button.UniFiClearCategoryButton",
+        ],
+    )
+    def test_available_true_despite_last_update_success_false(self, entity_cls_path):
+        import importlib
+
+        module_name, cls_name = entity_cls_path.rsplit(".", 1)
+        entity_cls = getattr(
+            importlib.import_module(f"custom_components.unifi_alerts.{module_name}"), cls_name
+        )
+        coord = make_coordinator({CATEGORY_NETWORK_WAN: make_state(enabled=True)})
+        coord.last_update_success = False
+        entry = make_entry()
+
+        entity = entity_cls(coord, entry, CATEGORY_NETWORK_WAN)
+
+        assert entity.available is True
+
+
+class TestClearAllButtonIgnoresPollFailure:
+    def test_available_true_despite_last_update_success_false(self):
+        from custom_components.unifi_alerts.button import UniFiClearAllButton
+
+        coord = make_coordinator({CATEGORY_NETWORK_WAN: make_state(enabled=True)})
+        coord.last_update_success = False
+        entry = make_entry()
+
+        entity = UniFiClearAllButton(coord, entry)
+
+        assert entity.available is True
+
+
+class TestRollupSensorAvailabilityFollowsCoordinatorPollHealth:
+    """Unlike the category-scoped entities and buttons above, the two rollup
+    sensors (UniFiRollupCountSensor, UniFiRollupBinarySensor) define no
+    `available` override, so they inherit CoordinatorEntity's default:
+    available exactly tracks `coordinator.last_update_success`. This test
+    locks in that (currently divergent) real behaviour; it does not assert
+    that the divergence is correct."""
+
+    @pytest.mark.parametrize(
+        "entity_cls_path",
+        ["sensor.UniFiRollupCountSensor", "binary_sensor.UniFiRollupBinarySensor"],
+    )
+    @pytest.mark.parametrize("last_update_success", [True, False])
+    def test_available_tracks_last_update_success(self, entity_cls_path, last_update_success):
+        import importlib
+
+        module_name, cls_name = entity_cls_path.rsplit(".", 1)
+        entity_cls = getattr(
+            importlib.import_module(f"custom_components.unifi_alerts.{module_name}"), cls_name
+        )
+        coord = make_coordinator({CATEGORY_NETWORK_WAN: make_state(enabled=True)})
+        coord.last_update_success = last_update_success
+        entry = make_entry()
+
+        entity = entity_cls(coord, entry)
+
+        assert entity.available is last_update_success


### PR DESCRIPTION
## Summary

Closes three gaps in entity state/attribute test coverage. Tests only — no production code changed.

## Changes

All in `tests/unit/test_entities.py`:

- **Webhook health state machine**: `TestUniFiWebhookHealthSensor` gains a full sequence test through the entity — `never_received` → `healthy` (webhook pushed) → `stale` (8 days pass) → `healthy` again (webhook pushed once more) — rather than only the existing point-in-time snapshots. Follows the existing house style (manipulating `last_webhook_at` relative to the real clock, as `test_native_value_stale` already does) rather than introducing `freezegun` as a new dependency the rest of the suite doesn't use.
- **Rollup sensor multi-category coverage**: `TestUniFiRollupCountSensor` and `TestUniFiRollupBinarySensor` each gain a test with alerts in two enabled categories, confirming the entity's `last_*` attributes reflect the most recently received alert end-to-end (this was previously only verified at the `coordinator.rollup_last_alert` property level in `tests/unit/coordinator/test_push_dedup.py`, not through the entity's `extra_state_attributes`).
- **Availability vs. `coordinator.last_update_success`**: no test anywhere previously touched this. Auditing every platform surfaced a real, existing split in behaviour:
  - `UniFiCategoryMessageSensor`, `UniFiCategoryCountSensor`, `UniFiWebhookHealthSensor`, `UniFiCategoryBinarySensor`, `UniFiAlertEventEntity`, and both buttons (`UniFiClearCategoryButton`, `UniFiClearAllButton`) each fully override `available` from `state.enabled` alone, so a poll failure (`coordinator.last_update_success = False`) never affects them — consistent with `docs/HOMEASSISTANT.md`'s documented intent for the buttons ("available reflects category-enabled state") and sensible for a `local_push` integration where webhook-driven state should stay visible even if polling is failing.
  - `UniFiRollupCountSensor` and `UniFiRollupBinarySensor` define **no** `available` override, so they inherit `CoordinatorEntity`'s default (`available == coordinator.last_update_success`) — meaning these two rollup entities *do* go unavailable on a poll failure, unlike every other entity in the integration.

  I added tests locking in this real, current behaviour on both sides of the split rather than changing any production code — this is a test-coverage issue, not a bug-fix one, and I don't think it's my call to make the two rollup sensors consistent with the rest without a decision from you. Flagging it here in case you want a follow-up issue to unify the two (either by having the rollup sensors also ignore poll health, or by adding the same ignore-poll-health override there too).

## How to test

```bash
make doc-check  # docs + translation parity
make check      # full validation suite
```

Note: as with #414/#415, this sandbox's only available Python 3.14 interpreter is `3.14.0rc2` (one patch below the `homeassistant==2026.7.1` floor's `Python>=3.14.2`), and `mashumaro` 3.22 (latest released) references `typing.ByteString`, which this interpreter build has already removed — neither is caused by this change. `lint`, `typecheck`, `validate`, and `doc-check` all pass locally; `pytest tests/ --cov-fail-under=95` was verified locally with a throwaway interpreter shim working around the `ByteString` gap (802 passed, 99.27% coverage, all new assertions included) — CI's pinned environment is authoritative for the final run.

Closes #385

## Checklist

- [x] Linked the issue this PR resolves (`Closes #385` in the description)
- [x] `make check` passes locally (see note above re: `test` target)
- [x] `CHANGELOG.md` not touched — no production code changed, tests-only PR (exempt from changelog-guard via the `tests` label)
- [x] PR title starts with a Conventional Commit prefix (`tests:`)
- [x] PR has a label recognised by `.github/release.yml` (applied automatically for CC-prefixed titles via pr-release-label.yml)
- [x] `strings.json` and `translations/en.json` untouched
- [x] No new category added
- [x] No blocking I/O introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Xhu6ypjFwWu2q8rfgzt4C

---
_Generated by [Claude Code](https://claude.ai/code/session_012Xhu6ypjFwWu2q8rfgzt4C)_